### PR TITLE
Tune common.mak 

### DIFF
--- a/common.mak
+++ b/common.mak
@@ -67,7 +67,7 @@ PALETTEFILE = $(TOPDIR)\blakston.pal
 # /EHsc- turns off exceptions
 
 CCOMMONFLAGS = -nologo -DBLAK_PLATFORM_WINDOWS -DWIN32 -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE \
-				 -TP -WX -GR- -EHsc-
+				 -TP -WX -GR- -EHsc- /MP
 
 CNORMALFLAGS = $(CCOMMONFLAGS) -W2 /Ox
 CDEBUGFLAGS = $(CCOMMONFLAGS) -Zi -W3 -DBLAKDEBUG
@@ -128,5 +128,5 @@ MAKEBGF = $(BLAKBINDIR)\makebgf
 
 # environment variables for compiler
 
-LIB = $(LIB);$(BLAKLIBDIR);$(TOPDIR)\miles\lib
-INCLUDE = $(INCLUDE);$(BLAKINCLUDEDIR);$(TOPDIR)\miles\include
+LIB = $(LIB);$(BLAKLIBDIR);C:\dx81sdk\DXF\DXSDK\lib
+INCLUDE = $(INCLUDE);$(BLAKINCLUDEDIR);C:\dx81sdk\DXF\DXSDK\include


### PR DESCRIPTION
This makes some adjustments to common.mak file for the build-process:

1) It adds the /MP flag to enable compiling with more than 1 cpu core. This speeds up the compilation time, see:
http://msdn.microsoft.com/en-us/library/vstudio/bb385193.aspx

2) It removes the miles soundsystem paths from the include and lib paths, we don't have MSS anyways.

3) It adds a static path to the DirectX 8.1 SDK.
I'm very aware of the fact this path probably doesn't match many systems with this default value, feel free to change it to anything else. Still I think having a default value set there is better, because it suggests more obviously to the user that this requires modification.
