### PR TITLE
Send groups now hold 100 names.

### DIFF
--- a/module/merintr/groups.h
+++ b/module/merintr/groups.h
@@ -12,7 +12,7 @@
 #ifndef _GROUPS_H
 #define _GROUPS_H
 
-#define MAX_GROUPSIZE 30  // Maximum number of players in a user-defined group
+#define MAX_GROUPSIZE 100  // Maximum number of players in a user-defined group
 
 #define MAX_NUMGROUPS 30  // Maximum number of user-defined groups
 #define MAX_GROUPNAME 10  // Maximum length of group name


### PR DESCRIPTION
With the amount of characters people have now, in-game communication can
be difficult so I changed max group size from 30 to 100.
