### PR TITLE
Adjusted offense and defense rating for players...

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4190,18 +4190,18 @@ messages:
          if oWeapon <> $
          {
             % Get weapon's numbers.
-            iStroke = Send(oWeapon,@GetStroke,#who=self);
-            iProficiency = Send(oWeapon,@GetProf,#who=self);
+            iStroke = Send(oWeapon,@GetStroke,#who=self) + 1;
+            iProficiency = Send(oWeapon,@GetProf,#who=self) + 1;
          }
          else
          {
             % Unarmed
-            iStroke = Send(self,@GetSkillAbility,#skill_num=SKID_PUNCH);
-            iProficiency = Send(self,@GetSkillAbility,#skill_num=SKID_BRAWLING);
+            iStroke = Send(self,@GetSkillAbility,#skill_num=SKID_PUNCH) + 1;
+            iProficiency = Send(self,@GetSkillAbility,#skill_num=SKID_BRAWLING) + 1;
          }
 
          iAim = Send(self,@GetAim);
-         iOffense = (iStroke*3) + (iProficiency*2) + (iAim*4) + (piBase_Max_Health*3/2);
+         iOffense = 200 + (iStroke*5) + (iProficiency*5) + (iAim*20) + (piBase_Max_Health*2);
 
          if oWeapon <> $
          {
@@ -4233,7 +4233,7 @@ messages:
       % The universal modifier.
       iOffense = iOffense + ((iOffense * piFlags3) / 100);
 
-      return bound(iOffense,1,1000);
+      return bound(iOffense,1,3000);
    }
 
    % This returns the battler's ability to avoid being hit.  Ranges from 1 to 1000.
@@ -4255,15 +4255,15 @@ messages:
          iBlock = 0;
 
          % Ask the weapon, it might give a bonus to parrying.
-         iParry = Send(self,@GetParryAbility,#stroke_obj=stroke_obj);
+         iParry = Send(self,@GetParryAbility,#stroke_obj=stroke_obj) + 1;
          
          % Ask the shield, it might give a bonus to block.
-         iBlock = Send(self,@GetBlockAbility,#stroke_obj=stroke_obj);
+         iBlock = Send(self,@GetBlockAbility,#stroke_obj=stroke_obj) + 1;
          
-         iDodge = Send(self,@GetDodgeAbility,#stroke_obj=stroke_obj);
+         iDodge = Send(self,@GetDodgeAbility,#stroke_obj=stroke_obj) + 1;
 
          iAgility = Send(self,@GetAgility);
-         iDefense = (iParry*2) + (iBlock) + (iDodge*3) + (iAgility*4) + (piBase_Max_Health*3/2);
+         iDefense = 200 + (iParry*5) + (iBlock*2) + (iDodge*3) + (iAgility*20) + (piBase_Max_Health*2);
       }
 
       for i in plDefense_modifiers
@@ -4276,7 +4276,7 @@ messages:
       % The universal modifier.
       iDefense = iDefense + ((iDefense * piFlags3) / 100);
 
-      return bound(iDefense,1,1000);
+      return bound(iDefense,1,3000);
    }
 
    % The next three messages deal with the three defense skills.  These messages return the relative values of the three


### PR DESCRIPTION
...giving agility and aim considerably more weight, and reducing the influence of buffs and items.
In short, rating is now capped at 3000.
1000 from agility/aim
1000 from weapon skills
300 from HPs
200 base line to avoid crazy swings in rating at early levels
500ish from buffs and items.

I didn't change the values of buffs and items, but since the rating is now capped at 3 times the old value and the other contributers have been scaled up by about the same factor, that makes buffs and items only one third as effective as before. The big winner are agility and aim. Yay, for stat diversity! 

Please test on 104 together with the changes to chance to hit and monster offense&defense! Thanks!
