### PR TITLE
Revamp of touch attack damage calculations

### DIFF
--- a/kod/object/passive/spell/persench/touchatk.kod
+++ b/kod/object/passive/spell/persench/touchatk.kod
@@ -17,6 +17,8 @@ constants:
    include blakston.khd
 
    HITVALUE_MAX = 100
+   POISON_DURATION = 30000 %%% in milliseconds
+   POISON_LOSSRATE = 10000 %%% in health points * 10^-4 / second
 
 resources:
 
@@ -32,6 +34,14 @@ resources:
    TouchAttack_missed3_sound = swswish3.wav
    
    TouchAttack_hit_sound = patk.wav
+   
+   purger_worked_user = "Your violent blast of electricity disrupts the magic surrounding %s%s!"
+   purger_worked_target = "%s%s blasts you with electricity, disrupting the magic surrounding you!"
+   poison_worked_user = "Your acidic touch eats into %s%s's flesh, polluting %s blood!"
+   poison_worked_target = "%s%s's acidic touch eats into your flesh and pollutes your blood!"
+   blinder_worked = "%s%s stumbles away, screaming and clutching %s eyes!"
+   holder_worked = "%s%s is frozen solid, unable to move even a finger."
+   heal_worked = "Shal'ille aids you in battle, healing you for ~g~B%i~B~n damage."
 
 classvars:
 
@@ -93,7 +103,14 @@ properties:
 
    plPrerequisites = $
    plReagents = $
-
+   
+   % The following are chances to proc special effects
+   piBlind_chance = 5
+   piHold_chance = 5
+   piPurge_chance = 5
+   piPoison_chance = 5
+   piHeal_chance = 5
+   
 messages:
 
    ImproveStroke(who=$,target=$)
