### PR TITLE
Increase imp rate of Conveyance.

### DIFF
--- a/kod/object/passive/spell/utility/conveyance.kod
+++ b/kod/object/passive/spell/utility/conveyance.kod
@@ -41,7 +41,7 @@ classvars:
    viSchool = SS_KRAANAN
    viMana = 0
    viSpellExertion = 0
-   viChance_To_Increase = 5
+   viChance_To_Increase = 15
 
 properties:
 


### PR DESCRIPTION
Increases the chance to improve conveyance 3x, which is only 50% higher
than elusion. 5 was extremely low and spellpower has no impact on
conveyance at all.

This really is only for the OCD people who like to get 99% in every spell/skill.
