### PR TITLE
Conveyance

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -1990,6 +1990,7 @@
    SID_CRYSTALIZE_MANA = 181
    SID_SET = 182
    SID_LOADOUT = 183
+   SID_CONVEYANCE = 184
 
    % Depreciated spell IDs
    SID_LIGHTNING = 1                   % use SID_LIGHTNING_BOLT

--- a/kod/object/passive/spell/utility/conveyance.kod
+++ b/kod/object/passive/spell/utility/conveyance.kod
@@ -1,0 +1,117 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+Conveyance is UtilitySpell
+
+constants:
+   include blakston.khd
+
+resources:
+
+   Conveyance_name_rsc = "conveyance"
+   Conveyance_icon_rsc = iboonint.bgf
+   Conveyance_desc_rsc = \
+     "Sends a stack of items to your closest personal vault.  "
+	 "Requires nothing but a will to clear clutter."
+ 
+   Conveyance_cant = "You cannot cast conveyance on %s%s."
+   Conveyance_not_enough_space = "Your vault does not have enough space!"
+   Conveyance_not_holding = "You cannot cast conveyance on an item you are not holding!"
+
+   Conveyance_cast = "A small portal whips into existence, pulling %s%s to your vault."
+     
+classvars:
+
+   vrName = Conveyance_name_rsc
+   vrIcon = Conveyance_icon_rsc
+   vrDesc = Conveyance_desc_rsc
+
+   viCast_time = 0
+
+   viSpell_num = SID_CONVEYANCE
+   viSpell_level = 1
+   viSchool = SS_KRAANAN
+   viMana = 0
+   viSpellExertion = 0
+   viChance_To_Increase = 5
+
+properties:
+
+messages:
+
+   ResetReagents()
+   {
+      plReagents = $;
+
+      return;
+   }
+
+   GetNumSpellTargets()
+   {
+      return 1;
+   }
+
+   CastSpell(who = $, lTargets = $)
+   {
+      local oTarget, oRoom, oVault;
+      
+      oTarget = First(lTargets);
+   
+      if NOT isClass(oTarget,&NumberItem)
+         OR NOT Send(oTarget,@CanBeStoredInVault)
+         OR isClass(oTarget,&Money)
+      {
+         Send(who,@MsgSendUser,#message_rsc=conveyance_cant,
+            #parm1=Send(oTarget,@GetDef),
+            #parm2=Send(oTarget,@GetName));
+
+         return;
+      }
+    
+      if NOT Send(who,@IsHolding,#what=oTarget)
+      {
+         Send(who,@MsgSendUser,#message_rsc=conveyance_not_holding);
+         return;
+      }
+
+      oRoom = Send(who,@GetOwner);
+      if oRoom = $
+         OR Send(oRoom,@GetRegion) <> RID_KOCATAN
+      {
+         oVault = Send(SYS,@FindVaultByNum,#num=VID_BARLOQUE);
+      }
+      else
+      {
+         oVault = Send(SYS,@FindVaultByNum,#num=VID_KOCATAN);
+      }
+      
+      if Send(oVault,@CanDepositItems,#lItems=lTargets,#who=who)
+      {
+         Send(oVault,@DepositItems,#lItems=lTargets,#who=who);
+         Send(who,@MsgSendUser,#message_rsc=Conveyance_cast,
+                  #parm1=Send(First(lTargets),@GetDef),
+                  #parm2=Send(First(lTargets),@GetName));
+      }
+      else
+      {
+         Send(who,@MsgSendUser,#message_rsc=Conveyance_not_enough_space);
+      }
+
+      propagate;
+   }
+
+   SuccessChance(who=$)
+   "Starter spell will always work."
+   {
+      return TRUE;
+   }
+ 
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/utility/makefile
+++ b/kod/object/passive/spell/utility/makefile
@@ -5,6 +5,6 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\utility.bof
-BOFS = set.bof loadout.bof
+BOFS = set.bof loadout.bof conveyance.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -3003,6 +3003,7 @@ messages:
 
       Send(self,@CreateOneSpellIfNew,#num=SID_SET,#class=&Set);
       Send(self,@CreateOneSpellIfNew,#num=SID_LOADOUT,#class=&Loadout);
+      Send(self,@CreateOneSpellIfNew,#num=SID_CONVEYANCE,#class=&Conveyance);
 
       % Trance may be searched for frequently, leave at end of list
       Send(self,@CreateOneSpellIfNew,#num=SID_TRANCE,#class=&Trance);


### PR DESCRIPTION
Utility Spell (never counts toward level progression) that sends any
stack of number items that can be stored in a vault to your closest
personal vault. Can't be used on money.
