### PR TITLE
Lupogg King Lair Fix

### DIFF
--- a/kod/object/active/holder/room/monsroom/bossroom/sewking.kod
+++ b/kod/object/active/holder/room/monsroom/bossroom/sewking.kod
@@ -134,7 +134,7 @@ messages:
    Constructor()
    {
       plMonsters = [ [&Lupogg, 100] ];
-      plGenerators = [ [19,19], [23,44], [23,31] ];
+      plGenerators = [ [11,37], [21,28], [23,31] ];
 
       poDoor1 = Create(&MovingSector,#sectorroom=self,#sectorID=SECTOR_DOOR1,
                         #upH=H_DOOR1_UP,#downH=H_DOOR1_DN,#upspeed=DOOR_UP_SPEED,


### PR DESCRIPTION
Problems with the generator locations made this room very broken. There
are only three generators, one of which was placed in a wall, thereby
preventing spawns. One of the generators is and remains in a tightly
confined space, preventing spawns after a short time.

This led the third generator actually _outside_ the Lupogg King Lair to
spawn continually in a single hallway with a safespot right next to it.
It has thus become one of the most abused spots in the game.

This commit simply moves the generators. The one in the wall is now in
the tight tunnel, adding to the cluster of dangerous lupoggs one must
pass through, and the abused generator point is now in the lupogg king
chamber itself.
