### PR TITLE
SSF fix #1: Thrust Resistance lowered for weaker Skeletons

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/skel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/skel.kod
@@ -73,7 +73,7 @@ messages:
    SetResistances()
    {
       plResistances = [ [ 70, ATCK_WEAP_PIERCE ],
-                        [ 70, ATCK_WEAP_THRUST ],
+                        [ 20, ATCK_WEAP_THRUST ],
                         [ 70, -ATCK_SPELL_UNHOLY ],
                         [ 70, -ATCK_SPELL_SHOCK ],
                         [ 70, -ATCK_SPELL_COLD ],

--- a/kod/object/active/holder/nomoveon/battler/monster/skel/batrskel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/skel/batrskel.kod
@@ -66,6 +66,20 @@ properties:
    
 messages:
 
+   SetResistances()
+   {
+      plResistances = [ [ 70, ATCK_WEAP_PIERCE ],
+                        [ 70, -ATCK_SPELL_UNHOLY ],
+                        [ 70, -ATCK_SPELL_SHOCK ],
+                        [ 70, -ATCK_SPELL_COLD ],
+                        [ -10, -ATCK_SPELL_FIRE ],
+                        [ -20, -ATCK_SPELL_HOLY ],
+                        [ -20, ATCK_WEAP_BLUDGEON ]
+                      ];
+
+      return;
+   }
+
    HitSideEffect(what = $)
    {
       local oSpell;

--- a/kod/object/active/holder/nomoveon/battler/monster/skel/tuskskel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/skel/tuskskel.kod
@@ -62,6 +62,21 @@ properties:
    
 messages:
 
+   SetResistances()
+   {
+      plResistances = [ [ 70, ATCK_WEAP_PIERCE ],
+                        [ 40, ATCK_WEAP_THRUST ],
+                        [ 70, -ATCK_SPELL_UNHOLY ],
+                        [ 70, -ATCK_SPELL_SHOCK ],
+                        [ 70, -ATCK_SPELL_COLD ],
+                        [ -10, -ATCK_SPELL_FIRE ],
+                        [ -20, -ATCK_SPELL_HOLY ],
+                        [ -20, ATCK_WEAP_BLUDGEON ]
+                      ];
+
+      return;
+   }
+
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
As a first step toward making Short Sword Fighting less painful for the
HP range in which players usually need to work it, thrust resistance has
been reduced to zero for battered skeletons, 20 for skeletons, and 40
for tusked skeletons.

These numbers are intended to be augmented by all skeletons' 20%
weakness to holy, so that holy enchanted short swords can reach
effective levels against these mid level monsters. However, they're
still much more satisfying than before, even without holy enchants.
Better yet, mystic swords (the higher level thrust weapon) can't
be given holy damage normally, so the change is overall highly focused.

It may be necessary to create an easy way to get holy short swords.
If players end up making mules for that task instead of buying enchants
from players or taking the level 2 spell themselves, we might have to add
something.

I'm hoping this is enough to ease the pain of SSFSS (Short Sword Fighting Suffering Syndrome).
Players above the relevant HPs here can work SSF on avars, so really the problem
has always been confined to the disruption in the flow of building.
