### PR TITLE
Client version

### DIFF
--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -48,8 +48,8 @@
 typedef unsigned char Bool;
 enum {False = 0, True = 1};
 
-#define MAJOR_REV 7   /* Major version of client program */
-#define MINOR_REV 15  /* Minor version of client program; must be in [0, 99] */
+#define MAJOR_REV 50   /* Major version of client program */
+#define MINOR_REV 1  /* Minor version of client program; must be in [0, 99] */
 
 #define MAXAMOUNT 9     /* Max # of digits in a server integer */
 #define MAXSTRINGLEN 255 /* Max length of a string loaded from string table */


### PR DESCRIPTION
This sets new versions in the meridian client.
I've chosen "50" as new major revision to hopefully not overlap with the original client.

Both values are at least limited to a max value of 255.
For minor_revision it states 0-99.

These values (mostly the minor) must be raised whenever a new meridian.exe is distributed with a client-update/we changed something in the client.

The server's blakserv.cfg must reflect this.
