### PR TITLE
Invigorate After HP

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -149,6 +149,7 @@ resources:
       "Feel free to take the %s%s by your feet as payment for returning the "
       "token."
    player_improve_maxhealth = "~I~BYou suddenly feel a little tougher."
+   player_improve_health_invigorate = "~I~BYou feel invigorated by your success."
    player_spits = "You spit on the corpse of your unworthy foe."
    player_regain_angel = \
       "Due to your weakness, your protective guardian angel returns."
@@ -7812,6 +7813,10 @@ messages:
 
                Send(self,@MsgSendUser,#message_rsc=player_improve_maxhealth);
                Send(self,@WaveSendUser, #what=self, #wave_rsc=player_tougher_wav_rsc);
+               Send(self,@MsgSendUser,#message_rsc=player_improve_health_invigorate);
+               piHealth = piMax_Health;
+               Send(self,@DrawHealth);
+               Send(self,@EatSomething,#nutrition=200);
 
                piGain_chance = -(piBase_Max_health/2);
                


### PR DESCRIPTION
I was building on 103 last night and noticed there really is no reward when you get an HP, sure you get the HP but that's it. If you're fighting and you go down low (lets say 15 hp) to kill a monster and you get an HP from that monster shouldn't you be rewarded with full vigor and health? I thought it would be nice to reward my HP with a full health bar & vig.

This change does just that, when you receive your HP it will bring your HPs to full and redraw the bar, then boost your vigor to 200. It sends a message saying "You feel invigorated by your success."

Most other games when you level or equivalent you get boosted to full mana, full hp, etc. I decided not to go with full everything and leave mana as is and just boost vigor and health. I know these will be happening every few minutes when you are below 30, but when you are above 30 and HPs take some time longer, then obviously as the HP becomes harder these become more rare and more sought after.

Just a thought to add a pep in the step of building/grinding.
