### PR TITLE
Blessings on Monster Kills

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -275,6 +275,10 @@ properties:
    plOffer_items = $
    % List of items offered to the player by seller.
    plFor_sale = $
+   % List of buffs the monster may give when killed.
+   plKilledBuffs = $
+   % List of area enchantments monsters may give when killed.
+   plKilledAreaEnchantments = $
 
    ptCancelOffer = $
    ptRandom = $
@@ -379,6 +383,25 @@ messages:
       Send(self,@ResetBehaviorFlags);
 
       piMood = 0;
+
+      plKilledBuffs = Cons(SID_BLESS,plKilledBuffs);
+      plKilledBuffs = Cons(SID_MAGIC_SHIELD,plKilledBuffs);
+      plKilledBuffs = Cons(SID_SUPER_STRENGTH,plKilledBuffs);
+
+      plKilledAreaEnchantments = Cons(SID_RESTORATE,plKilledAreaEnchantments);
+      plKilledAreaEnchantments = Cons(SID_KILLING_FIELDS,plKilledAreaEnchantments);
+      
+      if viKarma < 0
+      {
+         plKilledAreaEnchantments = Cons(SID_MIRTH,plKilledAreaEnchantments);
+         plKilledAreaEnchantments = Cons(SID_FORCES_OF_LIGHT,plKilledAreaEnchantments);
+      }
+
+      if viKarma > 0
+      {
+         plKilledAreaEnchantments = Cons(SID_MELANCHOLY,plKilledAreaEnchantments);
+         plKilledAreaEnchantments = Cons(SID_REJUVENATE,plKilledAreaEnchantments);
+      }
 
       propagate;
    }
@@ -5783,6 +5806,15 @@ messages:
       return;
    }
 
+   GetKilledBuffs()
+   {
+      return plKilledBuffs;
+   }
+   
+   GetKilledAreaEnchantments()
+   {
+      return plKilledAreaEnchantments;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/monster/avchief.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/avchief.kod
@@ -124,6 +124,8 @@ messages:
                         [ 10, ATCK_WEAP_SLASH ],
                         [-15, ATCK_WEAP_NERUDITE ]
                       ];
+      
+      plKilledBuffs = Cons(SID_EAGLE_EYES,plKilledBuffs);
 
       propagate;
    }

--- a/kod/object/active/holder/nomoveon/battler/monster/orccave.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/orccave.kod
@@ -70,6 +70,9 @@ messages:
                         [ 20, ATCK_WEAP_PIERCE ],
                         [ 25, ATCK_WEAP_SLASH ],
                         [-20, -ATCK_SPELL_HOLY ] ];
+
+      plKilledBuffs = Cons(SID_NIGHT_VISION,plKilledBuffs);
+
       propagate;
    }
 

--- a/kod/object/active/holder/nomoveon/battler/monster/skel/batrskel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/skel/batrskel.kod
@@ -87,6 +87,12 @@ messages:
       return;
    }
 
