### PR TITLE
Last Safe Room penalties

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -241,6 +241,7 @@ resources:
 
    user_logon = \
       "Welcome to the world of Meridian 59! (type \"help\" to see the manual)."
+   user_goto_lastsaferoom = "You have been sent to the last safe place you visited."
    user_goto_safety = "You have been sent to a safe place."
    user_goto_object = "You have been sent to %s%s."
    user_goto_jail = "You have been thrown in the Barloque Jail!"
@@ -307,6 +308,8 @@ properties:
    vrName = user_name_rsc
 
    piHomeroom
+   
+   piLastSafeRoom = $
 
    plNew_mail = $
 
@@ -5994,6 +5997,13 @@ messages:
             Send(self,@CheckLeavingNewbieOrGuest,#leaving=old);
             Send(self,@CheckTokenInNewRoom,#what=old);
          }
+         
+         % If room is no combat and safe logoff, record it as the player's last safe location
+         if Send(poOwner,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
+            AND Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
+         {
+            piLastSafeRoom = Send(poOwner,@GetRoomNum);
+         }
 
          piRow = First(Send(poOwner,@GetRoomPos,#what=self));
          piCol = Nth(Send(poOwner,@GetRoomPos,#what=self),2);
@@ -6971,6 +6981,68 @@ messages:
          return Send(SYS,@GetSuccessRsc);
       }
       
+      return;
+   }
+   
+   AdminGoToLastSafeRoom()
+   "Admin supported\n"
+   "Sends the user to the last safe room they visited, whether they're logged in or not!\n"
+   {
+      local oCurrentRoom, iCurrentRegion, oLastSafeRoom, iLastSafeRegion, oTargetRoom;
+
+      if piLastSafeRoom <> $
+      {
+         oLastSafeRoom = Send(SYS,@FindRoomByNum,#num=piLastSafeRoom);
+         iLastSafeRegion = Send(oLastSafeRoom,@GetRegion);
+         
+         if pbLogged_on
+         {
+            oCurrentRoom = Send(self,@GetOwner);
+            iCurrentRegion = Send(oCurrentRoom,@GetRegion);
+            
+            if iCurrentRegion = iLastSafeRegion
+            {
+               Send(oLastSafeRoom,@Teleport,#what=self);
+               Send(self,@MsgSendUser,#message_rsc=user_goto_lastsaferoom);
+            }
+            else
+            {
+               % If the user is in a different region from their last safe room, use region default homeroom instead.
+               % This can happen if a player goes to a new region but never stops in at a safe room.
+
+               oTargetRoom = send(SYS,@FindRoomByNum,#num=Send(oCurrentRoom,@GetCurrentRegionHomeroom));
+               Send(oTargetRoom,@Teleport,#what=self);
+               Send(self,@MsgSendUser,#message_rsc=user_goto_safety);
+            }
+         }
+         else
+         {
+            % If the user is logged off, we can't teleport.
+            % Instead, we update their saved logoff location.
+
+            oCurrentRoom = Send(SYS,@FindRoomByNum,#num=piSave_Room);
+            iCurrentRegion = Send(oCurrentRoom,@GetRegion);
+            
+            if iCurrentRegion = iLastSafeRegion
+            {
+               piSave_room = piLastSafeRoom;
+               piSave_row = Send(oLastSafeRoom,@GetTeleportRow);
+               piSave_col = Send(oLastSafeRoom,@GetTeleportCol);
+               piSave_fine_row = 32;
+               piSave_fine_col = 32;
+            }
+            else
+            {
+               oTargetRoom = send(SYS,@FindRoomByNum,#num=Send(oCurrentRoom,@GetCurrentRegionHomeroom));
+               
+               piSave_room = Send(oTargetRoom,@GetRoomNum);
+               piSave_row = Send(oTargetRoom,@GetTeleportRow);
+               piSave_col = Send(oTargetRoom,@GetTeleportCol);
+               piSave_fine_row = 32;
+               piSave_fine_col = 32;
+            }
+         }
+      }
       return;
    }
 

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -913,6 +913,37 @@ messages:
       return RID_DEFAULT;
    }
 
+   GetCurrentRegionHomeroom()
+   "Returns the RID of the region's default safe location.\n"
+   "Regions without safe rooms will default to Cor Noth inn."
+   {
+      local iRegion;
+      
+      iRegion = Send(self,@GetRegion);
+      
+      if iRegion = RID_GUEST_BASE
+      {
+         return RID_GUEST1;
+      }
+
+      if iRegion = RID_OUTOFGRACE
+      {
+         return RID_OUTOFGRACE;
+      }
+
+      if iRegion = RID_NEWB_BASE
+      {
+         return RID_NEWB1;
+      }
+
+      if iRegion = RID_KOCATAN
+      {
+         return RID_KOC_INN;
+      }
+
+      return RID_COR_INN;
+   }
+
    CreateYellZoneList()
    "Creates a list of room ID numbers (RIDs) that yells are extended to.  Does "
    "this by traversing plExits and plEdge_exits. Additional exits hardcoded "

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -227,9 +227,9 @@ messages:
       
       if Send(poGhostedPlayer,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
       {
-         if Send(Send(SYS, @GetSettings), @HometownPenaltiesEnabled)
+         if Send(Send(SYS, @GetSettings), @ReturnToSafetyPenaltiesEnabled)
          {
-	        Send(poGhostedPlayer,@AdminGoToSafety);
+	        Send(poGhostedPlayer,@AdminGoToLastSafeRoom);
          }
          else
          {
@@ -238,9 +238,9 @@ messages:
       }
       else
       {
-         if Send(Send(SYS, @GetSettings), @AngelHometownPenaltiesEnabled)
+         if Send(Send(SYS, @GetSettings), @AngelReturnToSafetyPenaltiesEnabled)
          {
-	        Send(poGhostedPlayer,@AdminGoToSafety);
+	        Send(poGhostedPlayer,@AdminGoToLastSafeRoom);
          }
          else
          {

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -125,13 +125,13 @@ properties:
    % Justicar
    piMinHPForJusticar = 100
 
-   % If enabled, unsafe penalties send the player to their hometown.
+   % If enabled, unsafe penalties send the player to their last safe place.
    % This is intended to prevent being players 'kept offline' by enemies.
-   pbHometownPenaltiesEnable = FALSE
+   pbReturnToSafetyPenaltiesEnable = FALSE
    
-   % If enabled, unsafe penalties send angeled players to their hometown.
+   % If enabled, unsafe penalties send angeled players to their last safe place.
    % This is intended to prevent being players 'scouting' with mules.
-   pbAngelHometownPenaltiesEnable = FALSE
+   pbAngelReturnToSafetyPenaltiesEnable = FALSE
    
    % If this is enabled a player will lose half their mana and all buffs when they log off in a safe zone.
    % This is to prevent 'character trains' with pre-buffed characters
@@ -315,16 +315,16 @@ messages:
       return piMinHPForJusticar;
    }
    
-   % This returns whether players go to a room's blink spot or their hometown when they pen
-   HometownPenaltiesEnabled()
+   % This returns whether players go to a room's blink spot or their last safe place when they pen
+   ReturnToSafetyPenaltiesEnabled()
    {
-      return pbHometownPenaltiesEnable;
+      return pbReturnToSafetyPenaltiesEnable;
    }
 
-   % This returns whether angeled players go to a room's blink spot or their hometown when they pen
-   AngelHometownPenaltiesEnabled()
+   % This returns whether angeled players go to a room's blink spot or their last safe place when they pen
+   AngelReturnToSafetyPenaltiesEnabled()
    {
-      return pbAngelHometownPenaltiesEnable;
+      return pbAngelReturnToSafetyPenaltiesEnable;
    }
    
    % Returns if a player should recive a 'penalty' for logging of in a safe zone


### PR DESCRIPTION
These two settings will affect where players go when they take a logoff penalty. One setting is for built players, one is for angeled newbies.

A player that takes a Last Safe Room penalty will be moved to the last location they visited that was both no_combat and safelogoff. For example, a player who leaves the Trading Post and gets logged and penned at the Riija Temple will appear back at the Trading Post.

This follows region restrictions - you can't pen on the island and get moved back to the mainland. Instead, you will appear at Ko'catan Inn. OOG, Raza, and Hazar have similar restrictions, but Brax and the Orc Caves will both send you to the mainland default, which is Cor Noth inn. I consider this a better solution than sending players to a central location at either region where they could be repeatedly attacked and logged again (Brax and the Caves don't have any no_combat + safelogoff rooms), and I also consider it better than using players' hometowns, which can be nowhere near the place they got logged (like penning in the orc caves and appearing at Marion). Cor Noth is central to most mainland locations and serves as the best default.

Guild halls are not no_combat, and therefore are never considered your last safe location.

Moving built players is intended to allow players to resume playing the game immediately, so that they are not forced off of the game by enemies.

Moving angeled players is intended to prevent abuse, such as 'scout mules'. I didn't provide for maintaining Brax lever mules because that region is now accessible via keys, and keeping a character just for Brax access has always seemed like poor design to me. We can find another way if we need to.
