### PR TITLE
Group Combat System

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -22,7 +22,7 @@ constants:
    BOND_REPORT_INTERVAL = 1000 * 60 * 3
    
    % One minute
-   DEATH_RIFT_INTERVAL = 1000 * 60  
+   DEATH_RIFT_INTERVAL = 1000 * 60
 
    KARMA_TUNE_A_INVERSE = 20
    KARMA_TUNE_B_INVERSE = 5
@@ -712,6 +712,8 @@ resources:
    player_logged_off_wav_rsc = player_logout2.wav
    
    death_rift_stayed_too_long = "Having lingered too long while still alive, you find yourself ejected back into reality!"
+   
+   group_experience_rsc = "You absorb a small amount of the energy released from %s's slaying of the %s."
 
 classvars:
 
@@ -975,6 +977,9 @@ properties:
    % Is the player currently using a Death Rift spell?
    pbDeath_rift = FALSE
    ptDeathRiftTimer = $
+   
+   % Players will naturally fall out of groups if they aren't getting kills
+   ptLeaveBuilderGroupTimer = $
 
 messages:
 
@@ -5034,6 +5039,8 @@ messages:
          Send(self,@AddKarma,#amount=Send(self,@CalculateKarmaChangeFromKill,
               #karma_victim=Send(what,@GetKarma),#karma_killer=Send(self,@GetKarma)),
               #bIsMob=TRUE);
+         
+         Send(self,@JoinBuilderGroup);
       }
 
       Send(what,@Killed,#what=self,#stroke_obj=stroke_obj);
@@ -5565,7 +5572,7 @@ messages:
             break;
          }
       }
-      
+
       propagate;
    }
 
