### PR TITLE
Hold duration/post-cast timer modification.

### DIFF
--- a/kod/object/passive/spell/hold.kod
+++ b/kod/object/passive/spell/hold.kod
@@ -198,8 +198,8 @@ messages:
    {
       local iDuration;
 
-      % about 4 - 6 seconds
-      iDuration = 4000 + (20 * iSpellPower);
+      % 2-5 seconds
+      iDuration = 2000 + (30 * iSpellPower);
 
       return iDuration;
    }


### PR DESCRIPTION
Players have noted that Qor is a little underpowered at the moment. This change leaves the maximum duration of hold unchanged (6 seconds), but raises the lower bound from 2 seconds to 4. The random component of hold duration was also removed in line with buff durations. Free action can still lower the duration of the spell. In addition, the post-cast timer for hold was lowered from 2 seconds to 1 second.
