### PR TITLE
Spell Totems

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -3726,7 +3726,7 @@ messages:
       return TRUE;
    }
 
-   AllowPlayerAttack(victim=$, stroke_obj=$, use_weapon=$, report=TRUE, actual=TRUE)
+   AllowPlayerAttack(victim=$, stroke_obj=$, use_weapon=$, report=TRUE, actual=TRUE, spell_obj=$)
    "Will not let a person attack someone who isnt pkill_enabled."
    "Wll not let a person who isnt pkill_enabled attack another person."
    {

--- a/kod/object/active/radiustotem.kod
+++ b/kod/object/active/radiustotem.kod
@@ -1,0 +1,333 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+RadiusEnchantmentTotem is ActiveObject
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   RadiusEnchantmentTotem_icon_rsc = blank.bgf
+   
+classvars:
+
+   viObject_flags = LOOK_NO
+   vrIcon = RadiusEnchantmentTotem_icon_rsc
+
+properties:
+
+   poSpell = $            %% The radius spell we're supporting
+   poCaster = $           %% The caster of the original spell
+
+   piSpellpower = $
+   ptExpirationTimer = $
+   
+   plEnchantments = $     %% The spell info we are using
+
+   piRow = 0
+   piCol = 0
+
+messages:
+
+   Constructor(totem_spell=$,totem_caster=$,totem_power=0)
+   {
+      local oRoom, iTime;
+      
+      poSpell = totem_spell;
+      poCaster = totem_caster;
+      piSpellpower = totem_power;
+      
+      oRoom = Send(poCaster,@GetOwner);
+      
+      If oRoom = $
+         OR poCaster = $
+         OR poSpell = $
+         OR piSpellpower = 0
+         OR NOT IsClass(oRoom,&Room)
+      {
+         Post(self,@Delete);
+         return;
+      }
+
+      Send(SYS,@AddSpellTotemToServerList,#oTotem=self);
+      
+      piRow = Send(poCaster,@GetRow);
+      piCol = Send(poCaster,@GetCol);
+
+      Send(oRoom,@NewHold,#what=self,#new_row=piRow,#new_col=piCol);
+
+      Send(poSpell,@CastSpell,#who=self,#iSpellPower=piSpellpower);
+
+      iTime = Send(poSpell,@GetDuration,#iSpellPower=piSpellpower);
+      if iTime <> $
+      {
+         ptExpirationTimer = CreateTimer(self,@TotemExpire,iTime);
+      }
+
+      propagate;
+   }
+   
+   TotemExpire()
+   {
+      local i;
+
+      ptExpirationTimer = $;
+      
+      Send(self,@Delete);
+      return;
+   }
+
+   Delete()
+   {
+      local i;
+
+      if ptExpirationTimer <> $
+      {
+         DeleteTimer(ptExpirationTimer);
+         ptExpirationTimer = $;
+      }
+
+      for i in plEnchantments
+      {
+         Send(Nth(i,2),@BreakTrance,#who=self,#state=Nth(i,3),#event=EVENT_STEER);
+         DeleteTimer(Nth(i,1));
+      }
+
+      poCaster = $;
+      poSpell = $;
+      plEnchantments = $;
+
+      Send(SYS,@DeleteSpellTotemFromMasterList,#oTotem=self);
+
+      propagate;
+   }
+   
+   GetCaster()
+   {
+      return poCaster;
+   }
+   
+   GetSpell()
+   {
+      return poSpell;
+   }
+
+   GetName()
+   {
+      return Send(poCaster,@GetName);
+   }
+   
+   GetTrueName()
+   {
+      return Send(poCaster,@GetTrueName);
+   }
+   
+   GetGuild()
+   {
+      if IsClass(poCaster,&Monster)
+      {
+         return $;
+      }
+
+      return Send(poCaster,@GetGuild);
+   }
+   
+   AllowPlayerAttack(victim=$,report=FALSE)
+   {
+      if IsClass(poCaster,&Monster)
+      {
+         return TRUE;
+      }
+
+      if victim = poCaster
+      {
+         return TRUE;
+      }
+
+      return Send(poCaster,@AllowPlayerAttack,#victim=victim,#report=FALSE,#spell_obj=poSpell);
+   }
+   
+   CheckPlayerFlag(flag=$)
+   {
+      if IsClass(poCaster,&Monster)
+      {
+         return $;
+      }
+
+      return Send(poCaster,@CheckPlayerFlag,#flag=flag);
+   }
+
+   SomethingEntered(where = $,what = $)
+   {
+      return;
+   }
+   
+   SomethingLeft(where = $,what = $)
+   {
+      return;
+   }
+   
+   SomethingMoved(what = $,new_row = $,new_col = $)
+   {
+      propagate;
+   }
+
+   LastUserLeft()
+   {
+      propagate;
+   }
+
+   DestroyDisposable()
+   {
+      % These naturally time out. They are never actively deleted.
+      return;
+   }
+   
+   StartEnchantment(what = $,time = $,state = $,lastcall=TRUE,addicon=TRUE)
+   "Adds <what> to our enchantments, and creates a timer that will cause it "
+   "to end."
+   {
+      local oTimer, lNew_enchantment;
+
+      if time = $ OR time = SPELL_INDEFINITE_DURATION 
+      {
+         oTimer = $;
+      }
+      else 
+      {
+         if lastcall
+         {
+            oTimer = CreateTimer(self,@EnchantmentTimer,time);
+         }
+         else
+         {
+            oTimer = CreateTimer(self,@PeriodicEnchantmentTimer,time);
+         }
+      }
+
+      if state = $
+      {
+         lNew_enchantment = [oTimer, what];
+      }
+      else
+      {
+         lNew_enchantment = [oTimer, what, state];
+      }
+
+      plEnchantments = Cons(lNew_enchantment,plEnchantments);
+
+      return;
+   }
+
+   EnchantmentTimer(timer = $)
+   {
+      local i,oEnchanter;
+ 
+      for i in plEnchantments
+      {
+         if First(i) = timer
+         {
+            if Length(i) >= 3
+            {
+               Send(Nth(i,2),@EndEnchantment,#who=self,#state=Nth(i,3));
+            }
+            else
+            {
+               Send(Nth(i,2),@EndEnchantment,#who=self);
+            }
+            
+            plEnchantments = DelListElem(plEnchantments,i);
+
+            return;
+         }
+      }
+
+      Debug("Enchantment timer went off with no enchantment",timer);
+
+      return;
+   }
+
+   PeriodicEnchantmentTimer(timer = $)
+   {
+      local i ;
+ 
+      for i in plEnchantments
+      {
+         if First(i) = timer
+         {
+            plEnchantments = DelListElem(plEnchantments,i);
+            
+            if Length(i) >= 3
+            {
+               Send(Nth(i,2),@StartPeriodicEnchantment,#who=self,#state=Nth(i,3));
+            }
+            else
+            {
+               Send(Nth(i,2),@StartPeriodicEnchantment,#who=self,#state=$);
+            }
+
+            return;
+         }
+      }
+
+      Debug("Enchantment timer went off with no enchantment",timer);
+
+      return;
+   }
+
+   GetEnchantedState(what = $)
+   "If enchanted by <what>, returns the state data (which MUST exist, or it's an error.  "
+   "In other words, the caller must know that <what> adds state data).  Returns $ otherwise."
+   {
+      local i;
+
+      for i in plEnchantments
+      {
+         if Nth(i,2) = what
+         {
+            return Nth(i,3);
+         }
+      }
+      
+      return $;
+   }
+   
+   SquaredDistanceTo(what = $)
+   "Computes squared distance to <what>.  Assumes they are in same room!"
+   {
+      local iRow, iCol;
+
+      iRow = Send(what,@GetRow);
+      iCol = Send(what,@GetCol);
+
+      % Sanity checking
+      if iRow = $ OR iCol = $
+      {
+         return $;
+      }
+
+      return send(self,@SquaredDistanceToLocation,#row=iRow,#col=iCol);
+   }
+
+   SquaredDistanceToLocation(row = $, col = $)
+   "Computes squared distance to (row,col)"
+   {
+      local iRow_diff, iCol_diff;
+
+      iRow_diff = piRow - row;
+      iCol_diff = piCol - col;
+
+      return  (iRow_diff * iRow_diff + iCol_diff * iCol_diff);
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -99,6 +99,7 @@ resources:
    spell_school_jala = "Jala"
    spell_intro_rsc = "One of the many mystical spells."
 
+   spell_sound_jala = lute_equip.wav
    spell_sound_shalille = shalille.wav
    spell_sound_qor = qor.wav
    spell_sound_kraanan = kraanan.wav
@@ -1513,7 +1514,12 @@ messages:
       {
          return vrSucceed_wav;
       }
-      
+
+      if viSchool = SS_JALA
+      {
+         return spell_sound_jala;
+      }
+
       if viSchool = SS_SHALILLE
       {
          return spell_sound_shalille;

--- a/kod/object/passive/spell/discord.kod
+++ b/kod/object/passive/spell/discord.kod
@@ -50,7 +50,7 @@ classvars:
    viSpell_level = 4
 
    viCast_time = 1000
-   viChance_To_Increase = 5
+   viChance_To_Increase = 15
 
 properties:
 
@@ -72,6 +72,7 @@ messages:
    CanPayCosts(who=$)
    {
       if send(send(who,@GetOwner),@GetEnchantmentList) = $
+         AND send(who,@GetRadiusEnchantments) = $
       {
          Send(who, @MsgSendUser, #message_rsc=spell_bad_location, #parm1=vrName);
          return FALSE;
@@ -81,7 +82,7 @@ messages:
 
    CastSpell(who = $,lTargets = $,iSpellPower = $)
    {
-      local oRoom;
+      local oRoom, i, lState;
 
       if isClass(who,&Room)
       {
@@ -111,6 +112,23 @@ messages:
       Send(oRoom,@SomeoneSaid,#type=SAY_MESSAGE,#string=discordance_on,#what=self);
       Send(self,@DoDiscordance,#oRoom=oRoom,#iChance=iSpellPower);
 
+      for i in Send(who,@GetRadiusEnchantments)
+      {
+         if iSpellPower = $
+            OR Random(1,100) < iSpellPower
+         {
+            if IsClass(Nth(i,3),&RadiusEnchantmentTotem)
+            {
+               Send(Nth(i,3),@Delete);
+            }
+            else
+            {
+               lState = Send(Nth(i,3),@GetEnchantedState,#what=Nth(i,1));
+               Send(Nth(i,1),@BreakTrance,#who=Nth(i,3),#state=lState,#event=EVENT_STEER);
+            }
+         }
+      }
+      
       if not IsClass(who,&Player)
       {
          return;

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -49,6 +49,10 @@ resources:
 
    radius_ench_need_instrument = "You need an instrument!"
 
+   radius_ench_old_style_aleady_cast = "You are already under the effects of that magic."
+
+   radius_ench_cant_fight_here = "You can't fight here."
+   
 classvars:
 
    radius_ench_already_cast = radius_ench_default_already_cast
@@ -84,13 +88,13 @@ classvars:
    viAffectsEnemies = FALSE     % Hostile, can cause outlaw status
    viAffectsInnocents = FALSE   % Unaffiliated white characters
    viAffectsNewbies = FALSE     % Angeled characters
+                                
+   viCasterPersist = FALSE      % If true, spell will 'follow' caster between rooms
 
 properties:
-
-   ptDrainTimer = $
-   ptDrainNow = FALSE
    
-   viLightIntensity = 60
+   piOldAreaEnchStyle = FALSE   % If true, spell functions as an old-style Area Enchantment
+                                % No trance required, and will remain in initial room for duration
 
 messages:
 
@@ -107,6 +111,16 @@ messages:
 
    CanPayCosts(who=$, lTargets=$)  
    {
+      local i, each_obj, oRoom;
+
+      oRoom = Send(who,@GetOwner);
+      if oRoom = $
+         OR NOT IsClass(oRoom,&Room)
+      {
+         % Don't cast without a room, may create hanging objects
+         return FALSE;
+      }
+
       if viNeedInstrument
       {
           if Send(who,@GetInstrumentLevel) = 0
@@ -115,6 +129,39 @@ messages:
              return FALSE; 
           }
       }
+      
+      if piOldAreaEnchStyle
+         AND IsClass(who,&User)
+         AND Send(who,@IsAffectedByRadiusEnchantment,#what=self)
+      {
+         Send(who,@MsgSendUser,#message_rsc=radius_ench_old_style_aleady_cast);
+         return FALSE;
+      }
+
+      if Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
+         AND viAffectsEnemies
+      {
+         if IsClass(who,&User)
+         {
+            Send(who,@MsgSendUser,#message_rsc=radius_ench_cant_fight_here);
+         }
+         return FALSE;
+      }
+      
+      % Make sure monsters don't spam area enchantments of the same type
+      if piOldAreaEnchStyle
+         OR IsClass(who,&Monster)
+      {
+         for i in Send(oRoom,@GetplActive)
+         {
+            each_obj = Send(oRoom,@HolderExtractObject,#data=i);
+            if IsClass(each_obj,&RadiusEnchantmentTotem)
+               AND Send(each_obj,@GetSpell) = self
+            {
+               return FALSE;
+            }
+         }
+      }
 
       propagate;
    }
@@ -122,17 +169,28 @@ messages:
    CastSpell(who=$, iSpellPower=0)
    "Initiation point for the spell."
    {
-      local i, lMaintaining, iState, oObj, oUser, oCasterGuild, oRoom, iElapsed, lEnchanted, iPower, iRange;
+      local i, lMaintaining, iState, oObj, oUser, oCasterGuild, oRoom, iDrain, lEnchanted, iPower, iRange;
 
-      iElapsed = 0;
+      % Old style Area Enchantments use a RadiusEnchantmentTotem as the center of the spell.
+      % This creates a timed invisible object that perpetuates the spell regardless of what the player does.
+      % The totem is linked to the caster for all characteristics (flags and affiliations).
+      if (piOldAreaEnchStyle
+         AND IsClass(who,&User))
+         OR IsClass(who,&Monster)
+      {
+         Create(&RadiusEnchantmentTotem,#totem_spell=self,#totem_caster=who,#totem_power=iSpellPower);
+         propagate;
+      }
+
+      iDrain = 0;
       lEnchanted = $;
       iPower = Send(self,@CalculatePower,#iSpellPower=iSpellPower);
       iRange = Send(self,@CalculateRange,#iSpellPower=iSpellPower);
-      
-      viLightIntensity = Send(self,@CalculateLightIntensity,#iSpellPower=iSpellPower);
 
-      % Cancel previous radius spell trance
-      if Send(who,@IsEnchanted,#byClass=&RadiusEnchantment)
+      % Cancel previous trance if this spell requires one as well
+      if NOT piOldAreaEnchStyle
+         AND IsClass(who,&User)
+         AND Send(who,@IsEnchanted,#byClass=&RadiusEnchantment)
       {
          lMaintaining = Send(who,@GetEnchantmentsByClass,#enchClass=&RadiusEnchantment);
          for i in lMaintaining
@@ -163,7 +221,8 @@ messages:
 
             % Important note: FindListElem returns nil on a passed nil value, not zero.
             if (lEnchanted = $ OR FindListElem(lEnchanted,oUser) = 0)
-               AND Send(who,@SquaredDistanceTo,#what=oUser) <= (iRange * iRange)
+               AND (Send(who,@SquaredDistanceTo,#what=oUser) <= (iRange * iRange)
+                   OR piOldAreaEnchStyle)
             {
                if Send(self,@TargetIsValid,#target=oUser,#caster=who)
                {
@@ -182,12 +241,9 @@ messages:
          }
       }
 
-      % Put spell maintenance info in casters enchantment list.
+      % Put spell maintenance info in caster's enchantment list.
       Send(who,@StartEnchantment,#what=self,#time=RADIUS_CHECK_TIME,
-           #state=[iElapsed,lEnchanted,iPower,iRange]);      
-
-      % Set up mana drain
-      ptDrainTimer = CreateTimer(self,@DrainTimer,viDrainTime);
+           #state=[iDrain,lEnchanted,iPower,iRange]);      
 
       propagate;
    }
@@ -263,6 +319,7 @@ messages:
    EnterRadius(who=$,iPower=0,caster=$)
    {      
       Send(who,@AddRadiusEnchantment,#what=self,#iPower=iPower,#caster=caster);
+      Send(self,@StartSpecialEffect,#who=who,#iPower=iPower,#caster=caster);
 
       return;
    }
@@ -270,16 +327,27 @@ messages:
    LeaveRadius(who=$,iPower=0,caster=$)
    {      
       Send(who,@RemoveRadiusEnchantment,#what=self,#iPower=iPower,#caster=caster);
+      Send(self,@EndSpecialEffect,#who=who,#iPower=iPower,#caster=caster);
       
+      return;
+   }
+   
+   StartSpecialEffect(who=$,iPower=0,caster=$)
+   {
+      return;
+   }
+   
+   EndSpecialEffect(who=$,iPower=0,caster=$)
+   {
       return;
    }
 
    EndEnchantment( who = $, state = $ )
    "Called only for caster. Refreshes itself to recalculate affected players."
    {
-      local iElapsed, lEnchanted, iPower, iRange, oUser, oCasterGuild, oRoom, lActive;
+      local iDrain, lEnchanted, iPower, iRange, oUser, oCasterGuild, oRoom, lActive;
 
-      iElapsed = Nth(state,1);
+      iDrain = Nth(state,1);
       lEnchanted = Nth(state,2);
       iPower = Nth(state,3);
       iRange = Nth(state,4);
@@ -290,7 +358,8 @@ messages:
       % Check for players that have left the radius of effect
       for oUser in lEnchanted
       {
-         if Send(who,@SquaredDistanceTo,#what=oUser) > (iRange * iRange)
+         if (Send(who,@SquaredDistanceTo,#what=oUser) > (iRange * iRange)
+            AND NOT piOldAreaEnchStyle)
             OR Send(who,@GetOwner) <> Send(oUser,@GetOwner)
             OR NOT Send(self,@TargetIsValid,#target=oUser,#caster=who)
          {
@@ -307,7 +376,8 @@ messages:
 
          if IsClass(oUser,&User)
             AND (lEnchanted = $ OR FindListElem(lEnchanted,oUser) = 0)
-            AND Send(who,@SquaredDistanceTo,#what=oUser) <= (iRange * iRange)
+            AND (Send(who,@SquaredDistanceTo,#what=oUser) <= (iRange * iRange)
+                OR piOldAreaEnchStyle)
          {
             if Send(self,@TargetIsValid,#target=oUser,#caster=who)
             {
@@ -318,21 +388,22 @@ messages:
          }
       }
 
-      Send(who,@StartEnchantment,#what=self,#time=RADIUS_CHECK_TIME,
-          #state=[iElapsed,lEnchanted,iPower,iRange],#Report=FALSE);
-              
-      if ptDrainNow = TRUE
+      if IsClass(who,&User)
+         AND iDrain > 1000
       {
-         if Send(who,@GetMana) >= viManaDrain
+         if Send(who,@GetMana) >= 1
          {
-            Send(who,@LoseMana,#amount=viManaDrain);
-            ptDrainNow = FALSE;
+            Send(who,@LoseMana,#amount=1);
+            iDrain = iDrain - 1000;
          }
          else
          {
-            Send(self,@BreakTrance,#who=who,#state=state,#event=EVENT_STEER);
+            Post(self,@BreakTrance,#who=who,#state=state,#event=EVENT_STEER);
          }
       }
+
+      Send(who,@StartEnchantment,#what=self,#time=RADIUS_CHECK_TIME,
+          #state=[iDrain + (((viManaDrain*1000 / viDrainTime)*1000) / (1000 / RADIUS_CHECK_TIME)),lEnchanted,iPower,iRange],#Report=FALSE);
 
       return;
    }
@@ -347,35 +418,47 @@ messages:
    "If caster runs out of mana or loses trance, spell ends."
    {
       local oUser, oObj, oRoom, lEnchanted;
-            
-      % The spell keeps going if you get damaged, move, cast, or make an attack.
+
+      % The spell keeps going if you get damaged, move, cast, use an item, or make an attack.
+      % Players must rest to end radius spells.
       if event = EVENT_DAMAGE
          OR event = EVENT_ATTACK
          OR event = EVENT_RUN
          OR event = EVENT_DISRUPT
          OR event = EVENT_CAST
+         OR event = EVENT_USE
       {
          return FALSE;
+      }
+      
+      oRoom = Send(who,@GetOwner);
+
+      % Only cancel Persist spells if they are offensive & caster is entering a non-combat room
+      if viCasterPersist
+         AND event = EVENT_NEWOWNER
+      {
+         if oRoom <> $
+            AND NOT (viAffectsEnemies
+                     AND Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT))
+         {
+            return FALSE;
+         }
       }
    
       iPower = Nth(state,3);
 
       % Clean up Trance.
-      Send(who,@ClearTranceFlag);
-      Send(who,@RemoveEnchantment,#what=self);
+      if IsClass(who,&User)
+      {
+         Send(who,@ClearTranceFlag);
+         Send(who,@RemoveEnchantment,#what=self);
+      }
       lEnchanted = Nth(state,2);
       for oUser in lEnchanted
       {
          Send(self,@LeaveRadius,#who=oUser,#iPower=iPower,#caster=who);
-      }
-      
-      oRoom = Send(who,@GetOwner);
-      
-      for oObj in Send(oRoom,@GetplActive)
-      {
-         oUser = Send(oRoom,@HolderExtractObject,#data=oObj);
-
-         if IsClass(oUser,&User)
+         
+         if piOldAreaEnchStyle
          {
             if oUser = who
             {
@@ -390,17 +473,29 @@ messages:
          }
       }
       
-      DeleteTimer(ptDrainTimer);
-      ptDrainTimer=$;
+      if NOT piOldAreaEnchStyle
+      {
+         for oObj in Send(oRoom,@GetplActive)
+         {
+            oUser = Send(oRoom,@HolderExtractObject,#data=oObj);
+
+            if IsClass(oUser,&User)
+            {
+               if oUser = who
+               {
+                  Send(oUser,@MsgSendUser,#message_rsc=radius_ench_caster_ends,#parm1=Send(who,@GetName));
+                  Send(oUser,@ClearFlickerFlag);
+                  Send(oUser,@RecalcFlickerFlag);
+               }
+               else
+               {
+                  Send(oUser,@MsgSendUser,#message_rsc=radius_ench_ends,#parm1=Send(who,@GetName));
+               }
+            }
+         }
+      }
 
       propagate;
-   }
-   
-   DrainTimer(who=$)
-   {
-      ptDrainNow = TRUE;
-      ptDrainTimer = CreateTimer(self,@DrainTimer,viDrainTime);
-      return;
    }
 
    SetSpellPlayerFlag(who=$)
@@ -451,7 +546,13 @@ messages:
    
    GetLightIntensity()
    {
-      return viLightIntensity;
+      return viBaseLightIntensity;
+   }
+
+   % Radius spells that use totems need to naturally time out.
+   GetDuration(iSpellPower=0)
+   {
+      return ((50 + iSpellpower)*1000);
    }
 
    %%%%% Effect Functions
@@ -464,6 +565,26 @@ messages:
    ModifyResistance(attacker=$,atype=-ATCK_SPELL_ALL,iPower=0,caster=$,resistance=$)
    {
       return resistance;
+   }
+
+   ModifyHitRoll(who = $,what = $,hit_roll = $)
+   {
+      return hit_roll;
+   }
+   
+   ModifyDamage(who = $,what = $,damage = $)
+   {
+      return damage;
+   }
+
+   ModifySpellPower(who=$,state=$,oSpell=$,iSpellPower=0)
+   {
+      return iSpellPower;
+   }
+   
+   TryRuinShot(who=$,iSpellPower=0)
+   {
+      return FALSE;
    }
 
 end

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -403,6 +403,9 @@ properties:
 
    % What server-wide flags are we using?
    piServerFlags = 0
+   
+   % A master list of all spell-casting active objects
+   plSpellTotems = $
 
 messages:
 
@@ -518,6 +521,9 @@ messages:
       piRecreate_State = RECREATE_PHASE_ONE;
       Debug("Starting: Recreate phase ONE");
 
+      % Don't leave any active spellcasting objects
+      Send(self,@DeleteAllSpellTotems);
+ 
       Send(self,@RecreateSettings);
       Send(self,@RecreateNecromancerBalance);
       Send(self,@ClearAllQuests);
@@ -6615,6 +6621,41 @@ messages:
    {
       return plBanks;
    }
+
+    AddSpellTotemToServerList(oTotem=$)
+    {
+       if oTotem <> $
+          AND IsClass(oTotem,&RadiusEnchantmentTotem)
+       {
+          plSpellTotems = Cons(oTotem,plSpellTotems);
+       }
+       return;
+    }
+    
+    DeleteSpellTotemFromMasterList(oTotem=$)
+    {
+       if oTotem <> $
+          AND IsClass(oTotem,&RadiusEnchantmentTotem)
+          AND plSpellTotems <> $
+          AND FindListElem(plSpellTotems,oTotem) = 0
+       {
+          plSpellTotems = DelListElem(plSpellTotems,oTotem);
+       }
+       return;
+    }
+    
+    DeleteAllSpellTotems()
+    {
+       local i;
+ 
+       for i in plSpellTotems
+       {
+          Send(i,@Delete);
+       }
+ 
+       return;
+    }
+ 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
Spell Totems are invisible catalysts for Radius Enchantments. They can be used to convert radius spells into old style area enchantments.
