### PR TITLE
PK/H alternative Part 1: Armor improvements

### DIFF
--- a/kod/object/item/passitem/defmod.kod
+++ b/kod/object/item/passitem/defmod.kod
@@ -128,7 +128,6 @@ messages:
       iDamageReduce = 0;
       if piDamage_reduce <> 0
       {
-         iDamageReduce = random(piDamage_reduce/3,piDamage_reduce);
          iDamageReduce = bound(iDamageReduce,0,(damage-1));
       }
 

--- a/kod/object/item/passitem/defmod/armor/chain.kod
+++ b/kod/object/item/passitem/defmod/armor/chain.kod
@@ -59,7 +59,7 @@ messages:
       return [ [ATCK_WEAP_THRUST,5],
                [ATCK_WEAP_PIERCE,25],
                [ATCK_WEAP_BLUDGEON,15],
-               [ATCK_WEAP_SLASH,20]
+               [ATCK_WEAP_SLASH,5]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/armor/leather.kod
+++ b/kod/object/item/passitem/defmod/armor/leather.kod
@@ -46,8 +46,8 @@ classvars:
    vrIcon_male = Leatherarmor_male_icon_rsc
    vrIcon_female = Leatherarmor_female_icon_rsc
 
-   viDefense_base = 50
-   viDamage_base = 0
+   viDefense_base = 200
+   viDamage_base = 1
 
 properties:
    

--- a/kod/object/item/passitem/defmod/armor/plate.kod
+++ b/kod/object/item/passitem/defmod/armor/plate.kod
@@ -45,7 +45,7 @@ classvars:
    vrIcon_female = platearmor_female_icon_rsc
 
    viDefense_base = -200
-   viDamage_base = 6
+   viDamage_base = 8
 
 properties:
 

--- a/kod/object/item/passitem/defmod/armor/scale.kod
+++ b/kod/object/item/passitem/defmod/armor/scale.kod
@@ -58,7 +58,8 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_BLUDGEON,10]
+      return [ [ATCK_WEAP_BLUDGEON,10],
+               [ATCK_WEAP_SLASH,20]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/helmet/ivycircl.kod
+++ b/kod/object/item/passitem/defmod/helmet/ivycircl.kod
@@ -65,8 +65,7 @@ messages:
    GetResistanceModifiers()
    {
       return [ [-ATCK_SPELL_FIRE,-10],
-               [-ATCK_SPELL_SHOCK,20],
-               [-ATCK_SPELL_UNHOLY,20]
+               [-ATCK_SPELL_UNHOLY,-50]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/shield/goldshld.kod
+++ b/kod/object/item/passitem/defmod/shield/goldshld.kod
@@ -46,8 +46,8 @@ classvars:
    viInventory_group = 1
    viBroken_group = 4
 
-   viDefense_base = 10
-   viDamage_base = 1
+   viDefense_base = 20
+   viDamage_base = 2
 
 properties:
 
@@ -55,9 +55,8 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_SLASH,10],
-               [ATCK_WEAP_BLUDGEON,10],
-               [ATCK_WEAP_THRUST,10]
+      return [ [ATCK_WEAP_BLUDGEON,25],
+               [ATCK_WEAP_ALL,10]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/shield/guilshld.kod
+++ b/kod/object/item/passitem/defmod/shield/guilshld.kod
@@ -552,7 +552,7 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_PIERCE,10] ];
+      return [ [ATCK_WEAP_ALL,10] ];
    }
 
    GetBaseSpellModifier(oSpell=$)

--- a/kod/object/item/passitem/defmod/shield/knhtshld.kod
+++ b/kod/object/item/passitem/defmod/shield/knhtshld.kod
@@ -46,7 +46,7 @@ classvars:
    viGround_group = 3
    viInventory_group = 1
 
-   viDefense_base = 15
+   viDefense_base = 20
    viDamage_base = 2
 
 properties:
@@ -55,8 +55,8 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [-ATCK_SPELL_ALL,-20],
-               [ATCK_WEAP_PIERCE,10]
+      return [ [ATCK_WEAP_SLASH,25],
+               [ATCK_WEAP_ALL,10]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/shield/metlshld.kod
+++ b/kod/object/item/passitem/defmod/shield/metlshld.kod
@@ -44,8 +44,8 @@ classvars:
    viGround_group = 3
    viInventory_group = 1
 
-   viDefense_base = 5
-   viDamage_base = 1
+   viDefense_base = 20
+   viDamage_base = 2
 
 properties:
 
@@ -53,7 +53,8 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_SLASH,10]
+      return [ [ATCK_WEAP_THRUST,25],
+               [ATCK_WEAP_ALL,10]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/shield/orcshld.kod
+++ b/kod/object/item/passitem/defmod/shield/orcshld.kod
@@ -86,7 +86,8 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_PIERCE,15],
+      return [ [ATCK_WEAP_PIERCE,25],
+               [ATCK_WEAP_ALL,10],
                [-ATCK_SPELL_HOLY,-20]
              ];
    }

