### PR TITLE
Giving lightning bolt back to trees!

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/ent.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/ent.kod
@@ -14,6 +14,8 @@ constants:
 
    include blakston.khd
 
+   SPELL_RANGE_SQUARED = 666
+
 resources:
 
    ent_koc_name_rsc = "tezmecya"
@@ -66,6 +68,7 @@ classvars:
 properties:
 
    piAnimation = ANIM_NONE
+   piSpell_chance = 10
 
 messages:
 
@@ -186,6 +189,41 @@ messages:
       return;
    }
 
+   AssessDamage(aSpell=0)
+   {
+      % Living trees get more dangerous if you burn 'em.
+
+      if (aSpell & ATCK_SPELL_FIRE) AND piSpell_chance > 2
+      {
+         piSpell_chance = piSpell_chance - 1;
+      }
+
+      propagate;
+   }
+
+   MonsterCastSpell()
+   {
+      local oSpell, iBase;
+      
+      iBase = Send(self,@AdjustedChanceBase,#base=piSpell_chance);
+
+      if Random(1,iBase) = 1
+         AND Send(self,@SquaredDistanceTo,#what=poTarget) < SPELL_RANGE_SQUARED
+         AND Send(poOwner,@LineOfSight,#obj1=self,#obj2=poTarget)
+         AND Send(poOwner,@ReqSomethingAttack,#what=self,#victim=poTarget)
+      {
+         piAnimation = ANIM_ATTACK;
+         Send(poOwner,@SomethingChanged,#what=self);
+         piAnimation = ANIM_NONE;
+         oSpell = Send(SYS,@FindSpellByNum,#num=SID_LIGHTNING);
+         Send(oSpell,@CastSpell,#who=self,#lTargets=List(poTarget));
+
+         return TRUE;
+      }
+      
+      return FALSE;
+   }
+
    CreateDeadBody(killer=$)
    {
       return Create(&DeadBody,#icon=vrDead_Icon,#name=vrDead_Name,
@@ -197,4 +235,4 @@ messages:
    }
 
 end
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
For balance and lore reasons. Living Trees have been given lightning bolt back to protect the forests of meridian! As it stands now, living trees can be killed with a longsword unable to attack back which can be capatilized on for imp rates. 
