### PR TITLE
Rescue Potion - No Karma Restriction

### DIFF
--- a/kod/object/item/passitem/spelitem/potion/rescuep.kod
+++ b/kod/object/item/passitem/spelitem/potion/rescuep.kod
@@ -43,9 +43,6 @@ classvars:
 
 properties:
 
-   % Letting everyone have rescue turned out to be too powerful
-   pbCheckKarma = TRUE
-
 messages:
 
 end


### PR DESCRIPTION
Karma restriction on rescue potions didn't work out.
