### PR TITLE
Buff durations

### DIFF
--- a/kod/object/passive/spell/persench/Eagleyes.kod
+++ b/kod/object/passive/spell/persench/Eagleyes.kod
@@ -95,12 +95,12 @@ messages:
    {
       local iDuration;
 
-      % 2 - 5.3 minutes max.
-      iDuration = 120 + (2 * iSpellPower);
+      % 2 - 8.6 minutes max.
+      iDuration = 120 + (4 * iSpellPower);
       % Convert to ms.
       iDuration = iDuration * 1000;
       
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }   
 
    OfferToNewCharacters()

--- a/kod/object/passive/spell/persench/bless.kod
+++ b/kod/object/passive/spell/persench/bless.kod
@@ -90,7 +90,7 @@ messages:
       % Base duration is 40-640 seconds.
       iDuration = (40 + (iSpellPower*6)) * 1000;
 
-      return Random(iDuration/2,iDuration);
+      return iDuration;
    }
 
    EndEnchantment(who=$, report=TRUE, state=0)

--- a/kod/object/passive/spell/persench/cloak.kod
+++ b/kod/object/passive/spell/persench/cloak.kod
@@ -102,8 +102,8 @@ messages:
    GetDuration(iSpellpower = 0)
    {
       local iDuration;
-      iDuration = (300 + 33*iSpellPower) * 1000;    %%% 5-20 minutes
-      return random(iDuration/2,iDuration);
+      iDuration = (116 + 4*iSpellPower) * 1000;    %%% 2-8.5 minutes
+      return iDuration;
    }
    
 

--- a/kod/object/passive/spell/persench/deflect.kod
+++ b/kod/object/passive/spell/persench/deflect.kod
@@ -103,7 +103,7 @@ messages:
       % 21-119 seconds
       iDuration = (20 + iSpellPower) * 1000;
 
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }
 
    TryDeflect(caster = $, victim = $, oSpell = $)

--- a/kod/object/passive/spell/persench/detevil.kod
+++ b/kod/object/passive/spell/persench/detevil.kod
@@ -95,7 +95,7 @@ messages:
       % 4 - 8 minutes max,
       iDuration = 2400 * (100 + iSpellPower);   
 
-      return Random(iDuration/2,iDuration);
+      return iDuration;
    }
    
    EndEnchantment(who = $, report = TRUE, state = 0)

--- a/kod/object/passive/spell/persench/detgood.kod
+++ b/kod/object/passive/spell/persench/detgood.kod
@@ -90,7 +90,7 @@ messages:
       % 4 - 8 minutes max.
       iDuration = 2400 * (100 + iSpellPower);   
 
-      return Random(iDuration/2,iDuration);
+      return iDuration;
    }
    
    EndEnchantment(who = $, report = TRUE, state = 0)

--- a/kod/object/passive/spell/persench/detinvis.kod
+++ b/kod/object/passive/spell/persench/detinvis.kod
@@ -77,7 +77,7 @@ messages:
       local iDuration;
       iDuration = 2400 * (100 + iSpellPower);   % 4 - 8 minutes max,
       
-      return random(iDuration/2,iDuration);     % randomly choose between max and half-max
+      return iDuration;
    }
    
    EndEnchantment(who = $, report = TRUE, state = 0)

--- a/kod/object/passive/spell/persench/freeact.kod
+++ b/kod/object/passive/spell/persench/freeact.kod
@@ -94,7 +94,7 @@ messages:
       iDuration = 180 + (3 * iSpellPower);   
       iDuration = iDuration * 1000;
       
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }
 
    DoFreeAction(oHoldCaster=$, oTarget=$, iDuration=0)

--- a/kod/object/passive/spell/persench/haste.kod
+++ b/kod/object/passive/spell/persench/haste.kod
@@ -83,7 +83,7 @@ messages:
       iDuration = 5 + ((15 * iSpellPower) / 100);   % 5 - 20 minutes,
       iDuration = iDuration * 1000 * 60;   % Convert to milliseconds
       
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }
 
    GetPotionClass()

--- a/kod/object/passive/spell/persench/invis.kod
+++ b/kod/object/passive/spell/persench/invis.kod
@@ -98,7 +98,7 @@ messages:
       iDuration = 20 + (iSpellPower*2);
       iDuration = iDuration * 1000;
 
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }
 
    GetStateValue(iSpellpower=$)

--- a/kod/object/passive/spell/persench/nightv.kod
+++ b/kod/object/passive/spell/persench/nightv.kod
@@ -74,10 +74,10 @@ messages:
    {
       local iDuration;
       
-      iDuration = 1500 + 25 * iSpellPower;
+      iDuration = 1500 + 10 * iSpellPower;
       iDuration = iDuration * 1000;
       
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }
 
 

