### PR TITLE
New Spawn locs in TR1 + TR2

### DIFF
--- a/kod/object/active/holder/room/monsroom/throne1.kod
+++ b/kod/object/active/holder/room/monsroom/throne1.kod
@@ -42,6 +42,10 @@ properties:
 
    % two minutes (in ms)
    piDispose_delay = 2 * 60 * 1000
+   
+   piMonster_Count_Max = 20
+   piGen_time = 10000
+   piGen_percent = 100
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/throne2.kod
+++ b/kod/object/active/holder/room/monsroom/throne2.kod
@@ -51,6 +51,10 @@ properties:
 
    % two minutes (in ms)
    piDispose_delay = 2 * 60 * 1000
+   
+   piMonster_Count_Max = 20
+   piGen_time = 10000
+   piGen_percent = 100
 
    ptGhost = $
 


### PR DESCRIPTION
Added 3 spawn locations to the top of TR1, directly inside the door, also doubled the spawn speed and max number of mobs from 10 to 20.... There should be no more problems in TR just straight CHAOS.

Added Tusked Skeletons back in with Ghost (Makes sense they would be
guarding him..) and added 6 extra spawn locations directly inside door.

I added the spawn locations and added the tusked skeleton back into TR 2
because TR1 is just simply too crowded at times, this gives people that
want to stay away from the Ghost the ability to stay away from the ghost
and those that want to go into the ghost go there too.....
