### PR TITLE
unset DRAWFX_INVISIBLE (=OF_INVISIBLE) bits in playerlist

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -816,7 +816,7 @@ messages:
          AddPacket(1,BP_PLAYER_ADD);
          AddPacket(4,what,4,rName);
          AddPacket(STRING_RESOURCE,rName);
-         AddPacket(4,Send(what,@GetObjectFlags));
+         AddPacket(4,Send(what,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
          SendPacket(poSession);
 
          if IsClass(self,&Admin) AND IsClass(what,&Admin)
@@ -2410,7 +2410,7 @@ messages:
          rName = Send(i,@GetTrueName);
 
          AddPacket(4,i, 4,rName, STRING_RESOURCE,rName);
-         AddPacket(4,Send(i,@GetObjectFlags));
+         AddPacket(4,Send(i,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
       }
       
       SendPacket(poSession);


### PR DESCRIPTION
This is a server-side fix for the black color of playernames in the wholist.

It simply unsets the bits in the object flags before sending the data to the client.
Those bits, which indicate the object is shadowformed or invisible (shadowformbits are subset of invis bits).

The 103 fix is a client-sided one... and I had to make the decision whether to fix it (again) locally in my new client or to do it right this time (=on the server-side).