@@ -7676,7 +7683,12 @@ messages:
 
    SomethingKilled(what=$,victim=$,use_weapon=$)
    {
-      if victim = poKill_target AND IsClass(victim,&Battler)
+      if NOT IsClass(victim,&Battler)
+      {
+         propagate;
+      }
+
+      if victim = poKill_target
       {
          if what = self
          {
@@ -7689,6 +7701,15 @@ messages:
          
          poKill_target=$;
          Send(self,@ResetGainFlags);
+      }
+      else
+      {
+         % Let players share XP if they're grouped, even if they're not fighting the same mob.
+         if Send(Send(self,@GetOwner),@AreGroupedHere,#who=self,#what=what)
+         {
+            Send(self,@MsgSendUser,#message_rsc=group_experience_rsc,#parm1=Send(what,@GetName),#parm2=Send(victim,@GetName));
+            Send(self,@AdvancementCheck,#what=victim,#killing_blow=FALSE,#group_member_kill=TRUE);
+         }
       }
       
       propagate;
@@ -7705,7 +7726,7 @@ messages:
    }
 
 
-   AdvancementCheck(what=$,killing_blow=TRUE)
+   AdvancementCheck(what=$,killing_blow=TRUE,group_member_kill=FALSE)
    "A player will need, on average, to kill a number of monsters equal to"
    "their maxhealth to gain a HP.  This number is reduced by the player's"
    "stamina, all the way down to half for those with high staminas."
@@ -7724,6 +7745,8 @@ messages:
          return FALSE;  
       }
 
+	  Post(self,@DrawHPChance);
+
       if IsClass(what,&User)
       {
          monster_level = Send(what,@GetBaseMaxHealth);
@@ -7733,8 +7756,9 @@ messages:
          monster_level = Send(what,@GetLevel);
       }
 
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_DID_DAMAGE)
-         AND poKill_target = what
+      if (Send(self,@CheckPlayerFlag,#flag=PFLAG_DID_DAMAGE)
+         AND poKill_target = what)
+         OR group_member_kill
       {
          if monster_level > piBase_Max_health
          {
@@ -7747,7 +7771,8 @@ messages:
             else
             {
                % Player either did not take damage, but did killing blow (mage),
-               %  or did take damage, did not land killing blow.
+               %  or did take damage, did not land killing blow, or
+               %  it's a group member kill.
                gain = 1;
                roll = TRUE;
             }
@@ -7831,6 +7856,7 @@ messages:
       }
       
       if Send(self,@CheckPlayerFlag,#flag=PFLAG_DODGED)
+         AND NOT group_member_kill
       {
          dodgeskill = SKID_DODGE;
          oWeapon = Send(self,@LookupPlayerWeapon);
@@ -12644,6 +12670,78 @@ messages:
          }
       }
       
+      return;
+   }
+   
+   LeaveBuilderGroupTimer()
+   {
+      ptLeaveBuilderGroupTimer = $;
+      
+      Send(self,@LeaveBuilderGroup);
+      return;
+   }
+   
+   LeaveBuilderGroup()
+   {
+      local oRoom, i, each_obj;
+      oRoom = Send(self,@GetOwner);
+      
+      if ptLeaveBuilderGroupTimer <> $
+      {
+         DeleteTimer(ptLeaveBuilderGroupTimer);
+         ptLeaveBuilderGroupTimer = $;
+      }
+      
+      if oRoom <> $
+      {
+         Send(oRoom,@RemoveFromBuilderGroup,#who=self);
+         Send(oRoom,@SomethingChanged,#what=self);
+
+         % Let's see that we left the group
+         for i in Send(oRoom,@GetPlActive)
+         {
+            each_obj = Send(oRoom,@HolderExtractObject,#data=i);
+            if IsClass(each_obj,&User)
+               AND Send(oRoom,@AreGroupedHere,#who=self,#what=each_obj)
+            {
+               Send(self,@SomethingChanged,#what=each_obj);
+            }
+         }
+      }
+      
+      return;
+   }
+   
+   JoinBuilderGroup()
+   {
+      local oRoom, i, each_obj;
+      oRoom = Send(self,@GetOwner);
+      
+      % Refresh an active group membership
+      if ptLeaveBuilderGroupTimer <> $
+      {
+         DeleteTimer(ptLeaveBuilderGroupTimer);
+         ptLeaveBuilderGroupTimer = CreateTimer(self,@LeaveBuilderGroupTimer,Send(Send(self,@GetOwner),@GetGroupTime));
+         return;
+      }
+
+      if oRoom <> $
+      {
+         Send(oRoom,@AddToBuilderGroup,#who=self);
+         Send(oRoom,@SomethingChanged,#what=self);
+         ptLeaveBuilderGroupTimer = CreateTimer(self,@LeaveBuilderGroupTimer,Send(Send(self,@GetOwner),@GetGroupTime));
+
+         % Let's see our new group
+         for i in Send(oRoom,@GetPlActive)
+         {
+            each_obj = Send(oRoom,@HolderExtractObject,#data=i);
+            if IsClass(each_obj,&User)
+               AND Send(oRoom,@AreGroupedHere,#who=self,#what=each_obj)
+            {
+               Send(self,@SomethingChanged,#what=each_obj);
+            }
+         }
+      }
       return;
    }
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2175,7 +2175,7 @@ messages:
    "show_type is used to get the look or inventory animation and overlays "
    "instead of the normal animation and overlays."
    {
-      local iFlags, iEnemyKarma, iSelfKarma, oIllusion, oOtherGuild;
+      local iFlags, iEnemyKarma, iSelfKarma, oIllusion, oOtherGuild, oRoom;
 
       % Send given object's id number, name, icon, and animation info
 
@@ -2264,6 +2264,15 @@ messages:
                   }
                }
             }
+         }
+      }
+      
+      oRoom = Send(self,@GetOwner);
+      if oRoom <> $
+      {
+         if Send(Send(self,@GetOwner),@AreGroupedHere,#who=self,#what=what)
+         {
+            iFlags = (iFlags | PLAYER_IS_FRIEND);
          }
       }
 

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -265,6 +265,13 @@ properties:
    % Don't set this.  It is set automatically.
    % Instead, override something in SetFarenBonus.
    piFaren_Bonus
+   
+   % The amount of time a player has before being booted from a group
+   % provided they don't get a monster kill
+   piGroupTime = 60000
+   
+   % A list of players building together
+   plBuilderGroup = $
 
 messages:
 
@@ -387,6 +394,7 @@ messages:
       plExits = $;
       plEdge_exits = $;
       plYell_zone = $;
+      plBuilderGroup = $;
       Send(self,@CreateStandardExits);
       Send(self,@CreateYellZoneList);
 
@@ -1957,6 +1965,8 @@ messages:
       {
          propagate;
       }
+
+      Send(what,@LeaveBuilderGroup);
 
       % unenchant this one occupant
       for i in plEnchantments
@@ -4017,6 +4027,66 @@ messages:
          }
       }
       return;
+   }
+   
+   AddToBuilderGroup(who=$)
+   {
+      if who = $
+         OR NOT IsClass(who,&User)
+         OR Send(who,@GetOwner) <> self
+      {
+         return;
+      }
+      
+      If plBuilderGroup = $
+         OR FindListElem(plBuilderGroup, who) = 0
+      {
+         plBuilderGroup = Cons(who,plBuilderGroup);
+      }
+      
+      return;
+   }
+   
+   RemoveFromBuilderGroup(who=$)
+   {
+      if plBuilderGroup = $
+         OR who = $
+      {
+         return;
+      }
+      
+      if FindListElem(plBuilderGroup,who) <> 0
+      {
+         plBuilderGroup = DelListElem(plBuilderGroup,who);
+      }
+      
+      return;
+   }
+   
+   GetBuilderGroup()
+   {
+      return plBuilderGroup;
+   }
+   
+   AreGroupedHere(who=$,what=$)
+   {
+      if who <> $
+         AND what <> $
+         AND IsClass(who,&User)
+         AND IsClass(what,&User)
+         AND plBuilderGroup <> $
+         AND FindListElem(plBuilderGroup,who) <> 0
+         AND FindListElem(plBuilderGroup,what) <> 0
+      {
+         return TRUE;
+      }
+
+      return FALSE;
+   }
+   
+   GetGroupTime()
+   {
+      return piGroupTime;
    }
 
 end


### PR DESCRIPTION
Players in the same room will join a building group automatically upon
killing a monster. Thereafter, every kill by a group member will share
experience with other group members, exactly as if the players were
fighting the same mobs.

Players must get a kill within a room's GroupTime to remain in the
group. Otherwise, they will leave the group until they make another kill.

Players that leave a room also leave the group.

Group members are denoted by green halos. Guilded group members will
have both yellow and green rings.

Enemies that join your group will remain red halo to avoid confusion
(and what are you doing building next to enemies anyway?)

Also included in this system is a DrawHPChance call for every
AdvancementCheck, fixing an oversight caused in the GainChance bar
that wasn't updating when someone else killed a mob and generated XP.
