### PR TITLE
Final Grouping Equation + Solo Builder Bonus

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -7927,44 +7927,12 @@ messages:
                %  or did take damage, did not land killing blow, or
                %  it's a group member kill.
                
-               if group_member_kill
-                  AND Send(self,@GetOwner) <> $
-               {
-                  lBuilderGroup = Send(Send(self,@GetOwner),@GetBuilderGroup);
-                  if lBuilderGroup <> $
-                     AND Length(lBuilderGroup) >= 1
-                  {
-                     % Player will always get 1 xp from a kill target he took damage from.
-                     % This may happen if fighting the same mob, or when fighting thrashers for example.
-                     if poKill_target = what
-                        AND Send(self,@CheckPlayerFlag,#flag=PFLAG_TOOK_DAMAGE)
-                     {
-                        gain = 1;
-                     }
-                     else
-                     {
-                        % Less gains for groups that are too large.
-                        if Length(lBuilderGroup) < 5
-                        {
-                           gain = 1;
-                        }
-                        else
-                        {
-                           % Starting at 5 people, we have a 50% chance to miss group experience.
-                           if Random(1,2) = 1
-                           {
-                              gain = 1;
-                           }
-                        }
-                     }
-                  }
-               }
-               else
-               {
-                  gain = 1;
-               }
+               gain = 1;
 
-               % No roll for kills by others
+               % No roll for kills by others. This puts tension on group size.
+               % As group sizes increase, getting kills oneself becomes difficult.
+               % Groups that are too large create their own advancement problems organically.
+               % Also, this keeps advancement based on the player himself. His own kill rate matters the most.
                if NOT group_member_kill
                {
                   roll = TRUE;
@@ -8013,6 +7981,21 @@ messages:
          if piBase_Max_health < Send(Send(SYS, @GetSettings), @GetPKillEnableHP)
          {
             gain = gain + 1;
+         }
+         else
+         {
+            % Give solo pkill-enabled builders a little bonus.
+            % This will roughly equal building with one other player in the room.
+            % Bonus requires that the player is fighting normally (no firewalls / distance killing)
+            lBuilderGroup = Send(Send(self,@GetOwner),@GetBuilderGroup);
+            if lBuilderGroup <> $
+               AND Length(lBuilderGroup) = 1
+               AND NOT group_member_kill
+               AND killing_blow
+               AND Send(self,@CheckPlayerFlag,#flag=PFLAG_TOOK_DAMAGE)
+            {
+               gain = gain + 1;
+            }
          }
 
          % If they're cheesing the situation by fighting wussy monsters in an altered form,


### PR DESCRIPTION
After much testing, the final grouping equation has been worked out:

All group kills will give 1 xp. There are no diminishing returns and no
artificial restrictions. However, only kills the player himself makes
will give a chance to roll for a tougher. This creates a natural tension
between group size and ability to get kills yourself amid the chaos. The
issue of 10+ players crushing mobs is naturally solved by the fact
that everybody is competing for kills. 3%, 5%, even 10% isn't a very
good chance if you're only getting kills rarely. This contrasts with
the initial grouping system equation, which gave a roll on every
group member kill - players never got past 1% or 2% due to the 
high number of rolls they were receiving, and toughers came way
too fast without any dependency on the player himself. Now, the
player's own kill speed is the most important factor.

Also, a Solo Builder Bonus has been implemented. If you are the only
player building on the screen, you will be given an extra XP per kill as
if you were building with one other person. Thus, building solo and
building with 2 people are now equal. Only the third builder and beyond will
actually increase your building speed. The Solo Builder Bonus
only applies to real fighting - you must take damage, land the killing blow,
and be the only person in the room's group.

The Solo Builder Bonus is mutually exclusive with the Angeled Bonus. You
can only have one or the other, never both.
