### PR TITLE
Heal wand fix

### DIFF
--- a/kod/object/item/passitem/specwand/healwand.kod
+++ b/kod/object/item/passitem/specwand/healwand.kod
@@ -78,11 +78,12 @@ messages:
 			#parm1=send(apply_on,@getdef),#parm2=send(apply_on,@getname));
 	      return FALSE;
 	   }
-      
-	   if IsClass(apply_on, &User)
-      {
-		   return True;
-      }
+
+   if IsClass(apply_on, &User)
+      AND apply_on = poOwner
+   {
+      return True;
+   }
       Send(poOwner, @MsgSendUser, #message_rsc = wand_fail_rsc);
       Send(poOwner, @WaveSendUser, #wave_rsc = wand_fail_snd);
       return False;


### PR DESCRIPTION
Can only heal wand yourself.

Stops all sorts of shenanigans with whites healing reds, unguildeds healing guildeds, whites healing soldiers, war, you get the idea...
