### PR TITLE
No reagent use in arena

### DIFF
--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -275,6 +275,9 @@ properties:
    % A list of players building together
    plBuilderGroup = $
 
+   % Flag for reagent use. If set to true, no reagent use in room
+   pbNoreagents = FALSE
+   
 messages:
 
    Constructor()
@@ -4124,5 +4127,10 @@ messages:
       return;
    }
 
+   NoReagents()
+   {
+      return pbNoReagents;
+   }
+   
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/room/tosrm/tosarena.kod
+++ b/kod/object/active/holder/room/tosrm/tosarena.kod
@@ -116,7 +116,8 @@ properties:
 
    pbLocked = FALSE
    pbRealdeath = FALSE
-
+   pbNoReagents = TRUE
+   
 messages:
 
 
@@ -603,7 +604,7 @@ messages:
       Send(self,@SomeoneSaid,#string=TosArena_start_tournament,#type=SAY_MESSAGE,#what=self);
       Send(self,@TeleportToBooth,#who=marshal);
       Send(self,@SomethingWaveRoom,#wave_rsc=TosArena_Fanfare_Sound);
-
+      pbNoReagents = FALSE;
       return;
    }
 
@@ -611,7 +612,7 @@ messages:
    {
       Send(self,@someonesaid,#string=TosArena_end_tournament,#type=SAY_MESSAGE,#what=self);
       Send(self,@SomethingWaveRoom,#wave_rsc=TosArena_Fanfare_Sound);
-      
+      pbNoReagents = TRUE;     
       return;
    }
 

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -626,9 +626,11 @@ messages:
    CanPayReagents(who = $, lTargets = $, iSpellPower = 0)
    {
       local lReagent, cReagentClass, iNumNeeded, bFound, lItems, lLists,
-            oUserObject, iNum, oOwner, oSpell, oRing;
-
+            oUserObject, iNum, oOwner, oSpell, oRing, oRoom;
+      
+      oRoom = Send(who,@GetOwner);
       if Send(who,@PlayerIsImmortal)
+         OR Send(oRoom,@NoReagents)
       {
          return TRUE;
       }


### PR DESCRIPTION
Created a new setting for each room called NoReagents. This is checked whenever casting a spell (defaults to false), but if set to true the spell will cast without reagent use. This flag is turned on in the arena. When an admin starts a royal tournament using the DM command, NoReagents is set to false so tournaments can be held with reagent loss.

Future additions would include an arena mode that players can set to turn reagents on/off themselves. Disclaimer: No red players were harmed in the making of this pull request.
