### PR TITLE
Shrine allegiance bug fix

### DIFF
--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -2762,9 +2762,13 @@ messages:
          power_count = 1;
          for n in plShrines
          {
-            Send(n,@SetAllegiance,#allegiance=Nth(plShrine_Allegiances,power_count));
-            power_count = power_count + 1;
+            if Nth(plShrine_Allegiances,power_count) <> 0
+            {
+               Send(n,@SetAllegiance,#allegiance=Nth(plShrine_Allegiances,power_count));
+               power_count = power_count + 1;
+            }
          }
+         plShrine_Allegiances = $;
       }
 
       for i in plShrines


### PR DESCRIPTION
Never sets shrines to no allegiance.

Eliminates saved shrine allegiances after first recompute.
