### PR TITLE
Ammo fix

### DIFF
--- a/kod/object/item/passitem/weapon.kod
+++ b/kod/object/item/passitem/weapon.kod
@@ -308,7 +308,7 @@ messages:
       local iDamage, i, oWeapAtt;
 
       % First, get base damage.
-      iDamage = send(self,@GetBaseDamage);
+      iDamage = send(self,@GetBaseDamage,#who=poOwner,#target=target);
 
       % Then check weapon attributes
       %  Weapon Attributes in general should only + or - damage - no multipliers!


### PR DESCRIPTION
Nerudite Arrows haven't been shattering because BaseDamage wasn't
passing who and target. Silver Arrows also weren't doing double damage
to undead.
