### PR TITLE
Treasure Shifted Toward Money

### DIFF
--- a/kod/object/passive/trestype/avart.kod
+++ b/kod/object/passive/trestype/avart.kod
@@ -28,18 +28,14 @@ messages:
    constructed()
    {
       plTreasure = [ [ &RainbowFern, 20],
-                     [ &Bread, 15],
-                     [ &KriipaClaw, 15],
-                     [ &Money, 14],
-                     [ &WebMoss, 8],
-                     [ &NeruditeSword, 7],
-                     [ &NeruditeArmor, 7],
-                     [ &IvyCirclet, 5],
-                     [ &CurePoisonPotion, 2],
-                     [ &CureDiseasePotion, 2],
-                     [ &RemoveCursePotion, 2],
-                     [ &PurifyPotion, 2],
-                     [ &Yrxlsap, 1]
+                     [ &KriipaClaw, 20],
+                     [ &Money, 30],
+                     [ &Snack, 13],
+                     [ &WebMoss, 10],
+                     [ &NeruditeSword, 1],
+                     [ &NeruditeArmor, 1],
+                     [ &IvyCirclet, 1],
+                     [ &Yrxlsap, 4]
 		             ];
 
       propagate;

--- a/kod/object/passive/trestype/dflyt.kod
+++ b/kod/object/passive/trestype/dflyt.kod
@@ -28,10 +28,10 @@ messages:
    constructed()
    {
       plTreasure = [ [ &DragonflyEye, 30 ],
-                     [ &WebMoss, 20 ],
-                     [ &Meatpie, 20 ],
+                     [ &WebMoss, 10 ],
+                     [ &Snack, 10 ],
                      [ &RainbowFern, 15 ],
-                     [ &Money, 7 ],
+                     [ &Money, 27 ],
                      [ &KriipaClaw, 7 ],
                      [ &Yrxlsap, 1 ]
 		             ];

--- a/kod/object/passive/trestype/skel2t.kod
+++ b/kod/object/passive/trestype/skel2t.kod
@@ -28,12 +28,12 @@ messages:
    
    Constructed()
    {
-      plTreasure = [ [ &MetalShield, 50 ],
-                     [ &Knightshield, 15 ],
-                     [ &Money, 15 ],
-                     [ &Scimitar, 10 ],
+      plTreasure = [ [ &MetalShield, 5 ],
                      [ &NeruditeArrow, 5 ],
                      [ &InkyCap, 4 ],
+                     [ &Knightshield, 1 ],
+                     [ &Money, 78 ],
+                     [ &Scimitar, 1 ],
                      [ &DiscordScroll, 1 ]
                    ];
 

--- a/kod/object/passive/trestype/skel3t.kod
+++ b/kod/object/passive/trestype/skel3t.kod
@@ -28,16 +28,14 @@ messages:
    
    Constructed()
    {
-      plTreasure = [ [ &NeruditeArrow, 15 ],
-                     [ &ShortSword, 15 ],
+      plTreasure = [ [ &NeruditeArrow, 25 ],
+                     [ &ShortSword, 5 ],
                      [ &InkyCap, 13 ],
-                     [ &Money, 12 ],
-                     [ &Hammer, 10 ],
-                     [ &KnightShield, 8 ],
-                     [ &Scimitar, 8 ],
-                     [ &ScaleArmor, 5 ],
-                     [ &NodeburstPotion, 5 ],
-                     [ &LightScroll, 5 ],
+                     [ &Money, 49 ],
+                     [ &Hammer, 1 ],
+                     [ &KnightShield, 1 ],
+                     [ &Scimitar, 1 ],
+                     [ &ScaleArmor, 1 ],
                      [ &EnfeebleWand, 2 ],
                      [ &ForgetWand, 2 ]
                    ];

--- a/kod/object/passive/trestype/skel4t.kod
+++ b/kod/object/passive/trestype/skel4t.kod
@@ -31,21 +31,18 @@ messages:
    
    constructed()
    {
-      plTreasure = [ [ &Scimitar, 20 ],
+      plTreasure = [ [ &Scimitar, 1 ],
                      [ &BlueDragonScale, 10 ],
                      [ &SilverArrow, 10 ],
                      [ &DarkAngelFeather, 10 ],
-                     [ &Circlet, 9 ],
-                     [ &Money, 7 ],
-                     [ &Gauntlet, 5 ],
-                     [ &SimpleHelm, 5 ],
+                     [ &Circlet, 1 ],
+                     [ &Money, 55 ],
+                     [ &Gauntlet, 1 ],
+                     [ &SimpleHelm, 1 ],
                      [ &InkyCap, 5 ],
-                     [ &KaraholsCursePotion, 5 ],
-                     [ &IdentifyWand, 5 ],
+                     [ &IdentifyWand, 1 ],
                      [ &WindScroll, 2 ],
-                     [ &SummonPoisonFogScroll, 2 ],
                      [ &KillingFieldScroll, 2 ],
-                     [ &LightScroll, 2 ],
                      [ &DementWand, 1 ]
                   ];
 

--- a/kod/object/passive/trestype/tought.kod
+++ b/kod/object/passive/trestype/tought.kod
@@ -32,10 +32,8 @@ messages:
    {
     plTreasure = [ [ &RedMushroom, 25 ],
                    [ &BlueMushroom, 20 ],
-                   [ &Snack, 16],
-                   [ &Emerald, 10 ],
-                   [ &Sapphire, 8 ],
-                   [ &Diamond,  6 ],
+                   [ &Snack, 15],
+                   [ &Money, 25 ],
                    [ &BlueDragonScale, 6],
                    [ &Ruby, 4],
                    [ &InkyCap, 4],

--- a/kod/object/passive/trestype/verytght.kod
+++ b/kod/object/passive/trestype/verytght.kod
@@ -29,7 +29,7 @@ messages:
    
    constructed()
    {
-      plTreasure = [ [ &BlueMushroom, 25],
+      plTreasure = [ [ &Money, 29],
                      [ &InkyCap, 14],
                      [ &PurpleMushroom, 12 ],
                      [ &Sapphire, 12 ],
@@ -37,12 +37,10 @@ messages:
                      [ &Ruby, 7 ],
                      [ &BlueDragonScale, 7],
                      [ &DarkAngelFeather, 5],
-                     [ &CloakPotion, 3],
                      [ &HoldWand, 2],
                      [ &MysticSword, 1 ],
                      [ &PlateArmor, 1 ],
-                     [ &Key, 1 ],
-                     [ &EarthquakeScroll, 1]
+                     [ &Key, 1 ]
                    ];
 
       propagate;

--- a/kod/object/passive/trestype/zombiet.kod
+++ b/kod/object/passive/trestype/zombiet.kod
@@ -29,11 +29,11 @@ messages:
    
    constructed()
    {
-      plTreasure = [ [ &RedMushroom, 26],
+      plTreasure = [ [ &RedMushroom, 8],
                      [ &Waterskin, 14],
                      [ &Flask, 10 ],
                      [ &Arsenic, 8 ],
-                     [ &Money, 8],
+                     [ &Money, 26],
                      [ &PurpleMushroom, 6],
                      [ &Sapphire, 6],
                      [ &Bread, 6 ],


### PR DESCRIPTION
Eliminated a ton of junk loot and significantly upped shilling drops on
avars, dragonflies, all undead, mollusks, and shadowbeasts. That should
cover options from 30ish to 150 hp for now. (CV, TR, Brax, OOK, beach
and caves)