--- a/kod/object/item/passitem/defmod/shield/soldshld/reblshld.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld/reblshld.kod
@@ -153,7 +153,7 @@ messages:
    ModifyDefenseDamage(who = $,what = $,damage = $,atype = 0,aspell = 0)
    "Sets piDamage_reduce for damage reduction in the superclass."
    {
-      % This ranges from 2-4.  At low end, we absorb 0-2 damage.  At high end, 1-4.
+      % This ranges from 2-4.  At low end, we absorb 2 damage.  At high end, 4.
       piDamage_reduce = viDamage_base + ((piFactionRank/3) - 1);
 
       propagate;

--- a/kod/object/item/passitem/defmod/shield/torch.kod
+++ b/kod/object/item/passitem/defmod/shield/torch.kod
@@ -43,8 +43,8 @@ classvars:
    viUse_type = ITEM_USE_HAND
    viUse_amount = 1
 
-   viHits_init_min = 50
-   viHits_init_max = 50
+   viHits_init_min = 450
+   viHits_init_max = 600
 
    viBulk = 10
    viWeight = 10
@@ -54,6 +54,9 @@ classvars:
    viGround_group = 14
    viBroken_group = 14
    viInventory_group = 7
+
+   viDefense_base = 20
+   viDamage_base = 2
 
 properties:
 
@@ -159,12 +162,6 @@ messages:
       Send(poOwner,@TryUnuseItem,#what=self);
 
       propagate;
-   }
-
-   % Torches don't allow you to use block.
-   GetBlockAbility(who = $)
-   {
-      return 0;
    }
 
    GetOverlayHotspot()
@@ -285,6 +282,13 @@ messages:
       }
 
       return 0;
+   }
+
+   GetResistanceModifiers()
+   {
+      return [ [-ATCK_SPELL_COLD,25],
+               [ATCK_WEAP_ALL,10]
+             ];
    }
 
    GetLightEffect()

--- a/kod/object/passive/spell/persench/gort.kod
+++ b/kod/object/passive/spell/persench/gort.kod
@@ -90,7 +90,7 @@ messages:
 
       iSpellPower = Send(who,@GetEnchantedState,#what=self);
       iMax = 15;
-      iAbsorbed = random(0,iSpellPower/25);
+      iAbsorbed = random(0,(iSpellPower+1)/25);
       iAbsorbed = bound(iAbsorbed,1,4);
 
       if aspell <> 0


### PR DESCRIPTION
If people would rather not have #299, a series of organic improvements to
the game can achieve a similar balancing effect. First off is armor.

Armor has been left behind by damage increases. It's just not very good.
It should do far more. In that line of thinking, here are a few rebalances
to get certain situations more in line with what players would expect.
Basically, armor should feel like armor. You should be tanking _something_.
Each armor and shield has a specialty now (very similar to what you 
might expect or already think is true):
- Armor had a random roll between 33% and 100% of its base armor value
  per strike received. That roll has been eliminated, keeping armor's
  damage reduction at 100% at all times. This should help armor feel more
  consistent, and will raise the effectiveness of direct armor values as
  compared to % resistance armor values (which have no such random
  reduction).
- All shields have been given 10% weapon resistance and a specialty.
  These don't stack. You only get 10% OR 25%, whichever is best vs the attack.
  Small round shields have 25% thrust resistance; Gold shields have 25% bludgeon
  resistance; Knight's shields have 25% slash resistance; herald shields'
  specialty remains the ability to give 10 spellpower (they still get 10%
  weapon resistance now); orc shields have 25% pierce resistance. Soldier
  shields get no new bonuses. Orc shields are an interesting case, allowing
  Qors to achieve some measure of protection vs arrows despite being purged.
- All shields have been set to 20 defense and 2 armor base. There's really no
  point in having them be different, since they are all easily obtainable.
- Torches have had their durability dramatically increased, and they can
  now serve as shields and even block. Like other shields, they have 20 def & 2
  armor, and also have 10% weapon resistance, but their specialty, unlike
  the other shields, is elemental: 25% cold resistance. Torches retain
  their 10 spellpower bonus to Faren that I bet you didn't know they had.
- Chain armor had its slash resistance slashed. It remains the best
  anti-arrow armor, but is now more consistently weaker vs melee.
- Scale armor has been given chain armor's slash resistance. It is now
  the best for melee combat against scimitars (20% slash resistance).
- Plate armor had its direct armor upped to 8, from 6. This will keep it
  the best armor for sheer direct damage reduction from all sources (it
  has no % resists, and remains weak to fire and shock).
- Leather armor had its defense raised to 200, and armor to 1. It is now
  a strong 'dodge armor' and/or 'mage armor', since it is the only armor
  with 0 sp penalty. But don't count on it to help you much when you
  do actually get hit.
- Ivy Circlet lost its gratuitous shock resistance. It is now weak to
  Unholy by 50%. Shals will, of course, want to cover this weakness with
  Holy Resolve (up to 65% unholy resist). Resist Magic alone will only
  cover 40% of that weakness. As a reminder, Orc Shields are still weak to
  Holy by 20%. The disparity is due to the fact that Qors can't use Unholy
  Resolve against Shals -- because it gets purged :)

**How will this change things?**

Notably, newbies will be equipped in scale and knight's shields in places
like the Throne Room. Knight's shields are no longer weak to magic by 20%,
and are in fact resistant to slash by 25%. You know what else resists
slash now? Scale armor. Together, a builder will have 45% slash resist.
This should save some newbie butts from PK scimitars. A wise PK will
resort to other weapon types, but, of course, direct surprise damage
isn't nearly so large with weapons like mystics and hammers. On the same
token, veteran PvPers probably won't be running around in scale and
KS since there are better options for endgame PvP, so this is something
largely reserved for builders.

The other option for attackers is to go elemental, something which resist
rings will help with. Getting resist rings out to newbies is something that
will come in another pull request.

The other changes are intended to bring interesting options to what is
otherwise a boring combat mechanic. If shields offer a variety of
interesting roles, then your shield choice actually matters. A meta
may even develop around which shields people prepare with. Slash
is clearly the most damaging weapon type - unless everyone
is using Knight's Shields. Then you may switch to Thrust,
but the battle after that people switch to Small Round Shields.
It's a mess! But maybe it's a good mess. If it doesn't work out,
we can try different roles for shields.
