### PR TITLE
Icky Caves slight spawn increase

### DIFF
--- a/kod/object/active/holder/room/monsroom/objroom/cave2.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/cave2.kod
@@ -41,7 +41,7 @@ properties:
 
    piOutside_factor = OUTDOORS_2
 
-   piGen_time = 38000
+   piGen_time = 35000
    piGen_percent = 80
 
    piGen_Object_Time = 1200000


### PR DESCRIPTION
Slightly increase the spawn speed in icky.

Does not make it harder to get the Chalice, the ratio is still 50/50
spiders to orcs, and there is a max number of monsters, so once all
monster spawns are spiders the room will stop spawning orcs allowing you
to go and get the chalice....
