### PR TITLE
Redbookinconsistency

### DIFF
--- a/blakserv/game.c
+++ b/blakserv/game.c
@@ -774,7 +774,7 @@ void UpdateSecurityRedbook()
 char* GetSecurityRedbook()
 {
    if (!_redbookstring)
-      return "BLAKSTON: Unknown Redbook";
+      return "BLAKSTON: Greenwich Q Zjiria";
 
    return _redbookstring;
 }

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -153,7 +153,7 @@ void UpdateSecurityRedbook(ID idRedbook)
 char* GetSecurityRedbook()
 {
    if (!_redbookstring)
-      return "BLAKSTON: Unknown Redbook";
+      return "BLAKSTON: Greenwich Q Zjiria";
 
    return _redbookstring;
 }


### PR DESCRIPTION
This is the same bugfix/pullrequest I added to the main repo.

This fixes the inconsistency in the fallbackstrings on client/server,
if the security redbook is not available (for whatever reason)
