### PR TITLE
Touch Spell Repair & Balancing

### DIFF
--- a/kod/object/item/passitem/attmod/frozjewl.kod
+++ b/kod/object/item/passitem/attmod/frozjewl.kod
@@ -38,8 +38,8 @@ classvars:
    viUse_type = ITEM_USE_HAND
    viUse_amount = 1
 
-   viHits_init_min = 150
-   viHits_init_max = 250
+   viHits_init_min = 350
+   viHits_init_max = 550
 
    viValue_average = 400
    viBulk = 10
@@ -71,7 +71,9 @@ messages:
       {
          Send(self,@DoFlash);
       
-         return hit_roll + 150;
+         % Adjust bonus by how strong the wielder is relative to their maximum potential.
+         % Throwaway characters will get very little benefit.
+         return hit_roll + (150 * (Send(who,@GetBaseMaxHealth)/(Send(who,@GetStamina)+100)));
       }
       
       return hit_roll + 50;
@@ -96,7 +98,9 @@ messages:
          if Send(who,@LoseMana,#amount=iMana) <> 0
          {
             % Add big damage if we spent the mana.
-            return damage + Random(3,5);
+            % Adjust it by how strong the wielder is relative to their maximum potential.
+            % Throwaway characters will get very little benefit.
+            return damage + (Random(3,5) * (Send(who,@GetBaseMaxHealth)/(Send(who,@GetStamina)+100)));
          }
 
          % Add a small amount of damage.

--- a/kod/object/passive/spell/persench/touchatk.kod
+++ b/kod/object/passive/spell/persench/touchatk.kod
@@ -66,14 +66,14 @@ classvars:
 
    viChance_To_Increase = 10
 
-   % typically, spells have hit probs that are high, provided you're good at
-   %  the skill.
-   viHit_Factor = 80
-
    % Touch spells typically do good damage but are unaffected by typical weapon
-   %  bonuses.
-   viMin_Damage = 3
-   viMax_Damage = 6
+   %  bonuses. These base damages will have proficiency added to them,
+   %  and will then be increased by up to 40% depending on the caster's Mysticism.
+   viMin_Damage = 4
+   viMax_Damage = 8
+   
+   % Max amount of damage that Punch or 2*Myst can add
+   viMaxProficiencyDamage = 5
 
    % Touch spell range can vary, but are typically good     
    viRange = 2
@@ -145,7 +145,15 @@ messages:
    "Attack spells typically are unaffected by strength, although they may "
    "be affected by other factors."
    {
-      return damage;
+      local iDamage, iMysticism;
+
+      iDamage = damage + (Send(self,@GetProf,#who=who)+1)*viMaxProficiencyDamage/100;
+      
+      % Get myst damage bonus.
+      iMysticism = Send(who,@GetMysticism);
+      iDamage = ((100+bound(iMysticism-25,0,40))*iDamage)/100;
+
+      return iDamage;
    }
 
    GetHitsound()
@@ -160,8 +168,7 @@ messages:
    % What's the stroke number?
    % Touch attacks are "backwards", they use Punch as the proficiency, or the
    %  secondary bonus to hit.  Added bonus for "pure" mages, can substitute
-   %  1.5 * Mysticism instead of punch.  This allows for a more focused
-   %  character, but you can reach higher levels if you learn punch.
+   %  2 * Mysticism instead of punch. 
    GetProf(who=$)
    {
       local iProf, iMysticism;
@@ -169,14 +176,14 @@ messages:
       iProf = Send(who,@GetSkillAbility,#skill_num=SKID_PUNCH);
       Send(who,@FlipSkillAtrophyFlag,#SKID=SKID_PUNCH);
       
-      iMysticism = (Send(who,@GetMysticism)*3)/2;
+      iMysticism = (Send(who,@GetMysticism)*2);
       
       if iProf < iMysticism
       {
          iProf = iMysticism;
       }
 
-      return iProf;
+      return bound(iProf,1,99);
    }
 
    GetStroke(who=$)
@@ -251,12 +258,17 @@ messages:
       % base weapon damage
       damage = random(viMin_Damage,viMax_damage);
 
-      iPower = Send(who,@GetEnchantedState,#what=self);
+      % Rather than an active spellpower check, use the player's
+      % ability in the spell. This makes touch spells function
+      % more like a stroke, and gives them immunity to anti-magic effects.
+      iPower = Send(who,@GetSpellAbility,#spell_num=viSpell_num);
       
-      % factor in the person's ability with the spell      
-      damage = damage/2 + ((damage/2)*iPower)/SPELLPOWER_MAXIMUM + 1;
+      % Factor in the person's ability with the spell
+      % It's alright if damage here is extremely low.
+      % Most players will get proficiency damage from punch or 2*Mysticism.
+      damage = damage * ((iPower+1)/(SPELLPOWER_MAXIMUM+1));
       
-      % might affects damage from different weapons differently
+      % myst affects damage
       damage = Send(self,@DamageFactors,#damage=damage,#who=who,
                     #victim=victim);
       
@@ -391,12 +403,11 @@ messages:
    {
       local iDuration;
 
-      iDuration = Random(iSpellpower/3,iSpellpower/2);
-      % 1 to 7.5 minutes
-      iDuration =  bound(iDuration,10,75);
-      iDuration = iDuration * 6 * 1000;  
+      % Up to 16.5 minutes
+      iDuration = iSpellPower * 10 * 1000; 
 
-      return iDuration;
+      % Min 2 minutes
+      return Bound(iDuration,120000,$);
    }  
 
    GetStateValue(iSpellpower=$)
@@ -404,6 +415,11 @@ messages:
       Return iSpellpower;
    }
 
+   SuccessChance(who=$)
+   "Allow mages to switch elements despite antagonistic conditions."
+   {
+      return TRUE;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/persench/touchatk/acidtch.kod
+++ b/kod/object/passive/spell/persench/touchatk/acidtch.kod
@@ -63,12 +63,12 @@ classvars:
    viSpell_level = 2
    viMana = 10
 
-   viHit_Factor = 10       %% typically, spells have hit probs
-                           %% that are high, provided you're good at the skill
-
-
    viMin_Damage = 4        %% touch spells typically do good damage    
    viMax_Damage = 8       %% but are unaffected by weapon or strength bonuses
+
+   % Max amount of damage that punch or 2*myst can add
+   % Acid touch is slightly weaker than Faren touch spells
+   viMaxProficiencyDamage = 3
 
    viRange = 2             %% touch spell range can vary, but are typically good     
 

--- a/kod/object/passive/spell/persench/touchatk/flametch.kod
+++ b/kod/object/passive/spell/persench/touchatk/flametch.kod
@@ -69,10 +69,11 @@ classvars:
    viSpellExertion = 2
    viMana = 9
 
-   viHit_Factor = 25
-
    viMin_Damage = 4
    viMax_Damage = 9
+
+   % Max amount of damage that punch or 2*myst can add
+   viMaxProficiencyDamage = 4
 
    viRange = 2
 

--- a/kod/object/passive/spell/persench/touchatk/holytch.kod
+++ b/kod/object/passive/spell/persench/touchatk/holytch.kod
@@ -68,10 +68,10 @@ classvars:
    viSpell_level = 2
    viMana = 12
 
-   viHit_Factor = 15
-
-   viMin_Damage = 3
-   viMax_Damage = 6
+   % It's alright if Holy Touch has high base damage.
+   % It gets no intrinsic proficiency damage, instead doing double base against undead.
+   viMin_Damage = 6
+   viMax_Damage = 10
 
    viRange = 2
 
@@ -100,7 +100,8 @@ messages:
    }
 
    DamageFactors(damage=0, who=$, victim=$)
-   "Damage for attack spells is determined largely by expertise in the spell."
+   "Holy Touch gets no punch or mysticism proficiency damage. Instead, "
+   "it is intrinsically effective versus undead."
    {
       local iDamage, iKarma;
 

--- a/kod/object/passive/spell/persench/touchatk/icyfing.kod
+++ b/kod/object/passive/spell/persench/touchatk/icyfing.kod
@@ -64,12 +64,11 @@ classvars:
    viSpell_level = 2
    viMana = 6
 
-   viHit_Factor = 60        %% typically, spells have hit probs
-                            %% that are high, provided you're good at the skill
-
-
    viMin_Damage = 5         %% touch spells typically do good damage    
    viMax_Damage = 8         %% but are unaffected by weapon or strength bonuses
+
+   % Max amount of damage that punch or 2*myst can add
+   viMaxProficiencyDamage = 7
 
    viRange = 2              %% touch spell range can vary, but are typically good     
 

--- a/kod/object/passive/spell/persench/touchatk/zap.kod
+++ b/kod/object/passive/spell/persench/touchatk/zap.kod
@@ -61,14 +61,13 @@ classvars:
    viSpell_level = 1
    viMana = 6
 
-   viHit_Factor = 50        %% typically, spells have hit probs
-                            %% that are high, provided you're good at the skill
-
-
-   viMin_Damage = 3         %% touch spells typically do good damage    
+   viMin_Damage = 5         %% touch spells typically do good damage    
    viMax_Damage = 8         %% but are unaffected by weapon or strength bonuses
 
-   viRange = 3              %% touch spell range can vary, but are typically good     
+   % Max amount of damage that punch or 2*myst can add
+   viMaxProficiencyDamage = 6
+
+   viRange = 2              %% touch spell range can vary, but are typically good     
 
    viSpellType = ATCK_SPELL_SHOCK + ATCK_SPELL_ALL
    viStroke = STROKE_ZAP


### PR DESCRIPTION
Touch spells now do the kind of damage we all remember. The issue was
that touch spells had backwards stroke and proficiency code, so they
were left behind by damage changes. Here's the rundown on how things
work now (note that much of this stuff is the same as before):

Touch spells use 2*Mysticism or Punch for their proficiency, which will
add base damage. Pure mages will find that their touch spells are strong
right from the get-go. Fighters and hybrid characters will have to max
Punch to get the full proficiency damage.

Touch spells also have a larger random damage component
that is dependent on your % in the spell (not spellpower).

Holy Touch does not receive proficiency bonus damage, but instead does
double damage to undead.

I've changed it so that touch spells cannot fizzle, and so that their
spellpower is irrelevant to your damage or to-hit. Instead, the touch spell
will use your % in the spell. This will allow mages to switch elements
at will regardless of gear or AMA, and allow them to use their touch
spells to full effect regardless of prevailing conditions. This should make
touch spells more reliable (i.e. more like the weapon strokes that they
emulate).

Jewels of Froz now have drastically more durability, but scale their
bonuses based on the wielder's HP versus his maximum potential. (For
example, if your Stamina is 25, it's your current HP / 125). Mule PKs
will get almost no benefit.

Finally, touch spells can have a much longer duration now,
dependent upon spellpower. (Up to 16 minutes)

**Bottom Line**

Touch spells are highly dependent on many factors that will scale
as players build. They will start out doing 3-8 damage, useful for
building on low-level monsters. As the player improves,
he can begin to do more damage, up to the 6-15 range.

Once a player has enough HP to use JoFs effectively, he can hit
the 12-20 range with 2 jofs. After that, victim resists and offensive
buffs can get that damage up to match even the best fighter's melee hit.

Of course, mages using two Jewels won't have Block or Parry...

The resulting balance remains to be seen.

As an interesting note, Holy Touch + 2 JoFs + Killing Fields and buffs
absolutely wrecks high level undead like Daemon Skeletons. The
experience made playing a mage actually seem viable.
