### PR TITLE
Logoff ghost change - whites freepen if they haven't attacked anyone in last 15 min

### DIFF
--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -198,6 +198,27 @@ messages:
          return;
       }
 
+	  % Innocents who haven't attacked another player in the last 15 minutes get a free pen and trip to last safespot
+      if Send(Send(SYS,@GetSettings),@GetNoAttackWhiteFreePen)
+      AND ((Send(poGhostedPlayer,@GetLastPlayerAttackTime)+ 900) < GetTime())
+         AND NOT (Send(poGhostedPlayer,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
+         OR Send(poGhostedPlayer,@CheckPlayerFlag,#flag=PFLAG_OUTLAW))
+		 {
+		    if Send(Send(SYS,@GetSettings), @ReturnToSafetyPenaltiesEnabled)
+            {
+	           Send(poGhostedPlayer,@AdminGoToLastSafeRoom);
+            }
+            else
+            {
+	           Send(poGhostedPlayer,@AdminGoToBlink);
+            }
+			
+			% delete the ghost, no penalty
+            Send(self,@Delete);
+			
+			return;
+		 }
+		 
       if Send(SYS,@GetLogoffPenaltyEnable)
       {
          if Send(poGhostedPlayer,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -176,7 +176,10 @@ properties:
 
    % If enabled, logoff penalties do not rise exponentially, and instead remain flat
    pbFlatPenalties = TRUE
-
+   
+   % If enabled, innocents who haven't struck another player will receive a free logoff penalty.
+   pbNoAttackWhiteFreePen = TRUE
+   
 messages:
 
    Constructor(server_num = $)
@@ -437,7 +440,11 @@ messages:
    {
       return piResistRingLoseDurability;
    }
-
+   
+   GetNoAttackWhiteFreePen()
+   {
+      return pbNoAttackWhiteFreePen;
+   }
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
This takes care of several issues:
1) Player logged by monster, nobody around to loot the item but it drops anyway (and disappears).
2) Player is walking around and his house loses power, or internet fault knocks out connection for 10+ minutes, item drops and disappears.
3) Player is jumped by PKs and has no chance to fight back, player was not hostile so he shouldn't drop the item.

My hope is that this will encourage players to build in more remote locations (since they could just log off when finished, provided they haven't attacked anyone), and encourage PKers to not use hold/blind/dazzle straight up on a builder, providing them a chance to fight back if they wish.

Murderers and outlaws of course do not receive the free pen.