+   Constructed()
+   {
+      plKilledBuffs = Cons(SID_HASTE,plKilledBuffs);
+
+      propagate;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -707,6 +707,15 @@ resources:
    player_logged_on_wav_rsc = player_login_or_out.wav
    player_logged_off_wav_rsc = player_logout2.wav
 
+   player_receive_killed_kraanan_buff = "You pray over the corpse of the %s, and Kraanan grants you a blessing!"
+   player_receive_killed_qor_buff = "You pray over the corpse of the %s, and Qor responds to your sacrifice with a dark gift."
+ 
+   player_receive_killed_jala_enchantment = "You pray over the corpse of the %s, and Jala graces you with a gift."
+   player_receive_killed_kraanan_enchantment = "As you pray over the corpse of the %s, you sense Kraanan turn his attention toward the area."
+   player_receive_killed_shalille_enchantment = "As you pray over the corpse of the %s, you feel Shal'ille's support warm you."
+   player_receive_killed_qor_enchantment = "As you pray over the corpse of the %s, you feel Qor's dark smile chill you."
+   player_receive_killed_faren_enchantment = "As you pray over the corpse of the %s, the very air surges with Faren's offered energies."
+
 classvars:
 
    viHand_space = 2
@@ -953,6 +962,10 @@ properties:
    % Used to construct a string for their description.
    plDonationYears = $
 
+   % Limit each player to one AE blessing at a time
+   pbCanReceiveKilledAreaEnchantment = TRUE
+   ptKilledAreaEnchantmentTimer = $
+
 messages:
 
    Constructor()
@@ -1013,6 +1026,12 @@ messages:
       {
          DeleteTimer(ptAttackTimer);
          ptAttackTimer = $;
+      }
+      
+      if ptKilledAreaEnchantmentTimer <> $
+      {
+         DeleteTimer(ptKilledAreaEnchantmentTimer);
+         ptKilledAreaEnchantmentTimer = $;
       }
 
       Send(self,@RemoveAllEnchantments,#report=FALSE);
@@ -4748,7 +4767,8 @@ messages:
    KilledSomething(what = $,use_weapon = $,stroke_obj = $)
    "Called when the player killed something."
    {
-      local i, oSoldierShield, monstkarma, iChance, oEnemyGuild;
+      local i, oSoldierShield, monstkarma, iChance, oEnemyGuild, lKilledBuffs, oKilledBuff, iRandomBuff,
+               lKilledAreaEnchantments, oKilledAreaEnchantment, iRandomAreaEnchantment, iAreaEnchantTime;
 
       % If we killed someone or something, we did damage.
       Send(self,@SetPlayerFlag,#flag=PFLAG_DID_DAMAGE,#value=TRUE);
@@ -4872,12 +4892,107 @@ messages:
          Send(self,@AddKarma,#amount=Send(self,@CalculateKarmaChangeFromKill,
               #karma_victim=Send(what,@GetKarma),#karma_killer=Send(self,@GetKarma)),
               #bIsMob=TRUE);
+
+         % Gift a player either a buff blessing or area enchantment blessing
+         if Random(1,2) = 1
+         {
+            lKilledBuffs = Send(what,@GetKilledBuffs);
+            if lKilledBuffs <> $
+            {
+               iRandomBuff = Random(1,Length(lKilledBuffs));
+               iRandomBuff = Nth(lKilledBuffs,iRandomBuff);
+               oKilledBuff = Send(SYS,@FindSpellByNum,#num=iRandomBuff);
+               if oKilledBuff <> $
+               {
+                  if NOT Send(self,@IsEnchanted,#what=oKilledBuff)
+                  {
+                     if Send(self,@IsLoggedOn)
+                     {
+                        Send(self,@MsgSendUser,#message_rsc=player_receive_killed_kraanan_buff,#parm1=Send(what,@GetName));
+                     }
+                     Send(oKilledBuff,@CastSpell,#who=what,#lTargets=[self],#iSpellPower=Random(25,75),#bItemCast=TRUE);
+                  }
+               }
+            }
+         }
+         else
+         {
+            lKilledAreaEnchantments = Send(what,@GetKilledAreaEnchantments);
+            if lKilledAreaEnchantments <> $
+            {
+               iRandomAreaEnchantment = Random(1,Length(lKilledAreaEnchantments));
+               iRandomAreaEnchantment = Nth(lKilledAreaEnchantments,iRandomAreaEnchantment);
+               oKilledAreaEnchantment = Send(SYS,@FindSpellByNum,#num=iRandomAreaEnchantment);
+
+               % Make sure players can't somehow get 'stuck' with a broken timer
+               if pbCanReceiveKilledAreaEnchantment = FALSE
+                  AND ptKilledAreaEnchantmentTimer = $
+               {
+                  pbCanReceiveKilledAreaEnchantment = TRUE;
+               }
+
+               if poOwner <> $
+                  AND NOT Send(poOwner,@IsEnchanted,#what=oKilledAreaEnchantment)
+                  AND pbCanReceiveKilledAreaEnchantment = TRUE
+               {
+                  if Send(self,@IsLoggedOn)
+                  {
+                     iAreaEnchantTime = Random(35000,65000);
+                     if Send(oKilledAreaEnchantment,@GetSchool) = SS_JALA
+                     {
+                        Send(self,@MsgSendUser,#message_rsc=player_receive_killed_jala_enchantment,#parm1=Send(what,@GetName));
+                        Send(poOwner,@RoomStartEnchantment,#what=oKilledAreaEnchantment,
+                                     #state=[Send(oKilledAreaEnchantment,@CalculateVolume,#iSpellPower=Random(65,99)),poOwner,Random(65,99)],
+                                     #time=iAreaEnchantTime);
+                     }
+
+                     if Send(oKilledAreaEnchantment,@GetSchool) = SS_KRAANAN
+                     {
+                        Send(self,@MsgSendUser,#message_rsc=player_receive_killed_kraanan_enchantment,#parm1=Send(what,@GetName));
+                        Send(poOwner,@RoomStartEnchantment,#what=oKilledAreaEnchantment,#state=Random(65,99),#time=iAreaEnchantTime);
+                     }
+                  
+                     if Send(oKilledAreaEnchantment,@GetSchool) = SS_SHALILLE
+                     {
+                        Send(self,@MsgSendUser,#message_rsc=player_receive_killed_shalille_enchantment,#parm1=Send(what,@GetName));
+                        Send(poOwner,@RoomStartEnchantment,#what=oKilledAreaEnchantment,#state=Random(65,99),#time=iAreaEnchantTime);
+                     }
+
+                     if Send(oKilledAreaEnchantment,@GetSchool) = SS_QOR
+                     {
+                        Send(self,@MsgSendUser,#message_rsc=player_receive_killed_qor_enchantment,#parm1=Send(what,@GetName));
+                        Send(poOwner,@RoomStartEnchantment,#what=oKilledAreaEnchantment,#state=Random(65,99),#time=iAreaEnchantTime);
+                     }
+                  
+                     if Send(oKilledAreaEnchantment,@GetSchool) = SS_FAREN
+                     {
+                        Send(self,@MsgSendUser,#message_rsc=player_receive_killed_qor_enchantment,#parm1=Send(what,@GetName));
+                        Send(poOwner,@RoomStartEnchantment,#what=oKilledAreaEnchantment,#state=Random(65,99),#time=iAreaEnchantTime);
+                     }
+                  
+                     Send(poOwner,@EnchantAllOccupants,#what=oKilledAreaEnchantment);
+
+                     pbCanReceiveKilledAreaEnchantment = FALSE;
+                     ptKilledAreaEnchantmentTimer = CreateTimer(self,@KilledAreaEnchantmentCooldownTimer,iAreaEnchantTime);
+                  }
+               }
+            }
+         }
       }
 
       Send(what,@Killed,#what=self,#stroke_obj=stroke_obj);
 
       return;
    }
+   
+   KilledAreaEnchantmentCooldownTimer()
+   {
+      ptKilledAreaEnchantmentTimer = $;
+      pbCanReceiveKilledAreaEnchantment = TRUE;
+      
+      return;
+   }
+   
 
    GetSomethingMissedYouSound(what = $,weapon_used = $)
    {
@@ -5559,7 +5674,7 @@ messages:
       
       if poOwner <> $
       {
-         lJalaInfo = Send(poOwner,@GetJalaInfo);
+         lJalaInfo = Send(poOwner,@GetJalaInfo,#class=&Restorate);
 
          if lJalaInfo <> $
          {
@@ -5598,7 +5713,7 @@ messages:
 
          if poOwner <> $
          {
-            lJalaInfo = Send(poOwner,@GetJalaInfo);
+            lJalaInfo = Send(poOwner,@GetJalaInfo,#class=&Rejuvenate);
 
             if lJalaInfo <> $
             {
@@ -9830,7 +9945,7 @@ messages:
 
       if poOwner <> $
       {
-         lJalaInfo = Send(poOwner,@GetJalaInfo);
+         lJalaInfo = Send(poOwner,@GetJalaInfo,#class=&Invigorate);
 
          if lJalaInfo <> $
          {

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3387,7 +3387,7 @@ messages:
       return;
    }
 
-   GetJalaInfo()
+   GetJalaInfo(class=$)
    "Returns all the info about the current Jala spell.  Returns a list of "
    "[timer, spell object, state]."
    {
@@ -3396,9 +3396,19 @@ messages:
       for i in plEnchantments
       {
          oSpell = Nth(i,2);
-         if Send(oSpell,@GetSchool) = SS_JALA
+         if class = $
          {
-            return i;
+            if Send(oSpell,@GetSchool) = SS_JALA
+            {
+               return i;
+            }
+         }
+         else
+         {
+            if IsClass(oSpell,class)
+            {
+               return i;
+            }
          }
       }
 

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -509,7 +509,7 @@ messages:
          {
             % The spell's spellpower is the third element of the state, which
             %  is the third element of Jala info stored by room.
-            iJalaPower = Nth(Nth(Send(where,@GetJalaInfo),3),3);
+            iJalaPower = Nth(Nth(Send(where,@GetJalaInfo,#class=&Spellbane),3),3);
 
             % Does Spellbane overpower the spell?
             % Spellbane always works on monsters that can be silenced
@@ -1184,7 +1184,7 @@ messages:
       num = ((100-iRequisiteStat)*iSpellpower/100) + iRequisiteStat;
 
       % Modify chance to succeed due to Jala's hinder spells.
-      lJalaInfo = Send(Send(who,@GetOwner),@GetJalaInfo);
+      lJalaInfo = Send(Send(who,@GetOwner),@GetJalaInfo,#class=&HinderSpell);
 
       if lJalaInfo <> $
       {

--- a/kod/object/passive/spell/jala.kod
+++ b/kod/object/passive/spell/jala.kod
@@ -154,7 +154,8 @@ messages:
       local oRoom;
       
       % Check for Necklace of Jala first
-      if Send(who,@IsUsingA,#class=&JalaNecklace)
+      if IsClass(who,&User)
+         AND Send(who,@IsUsingA,#class=&JalaNecklace)
       {
          % The song keeps going if you get damaged, move, cast, or make an attack.
          if event = EVENT_DAMAGE
@@ -180,6 +181,11 @@ messages:
       else
       {
          oRoom = location;
+      }
+      
+      if IsClass(who,&Room)
+      {
+         location = who;
       }
       
       Send(oRoom,@RemoveEnchantment,#what=self,#state=state);
@@ -218,7 +224,12 @@ messages:
       local oCaster;
       
       oCaster = Nth(state,2);
-   
+
+      if IsClass(oCaster,&Room)
+      {
+         return;
+      }
+
       % If caster runs out of mana or loses trance, spell ends.
       if Send(oCaster,@GetMana) < viManaDrain * 2
       {
@@ -261,6 +272,12 @@ messages:
    {
       local oCaster, lActive, each_obj, oRoom, i;
       oCaster = Nth(state,2);
+      
+      if IsClass(oCaster,&Room)
+         AND where = $
+      {
+         where = oCaster;
+      }
 
       if pbUserEffects
       {
@@ -284,8 +301,12 @@ messages:
       Send(where,@SomeoneSaid,#type=SAY_MESSAGE,#string=jala_song_ends,
            #what=self);
       % Send $ as midi_rsc to end music and resume default.
-      Send(self,@StartMusic,#oCaster=oCaster,#rMusic=$);
-      Send(oCaster,@ClearTranceFlag);
+      
+      if IsClass(oCaster,&User)
+      {
+         Send(self,@StartMusic,#oCaster=oCaster,#rMusic=$);
+         Send(oCaster,@ClearTranceFlag);
+      }
       
       return;
    }
@@ -299,6 +320,11 @@ messages:
          debug("BAD MUSIC SETUP, MAN!");
 
          return FALSE;
+      }
+      
+      if IsClass(oCaster,&Room)
+      {
+         return;
       }
 
       oRoom = Send(oCaster,@GetOwner);


### PR DESCRIPTION
In classic MUD style, players will pray over monster corpses they've
just killed and perhaps receive a blessing. These blessings default to
generic buffs like Bless, Magic Shield, and Super Strength, but can be
customized per monster. For example, Avar Chieftains also give Eagle
Eyes, and Battered Skeletons give Haste.

Players may also receive one short duration Area Enchantment at a time.
Multiple players killing monsters in the same room can have one each,
thus encouraging players to work together. Mules that are not killing
monsters do not contribute. These are also customizable, and default
to Restorate and Killing Fields, Mirth and Forces of Light from evil
creatures, and Melancholy and Rejuvenate from good creatures.

In this way, I believe we can cut out the need for players to bring a
second character to buff themselves. It's also pretty fun and breaks up
the monotony.

Spellpower for the buffs is 25 - 75, so it can be better to cast your
own buffs on yourself. Spellpower for the AEs is a little higher and
more consistent, since you only get one at a time per player.

Commit also includes some structural work on Jala to make caster-less
songs possible (the room is considered the caster) and to make sure that
multiple Jala songs work at the same time.

---

This can also be used in the future to give monsters revenge spells.
For example, a dying Xeo might cast Heat, or a dying Dark Angel
might cast Silence.
