### PR TITLE
Faster item disposal

### DIFF
--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -208,7 +208,7 @@ properties:
    prBackground = $
 
    % Default length: five minutes (in ms)
-   piDispose_delay = 60000
+   piDispose_delay = 180000
    ptDispose = $
 
    % Exits list: each member is a list of row in this room, col in this room


### PR DESCRIPTION
Dispose behavior is already asymptotic (the oldest 20% of the items in
the room are cleared). It doesn't need to be 5 minutes in between each
cleanup. Players have always had issues with rooms filling up with loot;
this should help. I've set it to 1 minute instead of 5.
