### PR TITLE
Defensive Skills Improvement Improvement

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8081,26 +8081,30 @@ messages:
       if Send(self,@CheckPlayerFlag,#flag=PFLAG_DODGED)
          AND NOT group_member_kill
       {
-         dodgeskill = SKID_DODGE;
          oWeapon = Send(self,@LookupPlayerWeapon);
          if oWeapon <> $
             AND (not IsClass(oWeapon,&RangedWeapon))
             AND Send(self,@HasSkill,#num=SKID_PARRY)
             AND Send(self,@GetSkillAbility,#skill_num=SKID_PARRY) < 99
          {
-            dodgeskill=SKID_PARRY;
+            oSkill=Send(SYS,@FindSkillByNum,#num=SKID_PARRY);
+            Send(oSkill,@ImproveAbility,#who=self,#target=poKill_Target);
          }
          
-         if dodgeskill = SKID_DODGE
-            AND (Send(self,@LookupPlayerShield) <> $)
+         if (Send(self,@LookupPlayerShield) <> $)
             AND Send(self,@HasSkill,#num=SKID_BLOCK)
             AND Send(self,@GetSkillAbility,#skill_num=SKID_BLOCK) < 99
          {
-            dodgeskill=SKID_BLOCK;
+            oSkill=Send(SYS,@FindSkillByNum,#num=SKID_BLOCK);
+            Send(oSkill,@ImproveAbility,#who=self,#target=poKill_Target);
          }
          
-         oSkill=Send(sys,@FindSkillByNum,#num=dodgeskill);
-         Send(oSkill,@ImproveAbility,#who=self,#target=poKill_Target);
+         if Send(self,@HasSkill,#num=SKID_DODGE)
+            AND Send(self,@GetSkillAbility,#skill_num=SKID_DODGE) < 99
+         {
+            oSkill=Send(SYS,@FindSkillByNum,#num=SKID_DODGE);
+            Send(oSkill,@ImproveAbility,#who=self,#target=poKill_Target);
+         }
       }
 
       return FALSE;


### PR DESCRIPTION
The former system (where certain defensive skills took priority) was
confusing and unintuitive. Now, all defensive skills may be improved at
the same time.

This means that you may rarely see this:

You killed the tusked skeleton.
_You have improved in the art of block._
_You have improved in the art of dodge._
_You have improved in the art of parry._

However, I don't see this is as a potential problem, because it's
very rare that players have all three of these skills unmaxed
at the same time / for very long, and the difference in imp rates
between the three will ensure block and dodge are maxed
long before parry.

Basically, this just eliminates the confusion and priority issues.
