### PR TITLE
Armor reducer vs monsters

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -1449,7 +1449,7 @@ messages:
 
    GetDefense(what = $, stroke_obj=$)
    "This returns the battler's ability to avoid being hit.  Ranges from "
-   "1 to 3000."
+   "1 to 1500."
    {
       local iDefense;
 


### PR DESCRIPTION
This reduces the damage reduction of armor against monsters when you have low hp to prevent wearing plate and making every monster up until 70hp or so hit for 1 damage.
