### PR TITLE
Fix reflections killing karma.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -360,11 +360,6 @@ messages:
       return 1;
    }
 
-   GetKarma(detect=FALSE)
-   {
-      return Send(poOriginal,@GetKarma);
-   }
-
    GetOffense(what = $, stroke_obj=$)
    {
       return Send(poOriginal,@GetOffense,#what=what,#stroke_obj=stroke_obj);


### PR DESCRIPTION
Reflections no longer get their karma from the caster which makes them default to 0 karma. Mobs with 0 karma don't change your karma when killed.
