### PR TITLE
Visual spell damage types

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4698,8 +4698,18 @@ messages:
       {
          iDuration = 400;
       }
-      
-      Send(self,@EffectSendUserDuration,#what=self,#effect=EFFECT_PAIN,#duration=iDuration);
+
+      % Spell damage types do different flashes to inform the victim. If it's just physical damage, do pain instead.
+      % Notably: spell damage type flashes cannot be turned off by unchecking the Show Pain option in client config.
+      if aspell <> 0
+      {
+         iDuration = iDuration / 2;
+         Send(self,@DamageTypeFlashEffect,#aspell=aspell,#duration=iDuration);
+      }
+      else
+      {
+         Send(self,@EffectSendUserDuration,#what=self,#effect=EFFECT_PAIN,#duration=iDuration);
+      }
 
       if NOT absolute and damage <= 0
       {

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3115,6 +3115,39 @@ messages:
       
       return;
    }
+   
+   DamageTypeFlashEffect(aspell=0, duration=800)
+   {
+      if aspell & ATCK_SPELL_QUAKE
+      {
+         Send(self,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=duration,#xlat=27);
+      }
+      if aspell & ATCK_SPELL_HOLY
+      {
+         Send(self,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=duration,#xlat=116);
+      }
+      if aspell & ATCK_SPELL_UNHOLY
+      {
+         Send(self,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=duration,#xlat=56);
+      }
+      if aspell & ATCK_SPELL_ACID
+      {
+         Send(self,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=duration,#xlat=79);
+      }
+      if aspell & ATCK_SPELL_COLD
+      {
+         Send(self,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=duration,#xlat=85);
+      }
+      if aspell & ATCK_SPELL_SHOCK
+      {
+         Send(self,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=duration,#xlat=82);
+      }
+      if aspell & ATCK_SPELL_FIRE
+      {
+         Send(self,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=duration,#xlat=81);
+      }
+      return;
+   }
 
    SendEffectData()
    {

--- a/kod/object/passive/spell/atakspel/boltspel/lightnin.kod
+++ b/kod/object/passive/spell/atakspel/boltspel/lightnin.kod
@@ -71,23 +71,6 @@ messages:
       return;
    }
 
-   CastSpell(who = $, lTargets = $)
-   {
-      % Do the invert effect
-      Send(who,@EffectSendUser,#what=self,#effect=EFFECT_INVERT);
-      Send(First(lTargets),@EffectSendUser,#what=self,#effect=EFFECT_INVERT);
-
-      propagate;
-   }
-
-   SendEffectData()
-   {
-      % for EFFECT_INVERT, 4 bytes of time to be inverted
-      AddPacket(4,500);
-      
-      return;
-   }
-
    GetProjectileSpeed()
    {
       return 12;

--- a/kod/object/passive/spell/atakspel/shokfury.kod
+++ b/kod/object/passive/spell/atakspel/shokfury.kod
@@ -66,23 +66,5 @@ messages:
       return;
    }
 
-   CastSpell(who = $, lTargets = $)
-   {
-      % Do the invert effect
-      Send(who,@EffectSendUser,#what=self,#effect=EFFECT_INVERT);
-      Send(First(lTargets),@EffectSendUser,#what=self,#effect=EFFECT_INVERT);
-
-      propagate;
-   }
-
-   SendEffectData()
-   {
-      % for EFFECT_INVERT, 4 bytes of time to be inverted
-      AddPacket(4,250);
-      
-      return;
-   }
-
-
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
When taking damage, if the damage has an elemental component, the
player's screen will now flash a color representing the element instead
of just red pain.
- Holy damage comes with an ethereal white flash (distinct from Dazzle).
- Unholy damage makes you momentarily see black & white.
- Acid causes a deep green flash.
- Shock causes a light blue flash.
- Fire causes a light orange flash.
- Cold causes a deep blue flash.
- Quake damage causes a brown flash. (Yes it's a separate damage type)

This should help players more quickly assess the kinds of damage they're
taking, without having to read fast-moving text messages mid-combat.
As always, duration of the flash depends on damage done. These flashes
are half as long as EFFECT_PAIN visual durations.

Note: since they now have shock colors done for them, shocking fury and
lightning bolt no longer do EFFECT_INVERT, which was also causing
players to see through blind.

Also note: these flashes cannot be turned off the same way that Show Pain can
be turned off.
