### PR TITLE
Killing reflections no longer kills karma

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -360,11 +360,6 @@ messages:
       return 1;
    }
 
-   GetKarma(detect=FALSE)
-   {
-      return Send(poOriginal,@GetKarma);
-   }
-
    GetOffense(what = $, stroke_obj=$)
    {
       return Send(poOriginal,@GetOffense,#what=what,#stroke_obj=stroke_obj);


### PR DESCRIPTION
Reflections default to 0 karma, 0 karma mobs don't cause karma
loss/gain. This is the fixed (branched) pull request, sorry.
