### PR TITLE
Soldier Spawn Time improved

### DIFF
--- a/kod/util/factgame/territry.kod
+++ b/kod/util/factgame/territry.kod
@@ -62,7 +62,7 @@ properties:
 
    piClaimTroopGenTime = 8000
    piClaimTroopCap = 15
-   piNonclaimTroopGenTime = 300000
+   piNonclaimTroopGenTime = 30000
    piNonclaimTroopCap = 4
 
    % Number of minutes to wait before a flag claim is done.


### PR DESCRIPTION
Down to 30 seconds from 5 minutes. Players have been clamoring for more
soldiers to kill for quests and shield status.

This affect non-claimed spawn times.