--- a/kod/object/passive/spell/persench/resist.kod
+++ b/kod/object/passive/spell/persench/resist.kod
@@ -74,7 +74,7 @@ messages:
       iDuration = 300 + iSpellPower * 3;
       iDuration = iDuration * 1000;	  %% translate to milliseconds
       
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }
 
    EndEnchantment(who = $, report = TRUE, state = -1)

--- a/kod/object/passive/spell/persench/resist/resacid.kod
+++ b/kod/object/passive/spell/persench/resist/resacid.kod
@@ -82,7 +82,7 @@ messages:
       local iDuration;	   %%% 5 to 15 minutes
       iDuration = 300 + iSpellPower * 6;
       iDuration = iDuration * 1000;	  %% translate to milliseconds
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }
 
    GetPotionClass()

--- a/kod/object/passive/spell/persench/resist/rescold.kod
+++ b/kod/object/passive/spell/persench/resist/rescold.kod
@@ -77,7 +77,7 @@ messages:
       local iDuration;	   %%% 5 to 15 minutes
       iDuration = 300 + iSpellPower * 6;
       iDuration = iDuration * 1000;	  %% translate to milliseconds
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }
 
    GetPotionClass()

--- a/kod/object/passive/spell/persench/resist/resevil.kod
+++ b/kod/object/passive/spell/persench/resist/resevil.kod
@@ -78,7 +78,7 @@ messages:
       local iDuration;	   %%% 5 to 15 minutes
       iDuration = 300 + iSpellPower * 6;
       iDuration = iDuration * 1000;	  %% translate to milliseconds
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }
 
    OfferToNewCharacters()

--- a/kod/object/passive/spell/persench/resist/resfire.kod
+++ b/kod/object/passive/spell/persench/resist/resfire.kod
@@ -78,7 +78,7 @@ messages:
       local iDuration;	   %%% 3 to 13 minutes
       iDuration = 180 + iSpellPower * 6;
       iDuration = iDuration * 1000;	  %% translate to milliseconds
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }
 
    GetPotionClass()

--- a/kod/object/passive/spell/persench/resist/resgood.kod
+++ b/kod/object/passive/spell/persench/resist/resgood.kod
@@ -77,7 +77,7 @@ messages:
       local iDuration;	   %%% 5 to 15 minutes
       iDuration = 300 + iSpellPower * 6;
       iDuration = iDuration * 1000;	  %% translate to milliseconds
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }
 
    OfferToNewCharacters()

--- a/kod/object/passive/spell/persench/resist/resmagic.kod
+++ b/kod/object/passive/spell/persench/resist/resmagic.kod
@@ -76,7 +76,7 @@ messages:
       % translate to milliseconds
       iDuration = iDuration * 1000;	  
       
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }
 
    GetPotionClass()

--- a/kod/object/passive/spell/persench/resist/resshock.kod
+++ b/kod/object/passive/spell/persench/resist/resshock.kod
@@ -77,7 +77,7 @@ messages:
       local iDuration;	   %%% 3 to 8 minutes
       iDuration = 180 + iSpellPower * 3;
       iDuration = iDuration * 1000;	  %% translate to milliseconds
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }
 
    GetPotionClass()

--- a/kod/object/passive/spell/persench/respois.kod
+++ b/kod/object/passive/spell/persench/respois.kod
@@ -62,7 +62,7 @@ messages:
       return;
    }
 
-   GetStateValue(iSpellpower=$)
+   GetStateValue(iSpellPower=$)
    {
       local ifactor;    
 
@@ -71,17 +71,16 @@ messages:
       return iFactor;
    }
   
-   GetDuration(iSpellpower = 0)
+   GetDuration(iSpellPower = 0)
    {
       local iDuration;
 
       % 5 - 15 minutes max
-      iDuration = 300 + (100 * 6);
+      iDuration = 300 + (6 * iSpellPower);
       % Convert to ms.
       iDuration = iDuration * 1000;
 
-      % randomly choose between max and half-max
-      return random(iDuration/2,iDuration);     
+      return iDuration;     
    }
 
    OfferToNewCharacters()

--- a/kod/object/passive/spell/persench/strength.kod
+++ b/kod/object/passive/spell/persench/strength.kod
@@ -80,7 +80,7 @@ messages:
       iDuration = 300 + (iSpellpower * 6);
       iDuration = iDuration * 1000;
       
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }
 
    EndEnchantment( who = $, state = 0, report = TRUE )


### PR DESCRIPTION
This fix removes the random component from buff durations, which I believe is responsible for most of what people are complaining about with regards to how long buffs last. In addition, cloak and night vision had their duration lowered, eagle eyes time was raised, and resist poison now correctly checks spellpower instead of assuming 100sp for every cast.

At min-max spellpower, Cloak now lasts 2-8.5 minutes, night vision 25-41 minutes and eagle eyes 2-8.6 minutes.
