### PR TITLE
Beta Potions 2.0

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -653,6 +653,8 @@ resources:
       "\n\n"
       "----Baron of Cor Noth Township, Gerah Springer."
 
+   player_LearnPoints = "%i out of %i points used."
+      
    player_Debug_playercanlearn = \
       "Do the math for %s to learn a %i level spell from the %s school.  "
       "%i points from spells already known (%i from this school).  Intellect "
@@ -975,6 +977,9 @@ properties:
    % Is the player currently using a Death Rift spell?
    pbDeath_rift = FALSE
    ptDeathRiftTimer = $
+   
+   % Used to check if a player drank a beta potion. This flag will allow them to select schools.
+   pbDrankBetaPotion = FALSE
 
 messages:
 
@@ -12162,13 +12167,26 @@ messages:
    {
       local oSnoop;
 
-      if type = SAY_NORMAL and what <> self and IsClass(what,&Player)
+      if type = SAY_NORMAL
       {
-         oSnoop = Send(self,@FindHolding,#class=&ShrunkenHead);
-         if oSnoop <> $
-         {
-            Send(oSnoop,@SomeoneOverheard,#from=what,#to=self,#string=string);
-         }
+	     if what = self
+		 {
+		     % If has Beta Potion flag, send the string to the function for further checks.
+		     if pbDrankBetaPotion
+		     {
+			     Send(self,@BetaPotionSay,#string=string);
+		     }
+		 }
+	  
+		 if what <> self AND IsClass(what,&Player)
+		 {
+             oSnoop = Send(self,@FindHolding,#class=&ShrunkenHead);
+             if oSnoop <> $
+             {
+                 Send(oSnoop,@SomeoneOverheard,#from=what,#to=self,#string=string);
+             }
+		 }
+		 
       }
 
       if NOT Send(SYS,@IsSuspect,#who=self)
@@ -12646,6 +12664,214 @@ messages:
       
       return;
    }
+   
+   %
+   % Beta Potion 2.0
+   % Allow players to select their schools, during beta mode.
+   %
+   
+   DrankBetaPotion()
+   {
+      % Only works if the server is in beta mode, or during a frenzy.
+      if Send(Send(SYS,@GetLore),@BetaPotionsEnabled) AND Send(Send(SYS,@GetParliament),@BetaPotionsEnabled)
+         OR Send(SYS, @GetChaosNight)
+      {
+		 pbDrankBetaPotion = TRUE;
+		 return TRUE;
+	   }
+	  else
+      {
+		 Debug("Player has beta potion flag while potions are not enabled!");
+		 pbDrankBetaPotion = FALSE;
+		 return FALSE;
+	   }
+	  
+	  return;
+   }
+   
+   BetaPotionSay(string = $)
+   {
+	  local iSchool, iLevel, iLearnPoints, iMaxLearnPoints, oItem, oItemAtt, oRobe, iItemDuration;
+	  
+	  iSchool = 0;
+	  iLevel = 0;
+	  iLearnPoints = 0;
+	  iMaxLearnPoints = 0;
+	  
+	  oItemAtt = send(SYS,@FindItemAttByNum,#Num=IA_MADE);
+	  iItemDuration = 18000000; %5 hours
+
+	  iMaxLearnPoints = Send(Send(SYS, @GetSettings), @GetMaxLearnPoints) + 
+		  (Send(self,@GetRawIntellect) * 2) / 5;
+
+	  iSchool = send(self,@BetaPotionCheckSchool,#string=string);
+	  iLevel = send(self,@BetaPotionCheckLevel,#string=string);
+
+	  if iSchool <> 0 AND iLevel <> 0
+	  {
+	 
+		 % 10 is used for weaponcraft
+		 if iSchool = SKS_FENCING
+		 {
+			 send(self,@GivePlayerAllSkills,#school=iSchool,#level=iLevel,#iability=50,#upto=TRUE);
+		 }
+		 else
+		 {
+			 if iSchool = SS_SHALILLE
+			 {
+				 % Can't add Shal'ille when already has Qor.
+				 if Send(self,@GetNumSpellsInSchool,#school=SS_QOR) 
+				 { 
+					 return FALSE;
+				 }
+				 
+				 piKarma = 100000;
+				 Send(self,@NewKarma);
+			 }
+
+			 if iSchool = SS_QOR
+			 {
+				 % Can't add Qor when already has Shal'ille.
+				 if Send(self,@GetNumSpellsInSchool,#school=SS_SHALILLE) 
+				 { 
+					 return FALSE;
+				 }
+
+				 piKarma = -100000;
+				 Send(self,@NewKarma);
+			 }
+			 
+			 % Give robe of that school
+			 oItem = Create(&DiscipleRobe,#school=iSchool);
+			 send(oItemAtt,@AddtoItem,#oitem=oItem,#timer_duration=(iItemDuration));
+			 
+			 oRobe = Send(self,@FindHolding,#class=&DiscipleRobe);
+			 if oRobe = $
+			 {
+				 Send(self,@NewHold,#what=oItem);
+			 }
+			 else
+			 {
+			    if Send(oRobe,@GetSchool) <> iSchool
+			    {
+				    Send(self,@NewHold,#what=oItem);
+			    }
+			 }
+			 
+			 send(self,@GivePlayerAllSpells,#school=iSchool,#level=iLevel,#iability=50,#upto=TRUE);
+		 }
+		 
+		 iLearnPoints = Send(self,@GetTotalLearnPoints,#except=0);
+		 send(self,@MsgSendUser,#message_rsc=player_LearnPoints,#parm1=iLearnPoints,#parm2=iMaxLearnPoints);
+		 
+		 % iLearnPoints should always equal iMaxLearnPoints,
+		 % only time it will go over if it is a DM
+		 if iLearnPoints >= iMaxLearnPoints
+		 {
+			 % Give reagents for spells
+			 Post(self,@AddReagentsForSpells,#iNumCasts=5);
+			 
+			 pbDrankBetaPotion = FALSE;
+			 return TRUE;
+		 }
+	  }
+
+	  return;
+   }
+ 
+   BetaPotionCheckSchool(string = $)
+   "Check if player says the name of a school."
+   {
+	  local school;
+	  
+	  school = 0;
+	  
+	  if StringContain(string,"Shal'ille")
+	  {
+		 school = SS_SHALILLE;
+	  }
+	  
+	  if StringContain(string,"Qor")
+	  {
+		 school = SS_QOR;
+	  }
+	  
+	  if StringContain(string,"Kraanan")
+	  {
+		 school = SS_KRAANAN;
+	  }
+	  
+	  if StringContain(string,"Faren")
+	  {
+		 school = SS_FAREN;
+	  }
+	  
+	  if StringContain(string,"Riija")
+	  {
+		 school = SS_RIIJA;
+	  }
+	  
+	  if StringContain(string,"Jala")
+	  {
+		 school = SS_JALA;
+	  }
+	  
+	  if StringContain(string,"Weaponcraft")
+	  {
+		 % We use 10 to indicate skills.
+		 school = SKS_FENCING;
+	  }
+	  
+	  return school;
+   }
+   
+   BetaPotionCheckLevel(string = $)
+   "Check if player also says the level."
+   {
+	  local level;
+	  
+	  if StringContain(string,"one") OR
+	     StringContain(string,"1")
+	  {
+		 level = 1;
+	  }
+	  
+	  if StringContain(string,"two") OR
+		 StringContain(string,"2")
+	  {
+		 level = 2;
+	  }
+	  
+	  if StringContain(string,"three") OR
+		 StringContain(string,"3")
+	  {
+		 level = 3;
+	  }
+	  
+	  if StringContain(string,"four") OR
+		 StringContain(string,"4")
+	  {
+		 level = 4;
+	  }
+	  
+	  if StringContain(string,"five") OR
+		 StringContain(string,"5")
+	  {
+		 level = 5;
+	  }
+	  
+	  if StringContain(string,"six") OR
+		 StringContain(string,"6")
+	  {
+		 level = 6;
+	  }
+	  
+	  return level;
+   }
+   
+   %
+   % End of Beta Potion Code
+   %
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/betap.kod
+++ b/kod/object/item/passitem/betap.kod
@@ -19,32 +19,28 @@ resources:
    BetaPotion_icon_rsc = potion01.bgf
 
    BetaPotion_name_rsc = "The infamous BETA POTION!"
-   BetaPotion_desc_rsc = "This potion is to facilitate beta testing by allowing "
+   BetaPotion_desc_rsc = \
+	   "This potion is to facilitate beta testing by allowing "
        "the testers to test the more advanced parts of the game.\n\n"
-
-   BetaPotion_Append_rsc = "This potion will give you a boost of " 
-   
-   BetaPotion_Append2_rsc = " hit points (but will not raise your health above "
-   BetaPotion_Append3_rsc = ").  "
-       "The size of the boost is directly related to how much time your "
-       "character has spent online.  Thus, beta testers who have devoted "
-       "more to the game have been rewarded greater.  "
-       "It will also give you all the spells up to level "
-   BetaPotion_Append4_rsc = " in the "
-   BetaPotion_Append5_rsc = " school of magic, limited by your Intellect.\n\n"
+	   "This potion will boost stats including your Mana and Hit Points. "
+	   "Once you drink the potion, you can also select your schools of magic "
+	   "by saying the name of the schools and the levels you wish to recieve. "
+	   "You may not have both Shal'ille and Qor spells. Limited by your Intellect you will "
+	   "only recieve a certain amount of points before the potion effect wears off. \n\n"
        "If you lose the potion in any way, shape or form (including if you give "
        "it to a friend and s/he quaffs it, or you step through the portal in "
        "Raza, or your little sister suicides your character just to spite you), "
-       "or you didn't get a potion in the school you wanted and threw it away, "
-       "you will NOT get another potion.  So don't ask.\n\n"
-         
+       "or you just threw it away, you will NOT get another potion.  So don't ask.\n\n"
+
    BetaPotion_gulp_sound = drkptn.wav
 
    BetaPotion_drink = "You quaff the contents of the vial in a single gulp."
    BetaPotion_worked = "You suddenly feel a little taller."
-   BetaPotion_bad_drink = \
-      "You choke down the foul-tasting contents of the vial, realizing almost "
-      "immediately that this was a pretty bad idea. Time has caused it to sour."
+
+   BetaPotion_ask = \
+	  "Add your schools until you are out of points. Say one of the following:\n"
+      "~B\"[SHAL'ILLE, QOR, KRAANAN, FAREN, RIIJA, JALA, WEAPONCRAFT]\"~n "
+	  "followed by ~B\"LEVEL [ONE, TWO, THREE, FOUR, FIVE, SIX]\""
 
 classvars:
    
@@ -68,104 +64,63 @@ properties:
    piGoBadTime = 0
    piItem_flags = PT_GRAY_TO_RED
 
-   piSchool = 0
-   piLevel = 0
-   piHealth = 0
-   piHealthCap = 100
-   pbGiveHealth = FALSE
+   % By default we will give these boosts
+   piHealth = 150
+   piHealthCap = 150
+   pbGiveHealth = TRUE
+   pbGiveMana = TRUE
 
 messages:
 
-   Constructor(school=SS_FAREN, level = 0, health = 0, giveHealth = FALSE, healthCap = 100)
+   Constructor(health = 150, healthCap = 150, giveHealth = TRUE, giveMana = TRUE, giveSpells = TRUE)
    {
-      piSchool = school;
-      piLevel = level;
       piHealth = health;
       piHealthCap = healthCap;
       pbGiveHealth = giveHealth;
+      pbGiveMana = giveMana;
 
       propagate;
    }
 
-   AppendDesc()
-   {
-      local oSpellOrSkill;
-
-      AppendTempString(BetaPotion_Append_rsc);
-
-      if pbGiveHealth
-      {
-         AppendTempString(piHealth);
-      }
-      else
-      {
-         AppendTempString(0);
-      }
-      
-      AppendTempString(BetaPotion_Append2_rsc);
-      AppendTempString(piHealthCap);
-      AppendTempString(BetaPotion_Append3_rsc);
-      AppendTempString(piLevel);
-      AppendTempString(BetaPotion_Append4_rsc);
-      
-      if piSchool >= SKS_FENCING
-      {
-         % Any skill will do.
-         oSpellOrSkill = Send(SYS,@FindSkillByNum,#num=SKID_PUNCH); 
-      }
-      else
-      {
-         % Any spell will do.
-         oSpellOrSkill = Send(SYS,@FindSpellByNum,#num=SID_BONK); 
-      }
-      
-      AppendTempString(Send(oSpellOrSkill,@GetSchoolStr,#iSchool=piSchool));
-      AppendTempString(BetaPotion_Append5_rsc);
-      
-      return;
-   }
-
    ApplyPotionEffects(apply_on = $)
    {
-      local HealthBoost, iBaseMaxHealth;
-
-      if Send(Send(SYS,@GetLore),@BetaPotionsEnabled)
-         AND Send(Send(SYS,@GetParliament),@BetaPotionsEnabled)
+	  local iBaseMaxHealth, HealthBoost;
+	  
+      % Only apply potion effects if potions have been enabled. 
+      if Send(Send(SYS,@GetLore),@BetaPotionsEnabled) AND Send(Send(SYS,@GetParliament),@BetaPotionsEnabled)
+         OR Send(SYS, @GetChaosNight)
       {
-         iBaseMaxHealth = Send(apply_on,@GetBaseMaxHealth);
-         Send(apply_on,@MsgSendUser,#message_rsc=BetaPotion_worked);
-         if pbGiveHealth AND (iBaseMaxHealth < piHealthCap)
+		 % Give Mana
+		 if pbGiveMana
+         {
+            Send(&ManaNode,@Meld,#who=apply_on);
+		 }
+		 
+		 % Give Health
+		 iBaseMaxHealth = Send(apply_on,@GetBaseMaxHealth);
+		 
+		 if pbGiveHealth AND (iBaseMaxHealth < piHealthCap)
          {
             % How many hps?  Don't give them over potion max, and don't give
             %  them over stamina max.
             HealthBoost = bound(piHealth,0,(100+Send(apply_on,@GetStamina)));
             HealthBoost = bound(HealthBoost,0,(piHealthCap-iBaseMaxHealth));
             Send(apply_on,@GainBaseMaxHealth,#amount=HealthBoost);
-
-            % Don't use iBaseMaxHealth, because it changed.
-            if (Send(apply_on,@GetBaseMaxHealth) >= Send(Send(SYS, @GetSettings), @GetPKillEnableHP))
-               AND (NOT Send(apply_on,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE))
-            {
-               Send(apply_on,@PkillEnable);
-            }
-         }
-         
-         if piLevel <> 0
+		 }
+		 
+		 %  Don't use iBaseMaxHealth, because it changed.
+         if (Send(apply_on,@GetBaseMaxHealth) >= PKILL_ENABLE_HP)
+            AND (NOT Send(apply_on,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE))
          {
-            if piSchool >= SKS_FENCING
-            {
-               Send(apply_on,@GivePlayerAllSkills,#school=piSchool,#level=piLevel,
-                    #iAbility=piHealth,#upto=TRUE);
-            }
-            else
-            {
-               Send(apply_on,@GivePlayerAllSpells,#school=piSchool,#level=piLevel,
-                    #iAbility=piHealth,#upto=TRUE);
-            }
+             Send(apply_on,@PkillEnable);
          }
-      }
-      
-      return;
+			
+		 Send(apply_on,@MsgSendUser,#message_rsc=BetaPotion_worked);
+		 post(apply_on,@MsgSendUser,#message_rsc=BetaPotion_ask);
+		 send(apply_on,@DrankBetaPotion);
+	  }
+
+	  return;
    }
 
    %%% Old Potion stuff
@@ -187,7 +142,7 @@ messages:
       {
          Send(apply_on,@waveSenduser,#wave_rsc=BetaPotion_gulp_sound);
       }
-
+	  
       Send(apply_on,@MsgSendUser,#message_rsc=BetaPotion_drink);
       Send(self,@ApplyPotionEffects,#apply_on=apply_on);
 
@@ -210,7 +165,29 @@ messages:
    {
       return FALSE;
    }
+   
+   %%% Making the potion undroppable
+   
+   DropOnDeath()
+   {
+      return FALSE;
+   }
+   
+   ReqLeaveOwner()
+   {
+      return FALSE;
+   }
 
+   ReqNewOwner(what=$)
+   {
+      if NOT IsClass(what,&Battler)
+         AND NOT IsClass(what,&DM)
+      {
+         return FALSE;
+      }
 
+      propagate;
+   }
+  
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -6228,136 +6228,140 @@ messages:
       return;
    }
 
-   DistributeBetaPotions(giveHealth=TRUE, maxHP=150, HealthCap=150,
-                         giveSpells=TRUE, maxLevel=6,
-                         MaxPotionsPerPlayer=5, deadwood=0, allMax=FALSE)
-   {
-      local i, temp, lFinal, iCount, iPosition, iCutoff, iNumPotions,
-            iSchool, iLevel, iHP;
+%
+%   Obsolete - No longer used with Beta Potions 2.0 (Dec.25 2013)
+%
 
-      % We want to give players potions based on the amount of logged on
-      %  time they've logged.  So let's sort em.
-
-      lFinal = Send(self,@SortUsersByPlayTime);
-
-      if lFinal = $
-      {
-         % Something went bad with the sort.  Bail.
-         return;
-      }
-
-      % Okay, only the percent above deadwood get anything.  The rest
-      %  are probably mostly chaff.
-
-      iCount = 1;
-      iHP = maxHP / 8;
-      iSchool = 0;
-      iLevel = 0;
-      iNumPotions = 1;
-
-      for i in lFinal
-      {
-         iPosition = (iCount*100)/length(lFinal);
-
-         % iCutoff is the place where we switch segments.  There are five
-         %  different cutoff categories once you get past the deadwood.
-         % EX: Deadwood = 40, so iCutoff = 12. Segments: 100-88%, 87-76%, etc.
-         % NOTE: If you want less categories, then have deadwood be a negative
-         %  number.  Ex: deadwood = -25 means there will be 4 categories, since
-         %  (100 - (-25)) / 5 = 25% cutoff.
-         iCutoff = (100 - deadwood) / 5;
-
-         if allMax
-         {
-            % If we're all max, give out max potions, but only one.
-            iHP = maxHP;
-            iLevel = maxLevel;
-            iNumPotions = 1;
-         }
-         else
-         {
-            if iPosition > (100 - iCutoff)
-            {
-               iHP = maxHP;
-               iLevel = maxLevel;
-               iNumPotions = MaxPotionsPerPlayer;
-            }
-            else
-            {
-               if iPosition > (100 - (2 * iCutoff))
-               {
-                  iHP = (maxHP*4/5);
-                  iLevel = bound(maxLevel-1,1,$);
-                  iNumPotions = bound(MaxPotionsPerPlayer-1,1,$);
-               }
-               else
-               {
-                  if iPosition > (100 - (3 * iCutoff))
-                  {
-                     iHP = (maxHP*3/5);
-                     iLevel = bound(maxLevel-1,1,$);
-                     iNumPotions = bound(MaxPotionsPerPlayer-2,1,$);
-                  }
-                  else
-                  {
-                     if iPosition > (100 - (4 * iCutoff))
-                     {
-                        iHP = (maxHP*2/5);
-                        iLevel = bound(maxLevel-2,1,$);
-                        iNumPotions = bound(MaxPotionsPerPlayer-3,1,$);
-                     }
-                     else
-                     {
-                        if iPosition > deadwood
-                        {
-                           iHP = (maxHP*1/5);
-                           iLevel = bound(maxLevel-2,1,$);
-                           iNumPotions = bound(MaxPotionsPerPlayer-4,1,$);
-                        }
-                        else
-                        {
-                           % Deadwood!  No potion for you!
-                           iHP = 0;
-                        }
-                     }
-                  }
-               }
-            }
-
-            iCount = iCount + 1;
-         }
-
-         temp = [ SS_QOR,SS_RIIJA,SS_KRAANAN,SS_SHALILLE,SS_FAREN,SS_JALA,SKS_FENCING ];
-
-         if iHP = 0
-         {
-            Debug(Send(i,@GetTrueName),"Was deemed unworthy of boosting.");
-         }
-         else
-         {
-            if NOT giveSpells
-            {
-               iLevel = 0;
-            }
-
-            if NOT giveHealth
-            {
-               iHP = 0;
-            }
-
-            while iNumPotions > 0 AND temp <> $
-            {
-               iSchool = Nth(temp,random(1,length(temp)));
-               temp = DelListElem(temp,iSchool);
-               Send(i,@Newhold,#what=Create(&BetaPotion,#health=iHP,#school=iSchool,
-                    #level=iLevel,#giveHealth=giveHealth,#healthCap=healthCap));
-               iNumPotions = iNumPotions - 1;
-            }
-         }
-      }
-
-      return;
-   }
+%   DistributeBetaPotions(giveHealth=TRUE, maxHP=150, HealthCap=150,
+%                         giveSpells=TRUE, maxLevel=6,
+%                         MaxPotionsPerPlayer=5, deadwood=0, allMax=FALSE)
+%   {
+%      local i, temp, lFinal, iCount, iPosition, iCutoff, iNumPotions,
+%            iSchool, iLevel, iHP;
+%
+%      % We want to give players potions based on the amount of logged on
+%      %  time they've logged.  So let's sort em.
+%
+%      lFinal = Send(self,@SortUsersByPlayTime);
+%
+%      if lFinal = $
+%      {
+%         % Something went bad with the sort.  Bail.
+%         return;
+%      }
+%
+%      % Okay, only the percent above deadwood get anything.  The rest
+%      %  are probably mostly chaff.
+%
+%      iCount = 1;
+%      iHP = maxHP / 8;
+%      iSchool = 0;
+%      iLevel = 0;
+%      iNumPotions = 1;
+%
+%      for i in lFinal
+%      {
+%         iPosition = (iCount*100)/length(lFinal);
+%
+%         % iCutoff is the place where we switch segments.  There are five
+%         %  different cutoff categories once you get past the deadwood.
+%         % EX: Deadwood = 40, so iCutoff = 12. Segments: 100-88%, 87-76%, etc.
+%         % NOTE: If you want less categories, then have deadwood be a negative
+%         %  number.  Ex: deadwood = -25 means there will be 4 categories, since
+%         %  (100 - (-25)) / 5 = 25% cutoff.
+%         iCutoff = (100 - deadwood) / 5;
+%
+%         if allMax
+%         {
+%            % If we're all max, give out max potions, but only one.
+%            iHP = maxHP;
+%            iLevel = maxLevel;
+%            iNumPotions = 1;
+%         }
+%         else
+%         {
+%            if iPosition > (100 - iCutoff)
+%            {
+%               iHP = maxHP;
+%               iLevel = maxLevel;
+%               iNumPotions = MaxPotionsPerPlayer;
+%            }
+%            else
+%            {
+%               if iPosition > (100 - (2 * iCutoff))
+%               {
+%                  iHP = (maxHP*4/5);
+%                  iLevel = bound(maxLevel-1,1,$);
+%                  iNumPotions = bound(MaxPotionsPerPlayer-1,1,$);
+%               }
+%               else
+%               {
+%                  if iPosition > (100 - (3 * iCutoff))
+%                  {
+%                     iHP = (maxHP*3/5);
+%                     iLevel = bound(maxLevel-1,1,$);
+%                     iNumPotions = bound(MaxPotionsPerPlayer-2,1,$);
+%                  }
+%                  else
+%                  {
+%                     if iPosition > (100 - (4 * iCutoff))
+%                     {
+%                        iHP = (maxHP*2/5);
+%                        iLevel = bound(maxLevel-2,1,$);
+%                        iNumPotions = bound(MaxPotionsPerPlayer-3,1,$);
+%                     }
+%                     else
+%                     {
+%                        if iPosition > deadwood
+%                        {
+%                           iHP = (maxHP*1/5);
+%                           iLevel = bound(maxLevel-2,1,$);
+%                           iNumPotions = bound(MaxPotionsPerPlayer-4,1,$);
+%                        }
+%                        else
+%                        {
+%                           % Deadwood!  No potion for you!
+%                           iHP = 0;
+%                        }
+%                     }
+%                  }
+%               }
+%            }
+%
+%            iCount = iCount + 1;
+%         }
+%
+%         temp = [ SS_QOR,SS_RIIJA,SS_KRAANAN,SS_SHALILLE,SS_FAREN,SS_JALA,SKS_FENCING ];
+%
+%         if iHP = 0
+%         {
+%            Debug(Send(i,@GetTrueName),"Was deemed unworthy of boosting.");
+%         }
+%         else
+%         {
+%            if NOT giveSpells
+%            {
+%               iLevel = 0;
+%            }
+%
+%            if NOT giveHealth
+%            {
+%               iHP = 0;
+%            }
+%
+%            while iNumPotions > 0 AND temp <> $
+%            {
+%               iSchool = Nth(temp,random(1,length(temp)));
+%               temp = DelListElem(temp,iSchool);
+%               Send(i,@Newhold,#what=Create(&BetaPotion,#health=iHP,#school=iSchool,
+%                    #level=iLevel,#giveHealth=giveHealth,#healthCap=healthCap));
+%               iNumPotions = iNumPotions - 1;
+%            }
+%         }
+%      }
+%
+%      return;
+%   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
Beta potions only work during a frenzy or if the server is in beta mode.

To enable the server in beta mode:
- send o 0 FlipOnBeta
- Must also change the flag pbHiddenSwitch in Parliament class to enable beta mode fully. (Not sure why it was done like this, just matching the existing code).

Features:
- Allow players to select schools of their choice. Based on the
  Intellect.
- Player will receive robes and reagents based on their selections.
- HP boost given based on stamina.
- Give maximum Mana boost based on Mana nodes found throughout the land.
- Several flags have been added to customize potions.
- String search has been adjusted for the lazy; so saying "qor6" will give you its spells. Don't have to say the exact phrase "qor level six".

Misc:
- DistributeBetaPotions message has been removed. Use the command send o 0 GlobalGive classtype class BetaPotion as a replacement.
- These changes have been heavily tested on a live server.
