### PR TITLE
Soldiers will always spawn

### DIFF
--- a/kod/object/active/flag.kod
+++ b/kod/object/active/flag.kod
@@ -825,8 +825,6 @@ messages:
          return;
       }
 
-      if not send(poOwner,@IsMonsterCountBelowMax) { return; }
-
       oTroop = create(oTroop);
 
       iGenRow = (send(self,@GetRow) + random(-1,1));


### PR DESCRIPTION
Flagpoles now create soldiers without consideration for the room's spawn
count. Flagpoles already have a 'soldier limit' above which they won't
continue creating soldiers. The recent spawn time upgrade made it
impossible for soldiers to appear because flagpoles curtail themselves
unnecessarily. This will fix that.
