### PR TITLE
Changed format of messages based on feedback. (needs 104 testing)

### DIFF
--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -32,7 +32,7 @@ resources:
    %  will comment out the next line.
 
    battler_blue_text = "~b"
-   battler_plain_text = ""
+   battler_plain_text = "~n"
 
    % battler_attacker_hit - Your scimitar wounds Psychochild for (10) damage.
    % battler_attacker_slay - Your scimitar slays Psychochild.
@@ -41,19 +41,19 @@ resources:
    % battler_defender_slay - Psychochild's scimitar slays you.
    % battler_defender_miss - Psychochild's attack is blocked by you.
 
-   battler_attacker_hit = "%sYour %s ~B%s~B %s%s for (~B%i~B) damage."       
-   battler_attacker_slay = "%sYour %s ~B%s~B %s%s."   
+   battler_attacker_hit = "%sYour %s %s %s%s for ~k~B%i~B%s damage."       
+   battler_attacker_slay = "%sYour %s %s %s%s."   
    battler_attacker_miss = "%sYour attack %s %s%s."    
-   battler_defender_hit = "%s%s%s's %s ~B%s~B you for (~B%i~B) damage."
-   battler_defender_slay = "%s%s%s's %s ~B%s~B you."  
+   battler_defender_hit = "%s%s%s's %s %s you for ~r~B%i~B%s damage."
+   battler_defender_slay = "%s%s%s's %s %s you."  
    battler_defender_miss = "%s%s%s's attack %s you."   
 
    battler_punch = "punch"
    battler_attack = "attack"
-   battler_blocked  = "is ~Bblocked~B by" 
-   battler_dodged  = "is ~Bdodged~B by"
-   battler_parried  = "is ~Bparried~B by"
-   battler_misses = "~Bmisses~B"
+   battler_blocked  = "is blocked by" 
+   battler_dodged  = "is dodged by"
+   battler_parried  = "is parried by"
+   battler_misses = "misses"
 
    battler_fail = "fails to damage"
    battler_nick = "nicks"
@@ -949,7 +949,7 @@ messages:
             Send(self,@MsgSendUser,#message_rsc=battler_attacker_hit,
               #parm1=rColor,#parm2=rWeaponName,#parm3=rDamageDesc,
               #parm4=Send(what,@GetDef),#parm5=Send(what,@GetName),
-              #parm6=damage);
+              #parm6=damage,#parm7=rColor);
          }
       }
 
@@ -967,7 +967,7 @@ messages:
             Send(what,@MsgSendUser,#message_rsc=battler_defender_hit,
               #parm1=rColor,#parm2=Send(self,@GetCapDef),
               #parm3=Send(self,@GetName),#parm4=rWeaponName,
-              #parm5=rDamageDesc,#parm6=damage);
+              #parm5=rDamageDesc,#parm6=damage,#parm7=rColor);
          }
       }
 


### PR DESCRIPTION
Format is now:

Your scimitar wounds Psychochild for 10 damage.

The damage number is bold and colored (black for damage done, red for damage received), while the rest remains unformatted.

Currently, I don't know whether ~n restores system text to purple or whether it will turn it white. If it turns system text white, I'll have to bloat the code a bit. Testing will show. :P
