### PR TITLE
Characters will now be listed before free character slots!

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4720,7 +4720,7 @@ messages:
               report = True, report_resistance = TRUE, absolute = FALSE)
    {
       local i, iResistance, oSoldierShield, gainchance, color_rsc, iDuration, oSpell, oGort,
-            iLimit, origdamage, oWeapon;
+            iLimit, origdamage, oWeapon, shrunken;
 			
 	  origdamage = damage;
 	  
@@ -4876,13 +4876,20 @@ messages:
               #color_rsc=color_rsc);
       }
       
+	  % report to shrunken head
+	  shrunken = Send(self,@FindHolding,#class=&ShrunkenHead);
+	  if damage > 0 AND shrunken <> $
+	  {
+		Send(shrunken,@DamageTaken,#what=what,#amount=damage);
+	  }		  
+	  
       return damage;
    }
 
    % This function handles when is damage done to opponent.
    DidDamage(what = $, amount = 0)
    {
-      local oWeapon, i;
+      local oWeapon, i, shrunken;
 
       oWeapon = Send(self,@GetWeapon);
       
@@ -4911,6 +4918,19 @@ messages:
       {
          Send(self,@SetPlayerFlag,#flag=PFLAG_DID_DAMAGE,#value=TRUE);
       }
+	  
+	  % report to shrunken head
+	  if amount > 0
+      {
+        Send(self,@SetPlayerFlag,#flag=PFLAG_DID_DAMAGE,#value=TRUE);
+		 
+		shrunken = Send(self,@FindHolding,#class=&ShrunkenHead);
+		if shrunken <> $
+		{
+			Send(shrunken,@DamageDealt,#what=what,#amount=amount);
+		}		
+ 
+      }	  
 
       return;
    }
@@ -5001,7 +5021,7 @@ messages:
    KilledSomething(what = $,use_weapon = $,stroke_obj = $)
    "Called when the player killed something."
    {
-      local i, oSoldierShield, monstkarma, iChance, oEnemyGuild;
+      local i, oSoldierShield, monstkarma, iChance, oEnemyGuild, shrunken;
 
       % If we killed someone or something, we did damage.
       Send(self,@SetPlayerFlag,#flag=PFLAG_DID_DAMAGE,#value=TRUE);
@@ -5132,6 +5152,14 @@ messages:
       Send(what,@Killed,#what=self,#stroke_obj=stroke_obj);
 	  Send(self,@DrawHPChance);
 
+	  % report to shrunken head
+	  shrunken = Send(self,@FindHolding,#class=&ShrunkenHead);
+      if shrunken <> $
+      {
+		Send(shrunken,@OpponentKilled,#what=what,#stroke_obj=stroke_obj);
+      }
+	  
+	  
       return;
    }
 
@@ -6880,7 +6908,7 @@ messages:
                       refigureschools = TRUE)
    {
       local i, bFound, elemnum, iability, bUsed, spellname, iChange,
-            newability, oSpell, oRoom;
+            newability, oSpell, oRoom, shrunken;
 
       oSpell = Send(sys,@FindSpellByNum,#num=spell_num);
       if oSpell = $
@@ -6931,6 +6959,13 @@ messages:
          Post(self,@MsgSendUser,#message_rsc=player_improved,#parm1=spellName);
          Send(oRoom, @SomethingWaveRoom, #what=self, 
               #wave_rsc=player_improved_wav_rsc);
+			
+		 % report to shrunken head
+		 shrunken = Send(self,@FindHolding,#class=&ShrunkenHead);
+		 if shrunken <> $
+		 {
+			Send(shrunken,@Improvement,#spellName=spellName);
+		 }				  
       }
 
       Send(self,@PlayerIsIntriguing);
@@ -7831,7 +7866,7 @@ messages:
    "their maxhealth to gain a HP.  This number is reduced by the player's"
    "stamina, all the way down to half for those with high staminas."
    {
-      local highmark, rand, dodgeskill, oSkill, monster_level, gain, gainmult, roll, iNumber, oWeapon;
+      local highmark, rand, dodgeskill, oSkill, monster_level, gain, gainmult, roll, iNumber, oWeapon, shrunken;
             
       gain = 0;
       roll = FALSE;
@@ -7914,7 +7949,7 @@ messages:
 
          gainmult = bound(Send(Send(SYS, @GetSettings), @GetHPGainMultiplier),1,500);
          gain = gain * gainmult;
-
+		 
          piGain_chance = piGain_chance + gain;
 
          if roll
@@ -7941,7 +7976,14 @@ messages:
                piHealth = piMax_Health;
                Send(self,@DrawHealth);
                Send(self,@EatSomething,#nutrition=200);
-
+			   
+			   % report to shrunken head
+			   shrunken = Send(self,@FindHolding,#class=&ShrunkenHead);
+			   if shrunken <> $
+			   {
+				  send(shrunken,@Tougher,#hp=pibase_max_health);
+			   }		 	
+			   
                piGain_chance = -(piBase_Max_health/2);
                
                if piBase_max_health > 30
@@ -12297,8 +12339,9 @@ messages:
    {
       local oSnoop;
 
-      if type = SAY_NORMAL and what <> self and IsClass(what,&Player)
+      if type = SAY_NORMAL AND IsClass(what,&Player)
       {
+		 % si: removed (and what <> self) to allow communication between shrunken head and owner.
          oSnoop = Send(self,@FindHolding,#class=&ShrunkenHead);
          if oSnoop <> $
          {

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3495,8 +3495,8 @@ messages:
          Send(self, @WaveSendUser, #what=self, #wave_rsc = user_cant_pickup_item_wav_rsc);
               
          return;
-      }
-
+      }	  
+	  
       lItem_pos = Send(what,@GetPos);
       if lItem_pos = $
       {
@@ -3607,7 +3607,13 @@ messages:
             
             return;                      
          }        
-      }
+      }	  
+	  		 
+	  % shrunken head picked up
+	  if isClass(what, &ShrunkenHead)
+	  {
+		 send(what,@PickedUp,#by=self);
+	  }	  		
 
       Send(self,@NewHold,#what=what);
       
@@ -3682,6 +3688,12 @@ messages:
       {
          Send(poOwner,@NewHold,#what=what,#new_row=piRow,#new_col=piCol,
               #fine_row=piFine_row,#fine_col=piFine_col);
+		 % shrunken head dropped by owner
+		 if isClass(what, &ShrunkenHead)
+		 {
+			Send(what,@Dropped,#by=self,#where=poOwner);
+	     }			  
+			  
       }
       
       return;
@@ -5868,10 +5880,11 @@ messages:
    NewHoldObject(what = $)
    {
       if pbLogged_on
-      {
+      {	  
          AddPacket(1,BP_INVENTORY_ADD);
          Send(self,@ToCliObject,#what=what,#show_type=SHOW_INVENTORY);
-         SendPacket(poSession);
+         SendPacket(poSession);		 
+
       }
       
       propagate;

--- a/kod/object/item/passitem/shruhead.kod
+++ b/kod/object/item/passitem/shruhead.kod
@@ -16,9 +16,16 @@ constants:
 
    BABBLE_MINIMUM = 10000
    BABBLE_MAXIMUM = 100000
+   
+   % percentage to speak on hit/kill
+   KILL_CHAT_PROB_HIT = 5
+   KILL_CHAT_PROB_KIL = 10
+   KILL_CHAT_PROB_IMP = 20
 
 resources:
 
+   ShrunkenHead_pickup = "Congratulations on adopting a Shrunken Head. This head will monitor your building activities and track your progress - most certainly a positive building accessory. Try using the following commands: 'Shrunken head, status report!' and 'Shrunken head, reset!."  
+     
    ShrunkenHead_icon_rsc = shruhead.bgf
    ShrunkenHead_name_rsc = "shrunken head"
    ShrunkenHead_desc_rsc = \
@@ -50,7 +57,33 @@ resources:
    ShrunkenHead_random_not_lonely_2 = "Sure!  You'll be my bestest friend!"
    ShrunkenHead_see_players = "I see "
    ShrunkenHead_and = "and"
-   ShrunkenHead_inventory_has = " has "
+   ShrunkenHead_inventory_has = " has "   
+   
+   ShrunkenHead_win1 = "Good form"
+   ShrunkenHead_win2 = "Have it! You pathetic "
+   ShrunkenHead_win3 = "Doooshh!"
+   ShrunkenHead_win4 = "ka-powza!"
+   ShrunkenHead_win5 = "Nicely done sir. I won't tell Shal'ille if you don't!"
+   
+   ShrunkenHead_dealt1 = "Ouch!!"
+   ShrunkenHead_dealt2 = "Stop hitting us!"
+   ShrunkenHead_dealt3 = "Run Away!! Retreat!! ~INo hope!!"
+   ShrunkenHead_dealt4 = "HA! Master laughs off your weak and insignificant blow!"
+   
+   ShrunkenHead_hit1 = "Strong and True!"
+   ShrunkenHead_hit2 = "Just and Powerful!"
+   ShrunkenHead_hit3 = "For the alliance!"
+   ShrunkenHead_hit4 = "There is no hope for you "
+
+   ShrunkenHead_cheer1 = "Well Done!"
+   ShrunkenHead_cheer2 = "Your patients really paid off..."
+   
+   ShrunkenHead_tougher1 = "Woooooooooooot!!!"
+   ShrunkenHead_tougher2 = "Master is sooooo strong!!!"
+   ShrunkenHead_tougher3 = "Oh Master!!! Congratulations!!!!"   
+      
+   ShrunkenHead_check = "Shrunken head, status report!"
+   ShrunkenHead_reset = "Shrunken head, reset!"
 
 classvars:
    
@@ -64,14 +97,265 @@ classvars:
 
    viGround_group = 1
 
+
 properties:  
 
    psOverheard = $
    poOverheard = $
    piSilenced = 0
    ptBabble = $
+   
+      
+   % what kind of shrunken head did you get? :D
+   personality = 1
+   
+   % shrunken head works like a walking journal... 
+   statKills = 0
+   statImprovements = 0
+   statToughers = 0   
+   statDealt = 0
+   statReceived = 0
 
 messages:   
+
+   Dropped(by = $, where = $)
+   "The poor shrunken head has been dropped!"
+   {
+		local s, choice;		
+		
+		s = createString();
+		clearTempString();
+
+		appendTempString("Please master ");
+		appendTempString(send(by,@GetName));
+		appendTempString(" don't leave me here like this!!");
+
+		setString(s,getTempString());
+        clearTempString();		
+		
+		send(self,@DoBabbleString,#string=s);
+		return;
+   }   
+   
+   PickedUp(by = $)
+   "Shrunken head has been picked up"
+   {		  
+		Send(by,@MsgSendUser,#message_rsc=ShrunkenHead_pickup);
+		return;
+   }
+
+   Tougher(hp = $)
+   "Master gained a tougher!"
+   {		
+		local s, choice, divulgeHp;
+		statToughers=statToughers+1;
+		
+		if poOwner = $ { return; }   		
+
+		s = createString();
+		clearTempString();		
+
+		choice = random(1,3);
+		divulgeHp = random(0, 100);
+		
+		if choice = 1 
+		{
+			appendTempString(ShrunkenHead_tougher1);
+		}
+		if choice = 2
+		{
+			appendTempString(ShrunkenHead_tougher2);
+		}
+		if choice = 3
+		{
+			appendTempString(ShrunkenHead_tougher3);
+		}		
+		if(divulgeHp<10) 
+		{
+			% 10 percentage chance to divulge current hp :D
+			appendTempString("Master now has ");
+			appendTempString(hp);
+			appendTempString(" hitpoints! hee hee hee");
+		}
+		
+		setString(s,getTempString());
+        clearTempString();		
+		
+		send(self,@DoBabbleString,#string=s);
+		return;
+   }
+
+   DamageTaken(what = $, amount = 0) 
+   "Master is being hit! Oww"
+   {
+		local s, choice;
+		
+		statReceived=statReceived+amount;
+
+		if poOwner = $ { return; }   		
+		if random(1,100) > KILL_CHAT_PROB_HIT { return; }
+		
+		s = createString();
+		clearTempString();		
+		
+		choice = random(1,2);
+		
+		if amount>18 
+		{
+			% owww
+			appendTempString(ShrunkenHead_dealt3);
+			choice = 3;
+		}		
+		if(amount = 1) 
+		{
+			% weak opponent
+			appendTempString(ShrunkenHead_dealt4);
+			choice = 3;
+		}		
+		if choice = 1 
+		{
+			appendTempString(ShrunkenHead_dealt1);
+		}
+		if choice = 2 
+		{
+			appendTempString(ShrunkenHead_dealt2);
+		}	
+		
+		setString(s,getTempString());
+        clearTempString();		
+		
+		send(self,@DoBabbleString,#string=s);
+		return;
+   }
+   
+   DamageDealt(what = $, amount = 0) 
+   "Master is hitting something... good"
+   {
+		local s, choice;
+		statDealt=statDealt+amount;
+		
+		if poOwner = $ { return; }   		
+		if random(1,100) > KILL_CHAT_PROB_HIT { return; }
+		
+		s = createString();
+		clearTempString();		
+		
+		choice = random(1,3);
+		
+		if amount > 18
+		{	
+			% powerful blow
+			appendTempString(ShrunkenHead_hit4);
+			appendTempString(send(what,@GetName));
+			appendTempString("!");
+			choice = 4;
+		}	
+	
+		if choice = 1 
+		{
+			appendTempString(ShrunkenHead_hit1);
+		}
+		if choice = 2 
+		{
+			appendTempString(ShrunkenHead_hit2);
+		}	
+		if choice = 3 
+		{
+			appendTempString(ShrunkenHead_hit3);
+		}	
+		
+		setString(s,getTempString());
+        clearTempString();		
+		
+		send(self,@DoBabbleString,#string=s);
+		return;
+   }   
+   
+   Improvement(spellName=$) 
+   "Master gained an improvement :-)"
+   {   
+		local s, choice;
+		statImprovements=statImprovements+1;
+		if poOwner = $ { return; }   		
+		if random(1,100) > KILL_CHAT_PROB_IMP { return; }
+		
+		s = createString();
+		clearTempString();		
+		
+		choice = random(1,2);
+		
+		if choice = 1 
+		{
+			appendTempString(ShrunkenHead_cheer1);
+		}
+		if choice = 2 
+		{
+			appendTempString(ShrunkenHead_cheer2);
+		}	
+		
+		setString(s,getTempString());
+        clearTempString();		
+		
+		send(self,@DoBabbleString,#string=s);
+		return;		
+   }
+   
+   OpponentKilled(what=$,stroke_obj=$) 
+   "Our master killed something..."
+   {
+      	local s, choice, karma;		
+		statKills=statKills+1;
+		if poOwner = $ { return; }   		
+		if random(1,100) > KILL_CHAT_PROB_KIL { return; }
+
+		s = createString();
+		clearTempString();
+		
+		choice = random(1,6);
+
+		if choice = 1 
+		{
+			appendTempString(ShrunkenHead_win1);
+			appendTempString(" ~B");
+			appendTempString(send(poOwner,@GetName));
+			appendTempString("~n.");
+		}
+		if choice = 2
+		{
+			appendTempString(ShrunkenHead_win2);
+			appendTempString(send(what,@GetName));
+			appendTempString("!");
+		}
+		if choice = 3
+		{
+			appendTempString(ShrunkenHead_win3);
+		}
+		if choice = 4
+		{
+			appendTempString(ShrunkenHead_win4);
+		}
+		if choice = 5 
+		{
+			appendTempString("Hail! Another ");
+			appendTempString(send(what,@GetName));
+			appendTempString(" bites the dust!");
+		}
+		if choice = 6
+		{	
+			karma = Send(what,@GetKarma);
+			if karma > 10
+			{
+				appendTempString(ShrunkenHead_win5);
+			}				
+		}
+
+		setString(s,getTempString());
+        clearTempString();		
+		
+		send(self,@DoBabbleString,#string=s);
+		return;
+   }  
+
 
    Delete()
    {
@@ -102,10 +386,61 @@ messages:
 
    SomeoneOverheard(from=$,string=$)
    {
-      % Keyword to get the thing to shut up.
-
+	  local s;
+	  
+      % Keyword to get the thing to shut up.	
       if poOwner = $ { return; }
 
+	  % check for stat request from master
+	  if from = poOwner AND stringContain(string,ShrunkenHead_check)
+	  {
+		s = createString();
+		clearTempString();
+		appendTempString("Master has killed ");
+		appendTempString(statKills);
+		appendTempString(" foes, improved ");
+		appendTempString(statImprovements);
+		appendTempString(" times and gained ");
+		appendTempString(statToughers);
+		appendTempString(" toughers! Master has also");
+		appendTempString(" dealt ");
+		appendTempString(statDealt);
+		appendTempString(" and hurt for ");
+		appendTempString(statReceived);
+		appendTempString(" damage.");
+		setString(s,getTempString());
+		clearTempString();
+		send(self,@DoBabbleString,#string=s);
+		return;			
+	  }
+	  
+	  % reset stats
+	  if from = poOwner AND stringContain(string,ShrunkenHead_reset)
+	  {
+		s = createString();
+		clearTempString();
+		appendTempString("OK boss!");
+		setString(s,getTempString());
+		clearTempString();
+		send(self,@DoBabbleString,#string=s);
+		
+		% and reset....
+		statKills = 0;
+		statToughers = 0;
+		statDealt = 0;
+		statReceived = 0;
+		statImprovements = 0;
+		
+		return;			
+	  }	  
+	  
+	  
+	  if from = poOwner
+	  {
+	    % don't record the master
+		return;
+	  }  
+	  
       if stringContain(string,ShrunkenHead_name_rsc)
          AND stringContain(string,ShrunkenHead_shut_up)
       {


### PR DESCRIPTION
A small client update when picking a character on your account. Characters will now be listed before free character slots! Character names will be listed in alphabetical order with free character slots always appearing last.

This saves lots of time logging in and pressing down. This is specifically for accounts with a single character and a free character slot. charpick.c now performs a bubble sort on character names rather than using LBS_SORT property on the charpick dialog listbox. delicious.
