### PR TITLE
Lowered time for Brax levers to reset

### DIFF
--- a/kod/object/active/holder/room/monsroom/g9.kod
+++ b/kod/object/active/holder/room/monsroom/g9.kod
@@ -54,8 +54,8 @@ constants:
 
    % 2 minutes (time the puzzle stays solved before resetting)
    LIGHTNING_TIMELIMIT = 1000 * 60 * 2
-   % 1 hour (once touched, time the puzzle stays that way before resetting)
-   LIGHTNING_TOUCHEDTIMELIMIT = 1000 * 60 * 60
+   % 5 minutes (once touched, time the puzzle stays that way before resetting)
+   LIGHTNING_TOUCHEDTIMELIMIT = 1000 * 60 * 5
 
    % 2 seconds
    LEVER_REACTIVATE_DELAY = 1000 * 2      


### PR DESCRIPTION
The reset puzzle time was set to one hour. Changed this to 5 minutes.
