### PR TITLE
God-given Bows Fix

### DIFF
--- a/kod/object/item/passitem/weapon/ranged/bow/magicbow.kod
+++ b/kod/object/item/passitem/weapon/ranged/bow/magicbow.kod
@@ -31,7 +31,9 @@ classvars:
 
 properties:
 
-   viRange = 50
+   viWeaponDamage = 1
+   viRange = 100
+   viHit_roll_modifier = 100
 
    % What's the basic color of the wood?
    viBaseXLAT = XLAT_TO_SKIN4

--- a/kod/object/item/passitem/weapon/ranged/bow/nerubow.kod
+++ b/kod/object/item/passitem/weapon/ranged/bow/nerubow.kod
@@ -33,7 +33,7 @@ classvars:
 
    vrWeaponBroke = NeruditeBow_shatters
 
-   viWeaponDamage = 2
+   viWeaponDamage = 3
    viRange = 20
    viHit_roll_modifier = 0
    
@@ -45,7 +45,7 @@ classvars:
    viHits_init_min = 100
    viHits_init_max = 150
 
-   viSpell_modifier = 0
+   viSpell_modifier = -30
 
    % What's the basic color of the bow?
    viBaseXLAT = XLAT_TO_GREEN


### PR DESCRIPTION
Magic Bow:
Doubled range to match long bow.
Added 100 hit roll modifier to match long bow.
Added 1 weapon damage.

Neru Bow:
Set spell modifier to match battle bow.
Added 1 damage.

Both of these weapons are now equivalent to a common type of bow, except
with 1 extra damage. Admins can always further modify their properties
if they wish, but magic bows were strictly inferior long bows, and neru
bows were extremely overpowered battle bows.

It was too late to fix this on 101, but let's nip this in the bud before it
becomes a problem on 103.
