### PR TITLE
Retain selected client group (inventory/spells/skills/stats) after system save!

### DIFF
--- a/clientd3d/client.def
+++ b/clientd3d/client.def
@@ -188,6 +188,8 @@ EXPORTS
 	GetRoomObjectById
 	FindVisibleObjectById
 	GetPlayerInfo
+	SetCurrentGroup
+	GetCurrentGroup	
 
 ; Bitmaps
 	DibOpenFile

--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -49,7 +49,7 @@ typedef unsigned char Bool;
 enum {False = 0, True = 1};
 
 #define MAJOR_REV 50   /* Major version of client program */
-#define MINOR_REV 6  /* Minor version of client program; must be in [0, 99] */
+#define MINOR_REV 7  /* Minor version of client program; must be in [0, 99] */
 
 #define MAXAMOUNT 9     /* Max # of digits in a server integer */
 #define MAXSTRINGLEN 255 /* Max length of a string loaded from string table */

--- a/clientd3d/game.c
+++ b/clientd3d/game.c
@@ -15,6 +15,9 @@ player_info player;
 room_type current_room;
 BOOL dataValid = FALSE;
 
+// si: currently selected group (invent,spells,skills||stats)
+BYTE group = -1;
+
 /* This flag is True before we get the first player info message from the server,
  * and when we're not in the game.  We use it to keep track of entering the game,
  * so that we can load stuff from the INI file only the first time we get a player
@@ -690,4 +693,14 @@ int ComputeObjectDistance(room_contents_node *r1, room_contents_node *r2)
 player_info *GetPlayerInfo(void)
 {
    return &player;
+}
+
+void SetCurrentGroup(BYTE newGroup) 
+{
+	group = newGroup;
+}
+
+BYTE GetCurrentGroup() 
+{
+	return group;
 }

--- a/clientd3d/game.c
+++ b/clientd3d/game.c
@@ -10,13 +10,15 @@
  */
 
 #include "client.h"
+#include "client.h"
 
 player_info player;
 room_type current_room;
 BOOL dataValid = FALSE;
 
 // si: currently selected group (invent,spells,skills||stats)
-BYTE group = -1;
+// 5 == STATS_INVENTORY 
+BYTE group = 5;
 
 /* This flag is True before we get the first player info message from the server,
  * and when we're not in the game.  We use it to keep track of entering the game,

--- a/clientd3d/game.h
+++ b/clientd3d/game.h
@@ -112,4 +112,8 @@ DWORD GetOverrideRoomDepth(int level);
 
 M59EXPORT player_info *GetPlayerInfo(void);
 
+// si : currently selected stat button (inventory,stats,spells,skils...)
+M59EXPORT void SetCurrentGroup(BYTE newGroup);
+M59EXPORT BYTE GetCurrentGroup();
+
 #endif _GAME_H

--- a/module/merintr/merintr.c
+++ b/module/merintr/merintr.c
@@ -1785,3 +1785,18 @@ player_info *GetPlayer(void)
 {
    return GetPlayerInfo();
 }
+
+// si: currently selected stat (inventory/spells/skills/stats...) defined within Game.h/.c
+extern void SetCurrentGroup(BYTE newGroup);
+
+void SetCurrentGroupStub(BYTE newGroup) 
+{
+	SetCurrentGroup(newGroup);	
+}
+
+extern BYTE GetCurrentGroup();
+
+BYTE GetCurrentGroupStub()
+{
+   return GetCurrentGroup();
+}

--- a/module/merintr/merintr.h
+++ b/module/merintr/merintr.h
@@ -100,4 +100,7 @@ extern HINSTANCE hInst;  // module handle
 
 extern player_info *GetPlayer(void);
 
+extern void SetCurrentGroupStub(BYTE newGroup);
+extern BYTE GetCurrentGroupStub();
+
 #endif /* #ifndef _MERINTR_H */

--- a/module/merintr/mermain.c
+++ b/module/merintr/mermain.c
@@ -129,7 +129,7 @@ void InterfaceResizeModule(int xsize, int ysize, AREA *view)
  */
 void InterfaceRedrawModule(HDC hdc)
 {
-	UserAreaRedraw();
+  UserAreaRedraw();
   InterfaceDrawElements(hdc);
   StatsDrawBorder();
   StatsMainRedraw();
@@ -140,6 +140,34 @@ void InterfaceRedrawModule(HDC hdc)
     ShowInventory(TRUE);
     InventoryRedraw();
   }
+  
+  // si: after system save set the correct stat (spells/skills/stats or inventory!)
+  if(GetCurrentGroupStub() != -1 ) 
+  {
+	  if(GetCurrentGroupStub() == STATS_INVENTORY )
+	  {
+		// show users inventory  
+		StatsShowGroup( False );
+		ShowInventory( True );
+		DisplayInventoryAsStatGroup( GetCurrentGroupStub() );
+	  } 
+	  else 
+	  {
+		list_type stat_list;
+		// show stats/skills or spells
+		StatsShowGroup( True );
+		ShowInventory( False );
+		// Check stat cache; if group not present, ask server
+		if (StatCacheGetEntry(GetCurrentGroupStub(), &stat_list) == True)
+			DisplayStatGroup(GetCurrentGroupStub(), stat_list);
+		else
+		{
+			debug(("Resetting selected group to %d\n", GetCurrentGroupStub()));
+			RequestStats(GetCurrentGroupStub());
+		}		
+	  }
+  }
+  
 }
 /****************************************************************************/
 Bool InterfaceDrawItem(HWND hwnd, const DRAWITEMSTRUCT *lpdis)

--- a/module/merintr/statbtn.c
+++ b/module/merintr/statbtn.c
@@ -417,6 +417,10 @@ void StatButtonCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify)
 	group = StatsFindGroupByHwnd(hwndCtl) + 1;  // Skip main stat group
 	if (group == GROUP_NONE)
 		return;
+		
+	// si: record which stat are we currently using (stats/skills/spells or inventory)
+	SetCurrentGroupStub(group);
+	debug(("Player selecting group -> %d\n", group, GetCurrentGroupStub()));		
 
 	if (group != StatsGetCurrentGroup())
 	{


### PR DESCRIPTION
The Meridian 59 client has _always_ reset to the same client side group (skills list) after a system save. This was very annoying during PVP and in general (e.g. to use equipment you would have to use the mouse to reselect the inventory window)! This update persists the most recently selected client group through systems saves and also client logins. This client side operation has annoyed me for a long time and I hope you will agree that this is an important and useful fix!  Implementation wise I have mirrored how the existing GetPlayerInfo method is shared between the meridian client and main library. This update includes a small client version revision and some helpful debugging information.
