### PR TITLE
Armor of Gort damage cap bug fix

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4516,7 +4516,8 @@ messages:
          oGort = Send(SYS,@FindSpellByNum,#Num=SID_ARMOR_OF_GORT);
          if Send(self,@IsEnchanted,#what=oGort)
          {
-            damage = Send(oGort,@CapIncomingDamage,#damage=damage,#atype=atype,#aspell=aspell);
+            damage = Send(oGort,@PriorityModifyDefenseDamage,#who=self,#what=what,#damage=damage,
+                          #atype=atype,#aspell=aspell);
          }
          
          for i in plDefense_modifiers

--- a/kod/object/passive/spell/persench/gort.kod
+++ b/kod/object/passive/spell/persench/gort.kod
@@ -84,32 +84,12 @@ messages:
       return iSpellPower;
    }
 
-   CapIncomingDamage(damage = $, atype = $, aspell = $)
+   PriorityModifyDefenseDamage(who = $, what = $, damage = $, atype = 0, aspell = 0)
    {
-      local iMax;
-      
-      iMax = 15;
-      
-      if aspell <> 0
-      {
-         if atype <> 0
-         {
-            iMax = 20;
-         }
-         else
-         {
-            iMax = 25;
-         }
-      }
-   
-      return bound(damage,1,iMax);
-   }
-
-   ModifyDefenseDamage(who = $, what = $, damage = $, atype = 0, aspell = 0)
-   {
-      local iSpellPower, iAbsorbed;
+      local iSpellPower, iAbsorbed, iMax;
 
       iSpellPower = Send(who,@GetEnchantedState,#what=self);
+      iMax = 15;
       iAbsorbed = random(0,iSpellPower/25);
       iAbsorbed = bound(iAbsorbed,1,4);
 
@@ -121,15 +101,22 @@ messages:
             % Only 1/2 of the damage reduction if we're doing both weapon
             %  and spell damage types.
             iAbsorbed = iAbsorbed / 2;
+            iMax = 20;
          }
          else
          {
             % If we're doing pure spell damage, we get no reduction.
             iAbsorbed = 0;
+            iMax = 25;
          }
       }
 
-      return bound(damage-iAbsorbed,1,$);
+      return bound(damage-iAbsorbed,1,iMax);
+   }
+
+   ModifyDefenseDamage(who = $, what = $, damage = $, atype = 0, aspell = 0)
+   {
+      return damage;
    }
 
    EndEnchantment(who = $, report = TRUE, state = 0)


### PR DESCRIPTION
Armor of Gort wasn't capping damage taken properly, because order
mattered. To receive the full benefit of Armor of Gort, a player would
have to buff while already wearing his armor, and then never switch to
any other gear. Switching would lose the benefits due to pushing Armor
of Gort later in the list of defense mods.

This change moves the capping mechanism before all defense modifiers.

This change will make Armor of Gort appear stronger.
In reality, it will just be working as intended, and as it always did for
a select few players with bad buffing habits.

There was a myth that casting Gort in armor made it better. Turns out,
in some fashion, it was true. This was why.

Example: a 30 damage hit with Gort first would be capped to 15,
then reduced by plate and jonas shield by up to 10, to 5 damage taken.

A 30 damage hit with Gort last (if cast in robes then switch to plate)
would have plate and jonas shield go first, reducing 30 to possibly 20,
then capped to 15. Thus the gear-switching changed your minimum
damage taken from 5 to 15. It's a pretty big swing in many common situations,
and there's no way for players to know how badly this was tilting things.
