### PR TITLE
Minimum Swings for Imp Setting

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4709,7 +4709,7 @@ messages:
       }
       
       piWeaponSwings = piWeaponSwings + times;
-      if (piWeaponSwings mod SWINGS_PER_IMPROVE_CHECK) = 0
+      if (piWeaponSwings mod Send(Send(SYS,@GetSettings),@GetSwingsPerImproveCheck)) = 0
       {
          % Increase this number.  Allows us to advance, and get bonuses for advancement.
          piWeaponInfo = piWeaponInfo + 1000;

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -135,6 +135,9 @@ properties:
 
    % If disabled, outlaws & murderers will not be afforded the 1/3-hp damage cap protection.
    pbDamageCapProtectionMurderersEnable = FALSE
+   
+   % Minimum swings needed for a chance to improve a weaponcraft skill.
+   piWeaponcraftImprovementMinimumSwings = 75
 
 messages:
 
@@ -332,6 +335,12 @@ messages:
    {
       return piLogoffPenaltyGhostTime;
    }
+   
+   GetSwingsPerImproveCheck()
+   {
+      return piWeaponcraftImprovementMinimumSwings;
+   }
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
WC requires 75 swings before you even have a chance to imp. This setting
allows that to change.
