### PR TITLE
Send guildpassword to guildmaster only

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -1857,7 +1857,7 @@ messages:
       AddPacket(1,BP_USERCOMMAND,1,UC_GUILDINFO);
       AddPacket(6,Send(poGuild,@GetName));
       lHall = Send(poGuild,@GetGuildHall);
-      if lHall <> $
+      if lHall <> $ AND Send(poGuild,@GetRank,#who=self) = RANK_MASTER
       {
          AddPacket(1,1);
          AddPacket(6,Send(poGuild,@GetPassword));


### PR DESCRIPTION
This is a small security fix.

Right now the guildpassword is transferred to any member, including the lowest ranks.
It's just not visible in the original client because the whole "guildmaster" tab is not displayed.

With this fix the password is only transferred to the guildmaster.