@@ -246,10 +263,11 @@ messages:
    FindDamage(weapon_used=$,who=$,victim=$)
    "Damage for attack spells is determined largely by expertise in the spell."
    {
-      local i, damage, mysticism, iAbility;
+      local i, damage, iMysticism, iAbility, iProcfactor;
 
       % base weapon damage
       damage = random(viMin_Damage,viMax_damage);
+      iProcfactor = 10;
 
       for i in send(who,@GetPlayerUsing)
       {
@@ -257,6 +275,8 @@ messages:
          {
             % Each jewel of Froz adds up to 3 to base damage depending on HPs.
             damage = damage + bound(send(who,@GetBaseMaxHealth)-40,0,60)/20;
+            % Each equipped JoFincreases the chance to proc effects.
+            iProcfactor = iProcfactor + 10;
          }
       }
       
@@ -268,10 +288,113 @@ messages:
       damage = damage + bound(send(who,@GetBaseMaxHealth)-50,0,50)/10;
       
       % touchspells are boosted by mysticism instead of might
-      mysticism = send(who,@GetMysticism);
-      damage = damage + ((100+bound(mysticism-25,0,40))*damage)/100;
+      iMysticism = send(who,@GetMysticism);
+      damage = damage + ((100+bound(iMysticism-25,0,40))*damage)/100;
+      
+      % allow individual adjustments by a specific spell
+      damage = Send(self,@DamageFactors,#damage=damage,#who=who,
+                          #victim=victim);
+      
+      % check for a proc if we have a JoF equipped
+      if iProcfactor <> 0
+      {
+         Send(who,@DoTouchProc,#spell_num=viSpell_num,#procfactor=iProcfactor,#target=victim,#damage=damage);
+      }
       
       return bound(damage,1,$);
+   }
+
+   DoTouchProc(spell_num = $, procfactor = 0, target=$, damage=0)
+   "Here, we handle procs that JoFs unlock within touch spells."
+   {
+      local oSpell;
+      
+      procfactor = procfactor * bound(send(who,@GetBaseMaxHealth)-50,0,50)/50;
+      
+      if spell_num = SID_ZAP
+      {
+         oSpell = send(SYS,@FindSpellByNum,#num=SID_PURGE);
+         
+         if random(1,1000) <= piPurge_chance*procfactor
+         {
+            %% Gotta have something to try to remove....
+            if Send(target,@IsEnchanted)
+            {
+               % Try to purge off random(25,75)% of the enchantments.
+               if send(oSpell,@DoPurge,#who=target,#iChance=random(25,75))
+               {
+                  % Only tell our victim if they lost enchantments.
+                  send(target,@MsgSendUser,#message_rsc=purger_worked_target,
+                       #parm1=send(who,@GetCapDef),#parm2=send(who,@GetName));
+               }
+
+               % Tell the zapper.
+               send(who,@MsgSendUser,#message_rsc=purger_worked_user,
+                    #parm1=send(target,@GetCapDef),#parm2=send(target,@GetName));
+            }
+         }
+      }
+      
+      if spell_num = SID_TOUCH_OF_FLAME
+      {
+         oSpell = send(SYS,@FindSpellByNum,#num=SID_BLIND);
+         
+         if random(1,1000) <= piBlind_chance*procfactor
+         {
+            %% no duplicates
+            if not Send(target,@IsEnchanted,#what=oSpell)
+            {        
+               send(oSpell,@CastSpell,#who=self,#ltargets=[target],#iSpellPower=50);
+               send(who, @MsgSendUser, #message_rsc = blinder_worked,
+                     #parm1=send(target,@GetCapDef),#parm2=send(target,@GetName),
+                     #parm3=send(target,@GetHisher));
+            }
+         }
+      }
+      
+      if spell_num = SID_ICY_FINGERS
+      {
+         oSpell = send(SYS,@FindSpellByNum,#num=SID_HOLD);
+
+         if random(1,1000) <= piHold_chance*procfactor
+         {
+            %% no duplicates
+            if not Send(target,@IsEnchanted,#what=oSpell)
+            {        
+               send(oSpell,@CastSpell,#who=self,#ltargets=[target],#ispellpower=99);
+               send(who,@MsgSendUser,#message_rsc=holder_worked,
+                  #parm1=send(target,@GetCapDef),#parm2=send(target,@GetName));
+            }
+         }
+      }
+
+      if spell_num = SID_ACID_TOUCH
+      {
+         oSpell = Send(SYS,@FindSpellByNum,#num=SID_POISON);
+         
+         if random(1,1000) <= piPoison_chance*procfactor
+         {
+
+            send(oSpell,@MakePoisoned,#who=target,
+                #lossrate=POISON_LOSSRATE,#duration=POISON_DURATION);
+            send(who,@MsgSendUser,#message_rsc=poison_worked_user,
+                 #parm1=send(target,@GetCapDef),#parm2=send(target,@GetName),
+                 #parm3=send(target,@GetHisher));
+            send(target,@MsgSendUser,#message_rsc=poison_worked_target,
+                 #parm1=send(target,@GetCapDef),#parm2=send(target,@GetName));
+         }
+      }
+
+      if spell_num = SID_HOLY_TOUCH
+      {
+         if random(1,1000) <= piHeal_chance*procfactor
+         {
+            send(who,@GainHealth,#amount = damage);
+            send(who,@MsgSendUser,#message_rsc=heal_worked,#parm1=damage);
+         }
+
+      }
+      return damage;
    }
 
    PlayerWasHitMsg(who=$,attacker=$,damage=$)


### PR DESCRIPTION
Goal: Make touch attacks equally effective as weapons for built characters while significantly lowering their usefulness for 30HP PKs.

Here is how damage is calculated:
1) Damage = Base Damage (4 to 9 for ToF - on par with a spirit hammer)

2) Damage = Damage scaled by skill (not SP!) from 0% to 100%
This means that you no longer have to worry about SP, only about your percent in the spell, when casting your touch attack. This brings touch attacks in line with weapons.

3) Damage = Damage +5, depending on the casters HPs.
Touch attacks are way faster to level than weapon proficiencies. As a result, proficiency damage is based on the casters HPs instead, gaining 1 bonus damage at 60, 2 at 70 and 5 at 100 HPs.

4) Damage = Damage \* Mysticism bonus (works the same as might bonus)

This basically brings touch attacks in line with weapons, allowing them the same damage range and late game use, but curbing their early game PKing potential (together with a change to JoF).

As an update, touch attacks now also have a chance to proc spells in a similar fashion as their weapon counterparts.
