### PR TITLE
This offers a post battle summary

### DIFF
--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -138,6 +138,12 @@ resources:
    battler_pierce_damage = "lacerates"
    battler_pierce_wound = "pierces"
    battler_pierce_nick = "grazes"
+   
+   battle_summary = "~IYou had a %i percent chance to %s %s%s and a "
+                    "%i percent chance to get %s by %s!"
+                    
+   summary_string_hit = "hit"
+   summary_string_crit = "crit"
 
 classvars:
 
@@ -321,7 +327,7 @@ messages:
    % For a monster, the stroke_obj is itself.
    TryAttack(what = $,stroke_obj=$)
    {
-      local iChanceToHit, iDamage, oWeapon, iMultiplier;
+      local iChanceToHit, iChanceToGetHit, iDamage, oWeapon, iMultiplier, iHitPercent, iGetHitPercent;
 
       oWeapon = Send(self,@GetWeapon);
 
@@ -335,6 +341,32 @@ messages:
                      / Send(what,@GetDefense,#what=self,
                             #stroke_obj=stroke_obj);
       iChanceToHit = bound(iChanceToHit,125,2000);
+      
+      if iChanceToHit > 1000
+      {
+         iHitpercent = (iChanceToHit/10)-100;
+      }
+      else
+      {
+         iHitpercent = (iChanceToHit/10);
+      }   
+         
+      iChanceToGetHit = (Send(what,@GetOffense,#what=what,#stroke_obj=stroke_obj)
+                      * EQUAL_CHANCE_HIT)
+                     / Send(self,@GetDefense,#what=self,
+                            #stroke_obj=stroke_obj);
+      iChanceToGetHit = bound(iChanceToGetHit,125,2000);
+      
+      if iChanceToGetHit > 1000
+      {
+         iGetHitpercent = (iChanceToGetHit/10)-100;
+      }
+      else
+      {
+         iGetHitpercent = (iChanceToGetHit/10);
+      }
+      
+      
       iMultiplier = 1;
 
       if iChanceToHit > 1000
@@ -359,16 +391,32 @@ messages:
          % We hit!
          iDamage = Send(what,@AssessDamage,#what=self,
                         #damage=Send(self,@GetDamage,#what=what,
-                                     #stroke_obj=stroke_obj),
+                                     #stroke_obj=stroke_obj) * iMultiplier,
                         #atype=Send(self,@GetDamageType),
                         #aspell=Send(self,@GetSpellType));
-         iDamage = iDamage * iMultiplier;
+
          Send(self,@AssessHit,#what=what,#stroke_obj=stroke_obj,
               #damage=iDamage);
          if iDamage = $
          {
             Send(self,@KilledSomething,#what=what,#use_weapon=oWeapon,
                  #stroke_obj=stroke_obj);
+            
+            if IsClass(self,&Player)
+            {
+               if iChanceToGetHit > 1000
+               {
+                  Send(self,@MsgSendUser,#message_rsc=battle_summary,
+                    #parm1=iHitPercent,#parm2=summary_string_crit,#parm3=Send(what,@GetDef),#parm4=Send(what,@GetName),
+                    #parm5=iGetHitPercent,#parm6=summary_string_crit,#parm7=Send(what,@GetHimHer));
+               }
+               else
+               {
+                  Send(self,@MsgSendUser,#message_rsc=battle_summary,
+                    #parm1=iHitPercent,#parm2=summary_string_crit,#parm3=Send(what,@GetDef),#parm4=Send(what,@GetName),
+                    #parm5=iGetHitPercent,#parm6=summary_string_hit,#parm7=Send(what,@GetHimHer));
+               }
+            }   
          }
          else
          {
@@ -385,13 +433,29 @@ messages:
                                         #stroke_obj=stroke_obj),
                            #atype=Send(self,@GetDamageType),
                            #aspell=Send(self,@GetSpellType));
-            iDamage = iDamage * iMultiplier;
+
             Send(self,@AssessHit,#what=what,#stroke_obj=stroke_obj,
                  #damage=iDamage);
             if iDamage = $
             {
                Send(self,@KilledSomething,#what=what,#use_weapon=oWeapon,
                     #stroke_obj=stroke_obj);
+               
+               if IsClass(self,&Player)
+               {     
+                  if iChanceToGetHit > 1000
+                  {
+                     Send(self,@MsgSendUser,#message_rsc=battle_summary,
+                       #parm1=iHitPercent,#parm2=summary_string_hit,#parm3=Send(what,@GetDef),#parm4=Send(what,@GetName),
+                       #parm5=iGetHitPercent,#parm6=summary_string_crit,#parm7=Send(what,@GetHimHer));
+                  }
+                  else
+                  {
+                     Send(self,@MsgSendUser,#message_rsc=battle_summary,
+                       #parm1=iHitPercent,#parm2=summary_string_hit,#parm3=Send(what,@GetDef),#parm4=Send(what,@GetName),
+                       #parm5=iGetHitPercent,#parm6=summary_string_hit,#parm7=Send(what,@GetHimHer));
+                  }
+               }   
             }
             else
             {
@@ -420,13 +484,13 @@ messages:
    }
 
    GetOffense(what = $, stroke_obj=$)
-   "Returns the battler's ability to-hit.  Ranges from 1 to 1000."
+   "Returns the battler's ability to-hit.  Ranges from 1 to 3000."
    {
       return 1;
    }
 
    GetDefense(what = $, stroke_obj=$)
-   "Returns the battler's ability to avoid being hit.  Ranges from 1 to 1000."
+   "Returns the battler's ability to avoid being hit.  Ranges from 1 to 3000."
    {
       return 1;
    }


### PR DESCRIPTION
This is mostly for testing stuff on 104, but might also be neat to patch to 103. 

After you kill a mob, you will get a message, telling you what your chance to hit/crit and chance to get hit/crit was. This gives you a pretty decent idea of how your combat skills compared to the enemy you took on. The message takes the last swing you did as a base for your odds.

Example:
You killed the skeleton.
You had a 76 percent chance to hit the skeleton and a 34 percent chance to get hit by it.

I figured that a post combat summary would be the best way to tell you about your odds. We could, of course, also create a utility spell that you can cast on a mob and that tells you what your chances would be. I'd call it "consider" since that ability would be fairly close to the Everquest mechanic of conning a target. Anyways, for now, this should work nicely.
