### PR TITLE
Vault Upgrade

### DIFF
--- a/kod/object/passive/storage.kod
+++ b/kod/object/passive/storage.kod
@@ -13,6 +13,8 @@ Storage is PassiveObject
 constants:
 
    include blakston.khd
+   
+   VAULT_ITEMS_MAX = 600
 
 resources:
    msg_not_enough_items_on_deposit = "%s%s does not have that many on deposit."
@@ -83,19 +85,19 @@ messages:
 
    CanDepositItems(lItems = $, who = $)
    {
-      local iBulk, i;
-      iBulk = 0;
+      local plItemsStored;
 
       if who = $     { debug("CanDepositItems passed with who=$!"); return FALSE; }
       if lItems = $  { debug("Cannot deposit a null set!"); return FALSE; }
-
-      iBulk = send(self,@GetCurrentBulkStored,#who=who);
-      for i in lItems
-      {	 
-	 iBulk = iBulk + send(i,@GetBulk);
+      
+      plItemsStored = Send(self,@GetItemsStored,#who=who);
+      if plItemsStored <> $
+         AND (Length(plItemsStored) + Length(lItems)) > VAULT_ITEMS_MAX
+         AND NOT (Length(lItems) = 1
+                  AND IsClass(First(lItems),&NumberItem))
+      {
+         return FALSE;
       }
-      if iBulk > piCapacity
-      { return FALSE; }
 
       return TRUE;
    }


### PR DESCRIPTION
- Vaults now have a maximum limit of 600 items.
- Vaults no longer have a weight or bulk limit.
- You can always store a single stack of items, so that Conveyance
  always works.

This will allow players to store unlimited amounts of reagents, and a
large amount of singular items, without making the vault list too long
and causing crashes.

This is one issue where players have us completely outmatched.
If we do not give them unlimited vault space, then, any time they
run out of space, they will simply create a free mule account to
increase their vault space. We can't stop them, and we can't
limit them.

To do away with the issue entirely, this pull will simply make
vaults effectively limitless (while still avoiding overload crashes).
I know that unlimited vault space is a scary concept design-wise,
but it's actually just codifying a mule abuse ability players
already have and already employ daily. This way we'll avoid
having a bloated number of extra mule accounts.
