### PR TITLE
Ghost difficulty reduced slightly

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/ghost.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/ghost.kod
@@ -57,7 +57,7 @@ classvars:
    viTreasure_type = TID_GHOST
    viSpeed = SPEED_FAST
    viLevel = 200
-   viDifficulty = 10
+   viDifficulty = 9
    viKarma = -100
 
    vrSound_hit = ghost_sound_hit


### PR DESCRIPTION
People are complaining that the ghost can wreck them even with full buffs, armor, etc. (tested with 150hp admin toon locally, tend to agree). Reduced difficulty slightly from 10 to 9, so it should wreck people less often.
