### PR TITLE
Curse weapon overhaul

### DIFF
--- a/kod/object/passive/spell/cursewp.kod
+++ b/kod/object/passive/spell/cursewp.kod
@@ -45,8 +45,9 @@ classvars:
    viSchool = SS_QOR
 
    viSpell_level =4
-   viMana = 14
    viSpellExertion = 10
+   viChance_To_Increase = 20
+
    vrSucceed_wav = CurseWeapon_sound
 
    viOutlaw = TRUE
@@ -54,6 +55,10 @@ classvars:
    viNoNewbieOffense = TRUE
 
 properties:
+
+   viMana = 25
+   viCast_time = 600
+   viPostCast_time = 1     % In seconds
 
 messages:
 


### PR DESCRIPTION
Completely changed this spell - it now targets players instead of weapons. Casting on other players will make you an outlaw (can safely practice on yourself). When cast, the target's weapon will become cursed for 25-35 seconds with a low power curse (damage is affected moderately, hit roll hardly affected). The weapon cannot be removed during this time without remove curse.

The spell now costs 17 mana, takes 10 vigor and is instant cast. As the curse power is dependent on spellpower, casting this spell under AMA will have much less of an effect on the target's weapon. At the present time shroud will not prevent the weapon from being cursed.

Thoughts?

Edit: made a few changes:
Duration of spell lowered to 6-11 seconds based on feedback about the spell being potentially too powerful. Added a debuff icon while the player's weapon is cursed, even if remove curse is cast, so the player won't try to reequip it until the icon disappears. Spell can now be cast on yourself for ease of building.

Shroud won't prevent it being cast, cannot be cast on mobs yet.
