### PR TITLE
Fixes for clientconfig (debug/timeout)

### DIFF
--- a/clientd3d/config.c
+++ b/clientd3d/config.c
@@ -117,7 +117,7 @@ static char INIQuickStart[]   = "QuickStart";
 
 static int   DefaultRedialDelay   = 60;
 static char  DefaultHostname[]    = "cheater";
-static char  DefaultDomainFormat[] = "meridian%d.meridian59.com"; // MUST have a %d in it somewhere.
+static char  DefaultDomainFormat[] = "meridian%d.daenks.org"; // MUST have a %d in it somewhere.
 static char  DefaultSockPortFormat[] = "59%.2d";
 static int   DefaultServerNum     = -1;
 static int   DefaultTimeout       = 1440; // 1 day in minutes (60*24)


### PR DESCRIPTION
This patch fixes the following issues with the client configuration (meridian.ini)

1) It was impossible to get the debug console to show up even on debug-builds, because it was disabled fully in code. The client writes its debug text to this console-window, which usually should show up if you set "Debug=1" in the [Special] section of your meridian.ini. This debug-window is supposed to work unless the binary was built with FINAL=1,  which is the supposed flag for distributing it afterwards. (Instead of RELEASE=1 or DEBUG=1)

2) This patch sets the default logoff timeout from 20 minutes to 1440 minutes (1 day). Please note that there is already a configvalue for this in meridian.ini, it's "Timeout=20" in section [Miscellaneous]. So this will not automatically change for users, they have to change their config value. Also the code was modified to read this timeout value also for builds created with FINAL=1, which otherwise would ignore it.

PS: I have not increased client buildnumber with this pullrequest, because there's already one pending for the client which does, the blind-change: https://github.com/Daenks/Meridian59_103/pull/184
