### PR TITLE
Allow non-damage walls in doors

### DIFF
--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3910,8 +3910,10 @@ messages:
       for i in plActive
       {
          each_obj = Send(self,@HolderExtractObject,#data=i);
-         if IsClass(each_obj,&ActiveWallElement)
-            or IsClass(each_obj,&Brambles)
+         if (IsClass(each_obj,&ActiveWallElement)
+            or IsClass(each_obj,&Brambles))
+            AND NOT IsClass(each_obj,&ActiveSporeCloud)
+            AND NOT IsClass(each_obj,&Web)
          {
             if Send(who,@SquaredDistanceTo,#what=each_obj) <= (WALL_DELETE_RADIUS * WALL_DELETE_RADIUS)
             {
@@ -3925,7 +3927,6 @@ messages:
       {
          each_obj = Send(self,@HolderExtractObject,#data=i);
          if IsClass(each_obj,&PassiveWallofFire)
-            OR IsClass(each_obj,&SporeCloud)
             OR IsClass(each_obj,&PassiveWallofLightning)
          {
             if Send(who,@SquaredDistanceTo,#what=each_obj) <= (WALL_DELETE_RADIUS * WALL_DELETE_RADIUS)


### PR DESCRIPTION
Popular requests to re-enable webs and spores in doors have been
intense, to say the least, predicated on the basis that they do not deal
damage and can't be used to kill newbies in a cheesy fashion. They are
also very important for crowd control, and best used in doors
specifically.
