### PR TITLE
HP gain mult bound changed

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -7672,7 +7672,7 @@ messages:
             roll = FALSE;
          }
 
-         gainmult = bound(Send(Send(SYS, @GetSettings), @GetHPGainMultiplier),1,100);
+         gainmult = bound(Send(Send(SYS, @GetSettings), @GetHPGainMultiplier),1,500);
          gain = gain * gainmult;
 
          piGain_chance = piGain_chance + gain;


### PR DESCRIPTION
You can now increase HP gain rates. This increases the amount of XP
gained per kill by a ratio. Max 500%.
