### PR TITLE
Reduce the 'cost' of blink

### DIFF
--- a/kod/object/passive/spell/blink.kod
+++ b/kod/object/passive/spell/blink.kod
@@ -36,8 +36,8 @@ classvars:
    viSpell_num = SID_BLINK
    viSpell_level = 1
    viSchool = SS_RIIJA
-   viMana = 15
-   viSpellExertion = 20
+   viMana = 8
+   viSpellExertion = 10
    viChance_To_Increase = 15
 
 properties:


### PR DESCRIPTION
Blink is really a 'utility' spell, it's given to everyone and it's only
'purpose' is to get people un-stuck in the event they are stuck... There
are some added benefits it gives like getting out of caves and getting a
new route from Tos to Jasper... But does it really need to cost 20 vigor
each time its cast?

This pull request just simply reduces the costs of the current blink by
~50% to:

Vigor: 10
Mana: 8
