### PR TITLE
Balanced out chance to hit.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -16,7 +16,7 @@ constants:
 
    % What's the percent chance to hit if offense and defense are equal?
    % The higher this number is, the easier it is to hit in combat.
-   EQUAL_CHANCE_HIT = 55      
+   EQUAL_CHANCE_HIT = 500      
                               
    % Raise or lower this number to raise or lower the chance the 'avoids 
    %  your attack' message comes up.
@@ -40,6 +40,9 @@ resources:
    % battler_defender_hit - Psychochild's scimitar wounds you for (10) damage.
    % battler_defender_slay - Psychochild's scimitar slays you.
    % battler_defender_miss - Psychochild's attack is blocked by you.
+
+   battler_attacker_crit = "~k~IYou dealt a critical strike!"  
+   battler_defender_crit = "~r~IYou suffered a critical strike!"  
 
    battler_attacker_hit = "%sYour %s %s %s%s for ~k~B%i~B%s damage."       
    battler_attacker_slay = "%sYour %s %s %s%s."   
@@ -318,7 +321,7 @@ messages:
    % For a monster, the stroke_obj is itself.
    TryAttack(what = $,stroke_obj=$)
    {
-      local iChanceToHit, iDamage, oWeapon;
+      local iChanceToHit, iDamage, oWeapon, iMultiplier;
 
       oWeapon = Send(self,@GetWeapon);
 
@@ -331,15 +334,35 @@ messages:
                       * EQUAL_CHANCE_HIT)
                      / Send(what,@GetDefense,#what=self,
                             #stroke_obj=stroke_obj);
-      iChanceToHit = bound(iChanceToHit,10,95);
-      if iChanceToHit >= random(1,100)
+      iChanceToHit = bound(iChanceToHit,125,2000);
+      iMultiplier = 1;
+
+      if iChanceToHit > 1000
       {
+         if iChanceToHit >= random(1001,2000)
+         {
+            % We do double damage!
+            iMultiplier = 2;
+            
+            % Let us tell them the good news.
+            if IsClass(self,&Player)
+            {
+               Send(self,@MsgSendUser,#message_rsc=battler_attacker_crit);
+            }
+            
+            if IsClass(what,&Player)
+            {
+               Send(what,@MsgSendUser,#message_rsc=battler_defender_crit);
+            }
+         }
+         
          % We hit!
          iDamage = Send(what,@AssessDamage,#what=self,
                         #damage=Send(self,@GetDamage,#what=what,
                                      #stroke_obj=stroke_obj),
                         #atype=Send(self,@GetDamageType),
                         #aspell=Send(self,@GetSpellType));
+         iDamage = iDamage * iMultiplier;
          Send(self,@AssessHit,#what=what,#stroke_obj=stroke_obj,
               #damage=iDamage);
          if iDamage = $
@@ -354,8 +377,32 @@ messages:
       }
       else
       {
-         % Oops, a miss.  See if something happens.
-         Send(self,@AssessMiss,#what=what,#stroke_obj=stroke_obj);
+         if iChanceToHit >= random(1,1000)
+         {
+            % We hit!
+            iDamage = Send(what,@AssessDamage,#what=self,
+                           #damage=Send(self,@GetDamage,#what=what,
+                                        #stroke_obj=stroke_obj),
+                           #atype=Send(self,@GetDamageType),
+                           #aspell=Send(self,@GetSpellType));
+            iDamage = iDamage * iMultiplier;
+            Send(self,@AssessHit,#what=what,#stroke_obj=stroke_obj,
+                 #damage=iDamage);
+            if iDamage = $
+            {
+               Send(self,@KilledSomething,#what=what,#use_weapon=oWeapon,
+                    #stroke_obj=stroke_obj);
+            }
+            else
+            {
+               Send(self,@DidDamage,#amount=iDamage,#what=what);
+            }
+         }
+         else
+         {
+            % Oops, a miss.  See if something happens.
+            Send(self,@AssessMiss,#what=what,#stroke_obj=stroke_obj);
+         }
       }
 
       if poOwner <> $


### PR DESCRIPTION
This is how it works:
chance=(Offense/Defense)_500 bound between 125(=500/4) and 2000(=500_4)
if chance > 1000 and chance > random(1001,2000) => double damage
if chance > 1000 and chance < random(1001,2000) => normal hit
if chance < 1000 and chance > random(1,1000) => normal hit
if chance < 1000 and chance < random(1,1000) => miss

This means: At equal offense and defense, you have a 50% chance to hit. The rest of the hit spectrum is perfectly balanced around this value. 

If your defense is 4 times higher, you will only be hit 12.5% of the time, which means a reduction of damage by the factor 4. 

If your offense is 4 times higher, you will do double damage every time, resulting in an increase of damage by the factor 4.

If you do double damage, you will receive a message in black italic, informing you of your crit. Likewise, if you take double damage, you receive a message in red italic. This corresponds to the color coding for damage numbers and avoids confusion of who is taking double damage.

You are most likely to only encounter crits in PvE or against a pathetic buffless caster as a PF.

Test it out on 104, give feedback!
