### PR TITLE
Adjusted starting items in Raza and real world.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -2430,12 +2430,13 @@ messages:
       % Give the poor newbie an weapon and a bit of cash.
       Send(self,@NewHold,#what=Create(&Mace));
       Send(self,@NewHold,#what=Create(&Money,#number=500));
+      Send(self,@AddReagentsForSpells,#iNumCasts=10);
 
       % If player hasn't suicided in last 5 hours, give them cash and prizes!
       if (GetTime() - piLast_restart_time) > (5*60*60)   
       {
-         Send(self,@NewHold,#what=Create(&Money,#number=2000));
-         Send(self,@AddReagentsForSpells);
+         Send(self,@NewHold,#what=Create(&Money,#number=500));
+         Send(self,@AddReagentsForSpells,#iNumCasts=10);
       }
 
       return;
@@ -2462,11 +2463,13 @@ messages:
    {
       local lItems,oItem,iSchool;
 
-      % If player hasn't suicided in last 5 hours, give them cash and prizes!
+      % If player hasn't suicided in last 5 hours, give them cash and fancy clothes!
       if (GetTime() - piLast_restart_time) > (5*60*60)   
       {
          Send(self,@NewHold,#what=Create(&Money,#number=1000));
-         Send(self,@AddReagentsForSpells);
+         Send(self,@NewHold,#what=create(&InkyCap,#number=5));
+         Send(self,@NewHold,#what=Create(&PantsC));
+         Send(self,@NewHold,#what=Create(&Shirt,#color=XLAT_TO_GRAY));
       }
 
       if Send(Send(SYS,@GetLore),@BetaPotionsEnabled) 


### PR DESCRIPTION
Giving fresh characters a few more reagents to get started (and in case they are unlucky with drops in the dungeon). Players now get 500sh and 10 casts, and twice that if they haven't suicided lately. The cash went down from 2500, since they aren't supposed to just hit the store and buy everything. They can fight with a basic setup at the beginnig and earm some cash to buy a chainmail a bit later.

Entering the real world no longer grants any reagents, but if you haven't suicided lately, you get 5 inkies and white pants and shirt.
This may also help us identify new players more easily. Hehe.
