### PR TITLE
Bait Radius Restriction

### DIFF
--- a/kod/object/passive/spell/bait.kod
+++ b/kod/object/passive/spell/bait.kod
@@ -48,6 +48,8 @@ classvars:
 
 properties:
 
+   piBaitRange = 16
+
 messages:
 
    ResetReagents()
@@ -102,10 +104,13 @@ messages:
             {
 	            %% don't allow in happyland, unless the monster has no master.
 	            if send(SYS,@IsPKAllowed) or send(first(oMonster),@GetMaster) = $
-	            {			
-		            send(first(oMonster), @TargetSwitch, #what=who, #iHatred=100);
-		            send(first(oMonster), @EnterStateChase, #target=who, #actnow=True);
-	            }
+	            {
+                    if Send(who,@SquaredDistanceTo,#what=First(oMonster)) < (piBaitRange * piBaitRange)
+                    {
+                       send(first(oMonster), @TargetSwitch, #what=who, #iHatred=100);
+                       send(first(oMonster), @EnterStateChase, #target=who, #actnow=True);
+                    }
+                }
             }
          }
       }


### PR DESCRIPTION
Defaults to 16. Implemented as a property so that it can be modified live.

This does not include the ability to cast Bait on others offensively.
I realized that would give an attacker the ability to kill someone without
going red. Additionally, there's no way to protect against such an attack
other than abusing safespots or logging; an offensive Bait in some
locations could be an instant death sentence. An offensive bait in
events, for example, could get hapless players immediately killed.

It just doesn't seem like a good idea without far more work put into the change.
