### PR TITLE
Revamped JoF

### DIFF
--- a/kod/object/item/passitem/attmod/frozjewl.kod
+++ b/kod/object/item/passitem/attmod/frozjewl.kod
@@ -23,7 +23,9 @@ resources:
    frozjewel_desc_rsc = \
       "This gem was created by the great alchemist, Froz, in a secret process "
       "known only to him.  Rumor has it that it is a conduit for mystical "
-      "aggression, using raw mana to boost elemental touch spells.  "
+      "aggression, that allows its user to channel their magical energy into "
+      "devastating touch spells.  Obviously, this would hinder the caster when "
+      "trying to use said energy for less destructive purposes.  "
       "Your hand tingles when you hold it."
 
    frozjewel_desc_broken_rsc = "The jewel seems ordinary and dull."


### PR DESCRIPTION
JoFs now add up to 3 damage to the base damage of a touch spell, basically taking it from spirit hammer damage levels to scimitar damage levels. This scales with HPs, granting 1 bonus damage at 60, 2 at 80 and 3 at 100 HPs.

However, just as with a real scimitar, you will take a -20 penalty to SP for each jewel used. Faren spells do not take a penalty, however.

JoFs now also have a lot higher durability and no longer consume mana. They basically allow a mage to fight on par with a warrior, at the cost of severly gimping their non damage spell casting.
