### PR TITLE
Guild attack reports by AEs

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -3740,7 +3740,7 @@ messages:
       % Make sure room allows the attack. Check if room has special combat affects.
       if actual = TRUE
          AND NOT Send(oRoom,@ReqSomethingAttack,#what=self,#victim=victim,
-                  #use_weapon=use_weapon,#stroke_obj=stroke_obj,#actual=actual)
+                  #use_weapon=use_weapon,#stroke_obj=stroke_obj,#report=report,#actual=actual)
       {
          return FALSE;
       }


### PR DESCRIPTION
This report boolean need to be passed so players aren't spammed.

Currently Old Style AEs that have been converted to Radius Enchantments will spam if an unguilded is present in a town room. 
