### PR TITLE
This turns the smith into a weaponcraft trainer that sells skills up to ...

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzsmith.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/hazartwn/hzsmith.kod
@@ -66,8 +66,8 @@ messages:
       			Create(&MetalShield),
       			Create(&ChainArmor),
       			Create(&Torch)],
-      			[ SKID_BLOCK, SKID_PROFICIENCY_MACE, SKID_PUNCH, SKID_SLASH, 
-         		 SKID_BRAWLING, SKID_DODGE, SKID_PROFICIENCY_SHORTSWORD ],$,$];
+      			[ SKID_PROFICIENCY_SHORTSWORD, SKID_DODGE, SKID_BRAWLING, 
+      			SKID_SLASH, SKID_PUNCH, SKID_PROFICIENCY_MACE, SKID_BLOCK ],$,$];
       return;
    }
 


### PR DESCRIPTION
...rank 2.

Tomas also sells a corresponding potion of forgetfulness. This allows newbies to experiment in Raza and figure out what they want to do before heading to the real world.
