### PR TITLE
Fizzles Min Reduction

### DIFF
--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1199,7 +1199,7 @@ messages:
          }
       }
 
-      num = bound(num,5,95);
+      num = bound(num,5,99);
 
       if lTargets <> $
          AND Send(self,@GetNumSpellTargets) = 1


### PR DESCRIPTION
Currently players can never get below a 5% fizzle rate, even at max
spellpower. This might be the most common player complaint of all time.
This change reduces the minimum fizzle rate to 1% at max spellpower.
