### PR TITLE
No soldier shields for murderers

### DIFF
--- a/kod/object/item/passitem/defmod/shield/soldshld.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld.kod
@@ -54,6 +54,8 @@ resources:
    SoldierShield_lost_status = "Your liege revokes your status as a soldier!"
    SoldierShield_lost_status_nonfaction = \
       "You are not worthy to hold a soldier shield!"
+   SoldierShield_lost_status_murderer = \
+      "As a murderer, you are not worthy to hold a soldier shield!"
    SoldierShield_booted_mail = "Subject: Your soldier status is revoked.\n"
       "I have removed you from my army of soldiers.  I have no use for one so "
       "cowardly as yourself."
@@ -281,6 +283,12 @@ messages:
          Send(self,@ModifyFactionRank,#amount=-1);
          Send(self,@ResetRankLossCount);
       }
+      
+      if Send(poOwner,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
+      {
+         Send(poOwner,@MsgSendUser,#message_rsc=SoldierShield_lost_status_murderer);
+         Post(self,@Delete);
+      }
 
       return;
    }
@@ -376,6 +384,12 @@ messages:
       else
       {
          % Otherwise, the owner shouldn't have the shield.
+         Post(self,@Delete);
+      }
+      
+      if Send(poOwner,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
+      {
+         Send(poOwner,@MsgSendUser,#message_rsc=SoldierShield_lost_status_murderer);
          Post(self,@Delete);
       }
 


### PR DESCRIPTION
An unintended consequence of the removal of faction loss and shield rank
on NPC soldiers is that murderers may have max soldier shields full time
with no consequences.

Unfortunately, murderers are already attackable by anyone, so they
receive soldier shield benefits without soldier shield risks.

This is clearly backwards and inappropriate, creating a situation where
PKs are actually much stronger than hunters, and the proof is in the
pudding (every PK has a full time soldier shield).

It's also a bit silly that murderers who are randomly attacking people
will sometimes have a 'legal' kill just because they're attacking an
innocent with an opposite soldier shield.

This commit changes soldier shields so that murderers may not wield them
or keep them. This is only fair, since **murderers cannot pay the risk
costs associated with a soldier shield, so neither should they receive
the benefits.**

Hunters also cannot typically have soldier shields, as it opens them up
to attack by white PK allies. This way, nobody in the hunter / pk scenario
will have soldier shields, and the shield game can remain largely its own arena.

So please don't think of this as some crazy nerf, but rather a separation
of pk / hunter and the soldier game.
