### PR TITLE
Defense Skill Improvement Fix

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -7837,21 +7837,17 @@ messages:
          if oWeapon <> $
             AND (not IsClass(oWeapon,&RangedWeapon))
             AND Send(self,@HasSkill,#num=SKID_PARRY)
+            AND Send(self,@GetSkillAbility,#skill_num=SKID_PARRY) < 99
          {
-            if random(1,100) < 30
-            {
-               dodgeskill=SKID_PARRY;
-            }
+            dodgeskill=SKID_PARRY;
          }
          
          if dodgeskill = SKID_DODGE
             AND (Send(self,@LookupPlayerShield) <> $)
             AND Send(self,@HasSkill,#num=SKID_BLOCK)
+            AND Send(self,@GetSkillAbility,#skill_num=SKID_BLOCK) < 99
          {
-            if random(1,100) < 30
-            {
-               dodgeskill=SKID_BLOCK;
-            }
+            dodgeskill=SKID_BLOCK;
          }
          
          oSkill=Send(sys,@FindSkillByNum,#num=dodgeskill);


### PR DESCRIPTION
Defense skills had random improvement architecture that made it
extremely difficult to improve defensive skills because dodge was
soaking up advancement even if it was 99.

Parry now has priority over Block, and both have priority over Dodge. If
a player wants to improve Dodge, they can remove their shield and
weapon.

This should make it significantly easier to max Parry, which was only
receiving improve checks 3 out of every 10 kills. Yes, you read right:
7 of every 10 kills didn't help advance Parry at all. That's why it takes
so long to improve.
