### PR TITLE
Elusioning to Kocatan is slightly easier.

### DIFF
--- a/kod/object/passive/spell/elusion.kod
+++ b/kod/object/passive/spell/elusion.kod
@@ -197,8 +197,8 @@ messages:
                     
       lAvailable = $;
 
-      % By dividing by 16, this means we need 96+ spellpower to get the Kocatan option.
-      iNumLocations = bound(iSpellPower/16,1,6);
+      % Originally divided by 16 for 96 spellpower, this has been dropped to 84 spellpower for Island (divide by 14)
+      iNumLocations = bound(iSpellPower/14,1,6);
 
       if send(send(target,@GetOwner),@GetRegion) = RID_KOCATAN
          OR iNumLocations = 6


### PR DESCRIPTION
Dropped the spellpower requirement to elusion to Kocatan from 96 to 84. It's still hard if you don't have all the right gear but it's more forgiving if you have a robe and sword plus a shrine or robe/sword/shield.
