### PR TITLE
Jig does not make players drop token.

### DIFF
--- a/kod/object/item/passitem/token.kod
+++ b/kod/object/item/passitem/token.kod
@@ -285,6 +285,16 @@ messages:
       send(poOwner,@MsgSendUser,#message_rsc=token_use_rsc);
       send(poOwner,@AddExertion,#amount = viVigorDrop/2+Random(0,viVigorDrop/2));
       
+      % This prevents players from hoarding tokens in a safe zone,
+      % making other players unable to retrive the tokens.
+      % Players will drop the token when their vigor drops down to 1
+      
+      if Send(poOwner,@GetVigor) <= 1
+      {
+        Send(poOwner,@TryUnuseItem,#what=self);
+        return;
+      }      
+      
       ptTortureTimer = CreateTimer(self,@TortureHolder,TOKEN_FATIGUE_TIME);
       
       return;

--- a/kod/object/passive/spell/jala/jig.kod
+++ b/kod/object/passive/spell/jala/jig.kod
@@ -124,8 +124,12 @@ messages:
          propagate;
       }
       
-      Send(who,@FreeHands);
-      Send(who,@DoDance);
+      % Jig does not make players drop tokens
+      if Send(who,@FindHolding,#class=&Token) = $
+      {
+         Send(who,@FreeHands);
+         Send(who,@DoDance);
+      }
       
       propagate;
    }


### PR DESCRIPTION
Jig is to powerful and players can to easily steal tokens by casting it
and then cancelling it.

This makes jig no longer causing a player drop a token they are holding
in their hands.
And to stop people from holding onto tokens forever they will drop the
token when they reach 1 vigor.
