### PR TITLE
Blind duration changes

### DIFF
--- a/kod/object/passive/spell/blind.kod
+++ b/kod/object/passive/spell/blind.kod
@@ -192,7 +192,7 @@ messages:
 
       iDuration = (4 + iSpellPower/6);
 
-      return random((iDuration-2),iDuration);
+      return random((iDuration-3),iDuration);
    }
    
    EndEnchantment(who = $, report = TRUE)


### PR DESCRIPTION
Changed blind duration range from 3-20 sec to 4-12 sec. Changed the spellpower calculation so that it gets an initial time of 4 sec instead of 5 sec, but changed the final iDuration calculation to range from iDuration-3 to iDuration instead of iDuration/2 to iDuration.

Blind times should be more predictable, but not 100% so.
