### PR TITLE
Rescue pots only for innocents

### DIFF
--- a/kod/object/item/passitem/spelitem/potion/rescuep.kod
+++ b/kod/object/item/passitem/spelitem/potion/rescuep.kod
@@ -21,6 +21,7 @@ resources:
                         "It smells crisp, clean and refreshing."
    RescuePotion_bad_desc_rsc = "This is a glass vial of slightly cloudy colored liquid.  "
                         "A slight whiff of it is enough to turn your stomach."
+   RescuePot_cant_use_pkill = "Only innocents may drink this potion."
 
 
 classvars:
@@ -44,6 +45,24 @@ classvars:
 properties:
 
 messages:
+ 
+   ReqNewApply(what = $, apply_on = $)
+   {
+      if (IsClass(what,&Player))
+      {
+         % Prevent use if you're red. This is because player killers
+         % were using this to escape too easily after kills.
+         if Send(what,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
+         OR Send(what,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
+         {
+            Send(what, @MsgSendUser, #message_rsc = RescuePot_cant_use_pkill);
+            return FALSE;
+         }
+         
+      }
+
+      return TRUE;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
PKs are using these way too frequently to avoid actual PvP so our choices are to either nerf the potions for everyone, or remove the ability for a PK to hide and escape 100% of the time.
