### PR TITLE
Group Time & Mollusks rebalancing

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/mollusk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/mollusk.kod
@@ -73,12 +73,12 @@ classvars:
    vrDead_name = MolluskMonster_dead_name_rsc
 
    viTreasure_type = TID_MOLLUSK
-   viSpeed = SPEED_VERY_FAST
-   viDefault_behavior = AI_FIGHT_AGGRESSIVE | AI_MOVE_OPTIMAL_RANGE | AI_FIGHT_DEFENDER | AI_FIGHT_THROUGH_WALLS | AI_MOVE_REGROUP | AI_FIGHT_NEWBIESAFE
+   viSpeed = SPEED_FAST
+   viDefault_behavior = AI_MOVE_OPTIMAL_RANGE | AI_FIGHT_NEWBIESAFE
    viAttack_types = ATCK_WEAP_BLUDGEON
 
    viAttributes = 0
-   viLevel = 150
+   viLevel = 140
    viDifficulty = 7
    viKarma = 90
 

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -270,7 +270,7 @@ properties:
    % provided they don't get a monster kill. This adjusts automatically
    % based on the strength of monsters killed in the zone. That implementation
    % will allow us to dynamically change monsters without worrying about additional changes.
-   piGroupTime = 30000
+   piGroupTime = 60000
    
    % A list of players building together
    plBuilderGroup = $
@@ -4100,11 +4100,11 @@ messages:
       {
          % Tusked Skeletons are our base case.
          % With level 100 and difficulty 6, they are the last mob that dies quickly.
-         % We'll give them and everything below 30 second group times.
+         % We'll give them and everything below 60 second group times.
          % Everything above them needs drastically more time as players progress.
          % Special case made for Thrashers, due to the extreme nature of their room.
          
-         piGroupTime = 30000;
+         piGroupTime = 60000;
          
          % 2 additional seconds per mob level point above 100
          % Max +100 seconds for 150 hp mobs
@@ -4115,7 +4115,7 @@ messages:
          piGroupTime = piGroupTime + bound(((Send(victim,@GetDifficulty)-6) * 1000 * 10),0,$);
          
          % Special cases
-         % Extra 2 minutes for thrashers (for 4 minutes 20 seconds total - nobody is muling thrashers)
+         % Extra 2 minutes for thrashers (for 4 minutes 50 seconds total - nobody is muling thrashers)
          If IsClass(victim,&Thrasher)
          {
             piGroupTime = piGroupTime + bound((60 * 1000 * 2),0,$);


### PR DESCRIPTION
Mollusks slowed down, AI toned down, level = 140. Reasoning: due to their boring placement and spawn, they just don't deserve to be 150 mobs.

Group time baseline upped to 60000. All mobs now have 30 more seconds of group time as a result.
