### PR TITLE
Reworked CCs(Blind, Hold, Dazzle) and Purge.

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2117,7 +2117,7 @@
 
    % Constants for spellpower
    SPELLPOWER_MINIMUM = 1
-   SPELLPOWER_MAXIMUM = 99
+   SPELLPOWER_MAXIMUM = 100
 
    %%% Player flags
 

--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -146,7 +146,7 @@ properties:
 
    % list of resistances, Each element is [value, type].
    plResistances = $
-
+	
 messages:
 
    % The first lump of code here deals with resistances and immunities/etc.
@@ -1043,7 +1043,41 @@ messages:
    {
       return;
    }
+	
+	InternalCooldown(spellid=$)
+	{
+		return;
+	}
+	
+	CanCastBlind()
+	{
+		return $;
+	}
+	
+	CanCastDazzle()
+	{
+		return $;
+	}
 
+	CanCastHold()
+	{
+		return $;
+	}
+	
+	DiminishingReturns(spellid=$)
+	{
+		return;
+	}
+	
+	CanBeBlinded()
+	{
+		return 0;
+	}
+	
+	CanBeHeld()
+	{
+		return 0;
+	}
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
@@ -84,8 +84,8 @@ properties:
 
    piHoldAttackChance = 12       % Chance he'll attack with a hold
    piHoldCounterChance = 5    % Chance he'll counter a spell or arrow with a hold
-   piHoldDurationMax = 45  % seconds
-   piHoldDurationMin = 30  % seconds
+   piHoldDurationMax = 45000  % seconds
+   piHoldDurationMin = 30000  % seconds
 
 messages:
 
@@ -323,7 +323,7 @@ messages:
 
       Send(poOwner,@SomethingWaveRoom,#what=self,#wave_rsc=lupoggking_cast_sound);
       Send(self,@DoCast);
-      Send(oSpell,@DoHold,#what=self,#oTarget=oTarget,#iDurationSecs=iRandom);
+      Send(oSpell,@DoHold,#who=self,#oTarget=oTarget,#duration=iRandom);
       Send(oTarget,@MsgSendUser,#message_rsc=lupoggking_cast_spell);
       Send(oTarget,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=iRandom*1000,#xlat=SPIT_COLOR); 
 

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -729,6 +729,9 @@ resources:
    player_truced = "Shal'ille's magic compels you to respect the truce."
    
    Jig_cannot_attack = "It wouldn't feel right to attack the %s while you two are dancing so well together!"
+	
+	denial_death = "Death has caught up with you. Your vision dims..."
+	denial_survived = "You pull through!"
    
 classvars:
 
@@ -1016,6 +1019,9 @@ properties:
 	ptHeld = $
 	piHeld = 0
 
+	% This here is started when a person enters limbo after dropping to 0 from a denial.
+	ptDenialDeathTimer = $
+	
 messages:
 
    Constructor()
@@ -4912,22 +4918,22 @@ messages:
 
       Send(self,@LoseHealth,#amount=damage);
 	  
-	  oWeapon = Send(what,@GetWeapon);
-	     
-	  if IsClass(what,&Monster)
-	  {
-	     RecordStat(STAT_ASSESS_DAM,Send(self,@GetTrueName),Send(what,@GetTrueName),aspell,atype,damage,origdamage,player_monster_attack_string);
-	  }
-	  else
-	  {
-	     if oWeapon <> $
-	     {
-            RecordStat(STAT_ASSESS_DAM,Send(self,@GetTrueName),Send(what,@GetTrueName),aspell,atype,damage,origdamage,Send(Send(what,@GetWeapon),@GetTrueName));
-	     }
-	     else
-	     {
-            RecordStat(STAT_ASSESS_DAM,Send(self,@GetTrueName),Send(what,@GetTrueName),aspell,atype,damage,origdamage,player_no_weapon_string);
-	     }
+		oWeapon = Send(what,@GetWeapon);
+		  
+		if IsClass(what,&Monster)
+		{
+			RecordStat(STAT_ASSESS_DAM,Send(self,@GetTrueName),Send(what,@GetTrueName),aspell,atype,damage,origdamage,player_monster_attack_string);
+		}
+		else
+		{
+			if oWeapon <> $
+			{
+				RecordStat(STAT_ASSESS_DAM,Send(self,@GetTrueName),Send(what,@GetTrueName),aspell,atype,damage,origdamage,Send(Send(what,@GetWeapon),@GetTrueName));
+			}
+			else
+			{
+				RecordStat(STAT_ASSESS_DAM,Send(self,@GetTrueName),Send(what,@GetTrueName),aspell,atype,damage,origdamage,player_no_weapon_string);
+			}
       }
 
       if piHealth <= 0
@@ -6638,32 +6644,32 @@ messages:
    
    GetMight()
    {
-      return bound((piMight + piMightMod/100),1,MAXIMUM_STAT);
+      return bound((piMight + piMightMod),1,MAXIMUM_STAT);
    }
    
    GetIntellect()
    {
-      return bound((piIntellect + piIntellectMod/100),1,MAXIMUM_STAT);
+      return bound((piIntellect + piIntellectMod),1,MAXIMUM_STAT);
    }
    
    GetAgility()
    {
-      return bound((piAgility + piAgilityMod/100),1,MAXIMUM_STAT);
+      return bound((piAgility + piAgilityMod),1,MAXIMUM_STAT);
    }
    
    GetAim()
    {
-      return bound((piAim + piAimMod/100),1,MAXIMUM_STAT);
+      return bound((piAim + piAimMod),1,MAXIMUM_STAT);
    }
    
    GetStamina()
    {
-      return bound((piStamina + piStaminaMod/100),1,MAXIMUM_STAT);
+      return bound((piStamina + piStaminaMod),1,MAXIMUM_STAT);
    }
    
    GetMysticism()
    {
-      return bound((piMysticism + piMysticismMod/100),1,MAXIMUM_STAT);
+      return bound((piMysticism + piMysticismMod),1,MAXIMUM_STAT);
    }
 
    GetRawMight()
@@ -8209,6 +8215,19 @@ messages:
       %  for Portal of Life to reduce penalties.  We get the default value of
       %  piDeathCost from SYS, so that we can adjust global death penalties.
 
+		% Kill the denial death timer in case someone is killed in limbo.
+		% Also allow him to move and fight again.
+		if ptDenialDeathTimer <> $
+		{
+			DeleteTimer(ptDenialDeathTimer);
+			ptDenialDeathTimer = $;
+			
+			Send(self,@SetPlayerFlag,#flag=PFLAG_NO_MOVE,#value=FALSE);
+			Send(self,@SetPlayerFlag,#flag=PFLAG_NO_FIGHT,#value=FALSE);
+			Send(self,@SetPlayerFlag,#flag=PFLAG_NO_MAGIC,#value=FALSE);
+			Send(self,@EffectSendUser,#effect=EFFECT_PARALYZE_OFF);	
+		}
+		
       if Send(self,@GetOwner) <> $
          AND Send(Send(self,@GetOwner),@GetRoomNum) = RID_UNDERWORLD
       {
@@ -13368,6 +13387,36 @@ messages:
 	{
 		return piHeld;
 	}
-
+	
+	StartDenialDeathTimer()
+	{
+		ptDenialDeathTimer = CreateTimer(self,@CutTheThread,10000);
+		
+		return;
+	}
+	
+	CutTheThread()
+	{
+		ptDenialDeathTimer = $;
+		
+		if send(self,@GetHealth) > 0
+		{
+			Send(self,@MsgSendUser,#message_rsc=denial_survived);
+		}
+		else
+		{
+			Send(self,@MsgSendUser,#message_rsc=denial_death);
+			Send(self,@Killed,#what=self);		
+		}
+		
+		% In either case, release the poor bastard.
+		Send(self,@SetPlayerFlag,#flag=PFLAG_NO_MOVE,#value=FALSE);
+		Send(self,@SetPlayerFlag,#flag=PFLAG_NO_FIGHT,#value=FALSE);
+		Send(self,@SetPlayerFlag,#flag=PFLAG_NO_MAGIC,#value=FALSE);
+		Send(self,@EffectSendUser,#effect=EFFECT_PARALYZE_OFF);	
+		
+		return;	
+	}
+	
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1004,6 +1004,17 @@ properties:
 
    % Players will naturally fall out of groups if they aren't getting kills
    ptLeaveBuilderGroupTimer = $
+	
+	% Internal Spell Cooldowns
+	ptBlind = $
+	ptDazzle = $
+	ptHold = $
+	
+	% These 4 properties handle hold and blind diminishing returns.
+	ptBlinded = $
+	piBlinded = 0
+	ptHeld = $
+	piHeld = 0
 
 messages:
 
@@ -6627,32 +6638,32 @@ messages:
    
    GetMight()
    {
-      return bound((piMight + piMightMod),1,MAXIMUM_STAT);
+      return bound((piMight + piMightMod/100),1,MAXIMUM_STAT);
    }
    
    GetIntellect()
    {
-      return bound((piIntellect + piIntellectMod),1,MAXIMUM_STAT);
+      return bound((piIntellect + piIntellectMod/100),1,MAXIMUM_STAT);
    }
    
    GetAgility()
    {
-      return bound((piAgility + piAgilityMod),1,MAXIMUM_STAT);
+      return bound((piAgility + piAgilityMod/100),1,MAXIMUM_STAT);
    }
    
    GetAim()
    {
-      return bound((piAim + piAimMod),1,MAXIMUM_STAT);
+      return bound((piAim + piAimMod/100),1,MAXIMUM_STAT);
    }
    
    GetStamina()
    {
-      return bound((piStamina + piStaminaMod),1,MAXIMUM_STAT);
+      return bound((piStamina + piStaminaMod/100),1,MAXIMUM_STAT);
    }
    
    GetMysticism()
    {
-      return bound((piMysticism + piMysticismMod),1,MAXIMUM_STAT);
+      return bound((piMysticism + piMysticismMod/100),1,MAXIMUM_STAT);
    }
 
    GetRawMight()
@@ -13237,6 +13248,126 @@ messages:
 	   }
 	   return;
    }
+	
+	InternalCooldown(spellid=$)
+	{
+		if spellid = SID_BLIND 
+		{
+			ptBlind = CreateTimer(self,@AllowCastingBlind,30000);
+		}
+		
+		if spellid = SID_DAZZLE
+		{
+			ptDazzle = CreateTimer(self,@AllowCastingDazzle,30000);
+		}
+		
+		if spellid = SID_HOLD
+		{
+			ptHold = CreateTimer(self,@AllowCastingHold,20000);
+		}		
+		return;
+	}
+	
+	AllowCastingBlind()
+	{
+		ptBlind = $;
+		
+		return;
+	}
+	
+	CanCastBlind()
+	{
+		return ptBlind;
+	}
+	
+	GetBlindCooldown()
+	{
+		return gettimeremaining(ptBlind);
+	}
+	
+	AllowCastingDazzle()
+	{
+		ptDazzle = $;
+		
+		return;
+	}
+	
+	CanCastDazzle()
+	{
+		return ptDazzle;
+	}
+
+	GetDazzleCooldown()
+	{
+		return gettimeremaining(ptDazzle);
+	}
+	
+	AllowCastingHold()
+	{
+		ptHold = $;
+		
+		return;
+	}
+	
+	CanCastHold()
+	{
+		return ptHold;
+	}
+	
+	GetHoldCooldown()
+	{
+		return gettimeremaining(ptHold);
+	}
+	
+	DiminishingReturns(spellid=$)
+	{
+		if spellid = SID_BLIND or spellid = SID_DAZZLE
+		{
+			if ptBlinded <> $
+			{
+				DeleteTimer(ptBlinded);
+			}	
+			ptBlinded = CreateTimer(self,@AllowBlindingMe,30000);
+			piBlinded = piBlinded + 1;
+		}
+		
+		if spellid = SID_HOLD
+		{
+			if ptHeld <> $
+			{
+				DeleteTimer(ptHeld);
+			}
+			ptHeld = CreateTimer(self,@AllowHoldingMe,20000);
+			piHeld = piHeld + 1;
+		}		
+		return;
+	}
+	
+	AllowBlindingMe()
+	{
+		ptBlinded = $;
+		piBlinded = 0;
+		
+		return;
+	}
+	
+	CanBeBlinded()
+	{
+		return piBlinded;
+	}
+	
+	AllowHoldingMe()
+	{
+		ptHeld = $;
+		piHeld = 0;
+		
+		return;
+	}
+	
+	CanBeHeld()
+	{
+		return piHeld;
+	}
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2818,7 +2818,7 @@ messages:
       
 	  % 3.2 Get time-deltas
 	  iDelta = iCurrentTime - piLastMoveUpdateTime;
-      iDeltaVigor = iCurrentTime - piLastVigorDrainTime;
+      iDeltaVigor = abs(iCurrentTime - piLastVigorDrainTime);
 	  
 	  % 3.3 Bound time-deltas
 	  % Prevents long teleports after stops and negative numbers
@@ -2968,9 +2968,15 @@ messages:
          
          if Send(self,@CheckPlayerFlag,#flag=PFLAG2_HASTED,#flagset=2)
          {
-            iHasteLevel = Send(self,@GetEnchantedState,
-                               #what=Send(SYS,@FindSpellByNum,#num=SID_HASTE));
-
+				if Send(self,@IsEnchanted,#what=Send(SYS,@FindSpellByNum,#num=SID_HASTE))
+				{
+					iHasteLevel = Send(self,@GetEnchantedState,#what=Send(SYS,@FindSpellByNum,#num=SID_HASTE));
+				}
+				else
+				{
+					iHasteLevel = Send(self,@GetEnchantedState,#what=Send(SYS,@FindSpellByNum,#num=SID_FREE_ACTION));
+				}
+				
             iExertion = (iExertion * (100 - iHasteLevel)) / 100;
          }
 
@@ -3322,7 +3328,10 @@ messages:
       if pbLogged_on
       {
          AddPacket(1,BP_EFFECT,2,effect);
-         Send(what,@SendEffectData,#what=self);
+			if what <> $
+			{
+				Send(what,@SendEffectData,#what=self);
+			}
 
          SendPacket(poSession);
       }

--- a/kod/object/active/holder/room/temprii.kod
+++ b/kod/object/active/holder/room/temprii.kod
@@ -401,7 +401,7 @@ messages:
               #new_row=8,#new_col=6,#new_angle=ANGLE_NORTH);
          send(what,@LoseHealth,#amount=(send(what,@GetHealth)-1));
          send(send(sys,@FindSpellByNum,#num=SID_HOLD),@DoHold,
-              #what=self,#oTarget=what,#iDurationSecs=5,#report=FALSE,#bAllowFreeAction=FALSE);
+              #who=self,#oTarget=what,#duration=5000,#report=FALSE,#bAllowFreeAction=FALSE);
          send(what,@EffectSendUserDuration,#effect=EFFECT_PAIN,#duration=2000);
          send(what,@EffectSendUserXLat,#xlat=0);
          send(what,@EffectSendUser,#what=what,#effect=EFFECT_PARALYZE_OFF);
@@ -415,7 +415,7 @@ messages:
               #where=send(SYS,@FindRoomByNum,#num=RID_KOC_INN),
               #new_row=8,#new_col=6,#new_angle=ANGLE_NORTH);
          send(what,@Losehealth,#amount=(send(what,@GetHealth)-1));
-         send(send(sys,@FindSpellByNum,#num=SID_HOLD),@DoHold,#oTarget=what,#iDurationSecs=30,#report=FALSE);
+         send(send(sys,@FindSpellByNum,#num=SID_HOLD),@DoHold,#who=self,#oTarget=what,#duration=30000,#report=FALSE);
          
          ptDeathMessageTimer = createtimer(self,@TimerMessage1,5000); 
       }

--- a/kod/object/active/wallelem/asburstc.kod
+++ b/kod/object/active/wallelem/asburstc.kod
@@ -66,8 +66,7 @@ messages:
 
       oSpell = Send(SYS,@FindSpellByNum,#num=SID_HOLD);
 
-      Send(oSpell,@DoHold,#what=self,#otarget=what,
-           #iDurationSecs=BASE_HOLD_DURATION+piBonus);
+      Send(oSpell,@DoHold,#who=self,#otarget=what,#duration=(BASE_HOLD_DURATION+piBonus)*1000);
 
       propagate;
    }   

--- a/kod/object/passive/sickness/poison.kod
+++ b/kod/object/passive/sickness/poison.kod
@@ -59,7 +59,7 @@ messages:
       oSpell = send(SYS,@Findspellbynum,#num=SID_RESIST_POISON);
       if send(who,@isenchanted,#what=oSpell)
       {
-         if (Random(1,100) < send(who,@GetEnchantedState,#what=oSpell))
+         if (Random(1,100) < send(who,@GetEnchantedState,#what=oSpell)/2)
          { 
             send(who,@MsgSendUser,#message_rsc=poison_kraanan);
             return; 

--- a/kod/object/passive/sickness/poison.kod
+++ b/kod/object/passive/sickness/poison.kod
@@ -59,7 +59,7 @@ messages:
       oSpell = send(SYS,@Findspellbynum,#num=SID_RESIST_POISON);
       if send(who,@isenchanted,#what=oSpell)
       {
-         if (Random(1,100) < send(who,@GetEnchantedState,#what=oSpell)/2)
+         if (Random(1,100) < send(who,@GetEnchantedState,#what=oSpell))
          { 
             send(who,@MsgSendUser,#message_rsc=poison_kraanan);
             return; 

--- a/kod/object/passive/skill/disarm.kod
+++ b/kod/object/passive/skill/disarm.kod
@@ -179,8 +179,8 @@ messages:
          % The better you are, the better your weapon, the longer your stun is.
          % The bigger the monster is, the shorter the stun is.
          % Stun between 2 and 6 seconds.
-         iAbil = bound((iAbil + iModifier - Send(oTarget,@GetLevel)/2)/10,2,6);
-         Send(oHoldSpell,@DoHold,#what=who,#otarget=oTarget,#idurationsecs=iAbil,#report=FALSE);
+         iAbil = bound((iAbil + iModifier - Send(oTarget,@GetLevel)/2)*100,2000,6000);
+         Send(oHoldSpell,@DoHold,#who=who,#otarget=oTarget,#duration=iAbil,#report=FALSE);
       }
 
       propagate;

--- a/kod/object/passive/spell/Dazzle.kod
+++ b/kod/object/passive/spell/Dazzle.kod
@@ -27,6 +27,9 @@ resources:
 
    Dazzle_on = "The world is washed away in a flood of pure light."
    Dazzle_off = "Your vision begins to clear."
+	Dazzle_cannot_cast_yet = "You can use the dazzle spell again in %i seconds."
+	Dazzle_victim_immune_caster = "Your target has temporarily grown immune to vision impairing effects!"
+	Dazzle_victim_immune_target = "You have temporarily grown immune to vision impairing effects!"
 
    Dazzle_sound = sDazzle.wav
 
@@ -39,10 +42,11 @@ classvars:
    viSpell_num = SID_DAZZLE
    viSchool = SS_SHALILLE
    viSpell_level = 4
-   viMana = 12
+   viMana = 10
    viChance_To_Increase = 15
 
-   viSpellExertion = 6
+   viSpellExertion = 0
+	viPostCast_time = 0
 
    viOutlaw = TRUE
    viHarmful = TRUE
@@ -71,6 +75,13 @@ messages:
    CanPayCosts(who = $, lTargets = $, bItemCast = FALSE)
    {
       local target, i;
+		
+		% Can't cast if we are on internal cooldown.
+		if Send(who,@CanCastDazzle) <> $
+      {
+			Send(who,@MsgSendUser,#message_rsc=Dazzle_cannot_cast_yet,#parm1=Send(who,@GetDazzleCooldown)/1000);
+         return FALSE;
+      }
       
       % Can cast spell if the 1 target item is a user
       if Length(lTargets) <> 1
@@ -122,41 +133,76 @@ messages:
       local oTarget, iDuration;
 
       oTarget = First(lTargets);
-      iDuration = Send(self,@GetDuration,#iSpellPower=iSpellPower,
-                       #caster=who,#target=otarget);
+		
+      iDuration = Send(self,@GetDuration,#iSpellPower=iSpellPower,#caster=who,#target=otarget);
 
-      Send(self,@DoDazzle,#what=who,#oTarget=oTarget,#iDurationSecs=iDuration);
+      % Spell effects
+      Send(self,@DoDazzle,#who=who,#oTarget=oTarget,#duration=iDuration);
+		
+		% Internal Cooldown
+		Send(who,@InternalCooldown,#spellid=viSpell_num);
       
       propagate;
    }
 
-   DoDazzle(what=$,oTarget=$,iDurationSecs=0)
+   DoDazzle(who=$,oTarget=$,duration=0)
    {
-      local oSpell, iDuration;
+      local iBlinded, oSpell;
 
-      iDuration = iDurationSecs;
+		% Let's see if the spell is suffering from diminishing returns.
+		iBlinded = Send(oTarget,@CanBeBlinded);
+		
+		if iBlinded > 0
+		{
+			duration = duration / 2;
+			
+			if iBlinded > 1
+			{
+				duration = duration / 2;
+				
+				if iBlinded > 2
+				{
+					% Target has grown immune to dazzle.
+					if who <> $
+					{
+						Send(who,@MsgSendUser,#message_rsc=Dazzle_victim_immune_caster);
+					}
+					Send(oTarget,@MsgSendUser,#message_rsc=Dazzle_victim_immune_target);
+					
+					return;
+				}
+			}
+		}
+
+		% Increase the diminishing returns counter by 1.
+		Send(oTarget,@DiminishingReturns,#spellid=viSpell_num);
      
+		% Reduce duration based on eagle eyes.
       oSpell = Send(SYS,@FindSpellByNum,#NUM=SID_EAGLE_EYES);
       if Send(oTarget,@IsEnchanted,#what=oSpell)
       {
-         iDuration = Send(oSpell,@DoEagleEyes,#oCaster=what,#oTarget=oTarget,
-                          #iDuration=iDuration,#iFactor=2);
-         if iDuration = $
-         {
-            % Resisted completely.
-            return;
-         }
+         duration = Send(oSpell,@DoEagleEyes,#oCaster=who,#oTarget=oTarget,#duration=duration);
       }
 
-      % Convert duration to milliseconds
-      iDuration = bound(iDuration,3,15);
-      iDuration = iDuration * 1000;
+		if duration = 0
+		{
+			% Resisted completely.
+			return;
+		}
+		
+      % Bound
+      duration = bound(duration,2000,$);
+
+      Send(oTarget,@StartEnchantment,#what=self,#time=duration);
 
       if IsClass(oTarget,&Player)
       {
-         Send(oTarget,@MsgSendUser,#message_rsc=Dazzle_on);
-         Send(oTarget,@EffectSendUserDuration,#effect=EFFECT_WHITEOUT,
-              #duration=iDuration);
+         % Do not dazzle DMs.
+         if NOT (IsClass(oTarget,&DM) AND Send(oTarget,@PlayerIsImmortal))
+         {		
+				Send(oTarget,@MsgSendUser,#message_rsc=Dazzle_on);
+				Send(oTarget,@EffectSendUserDuration,#effect=EFFECT_WHITEOUT,#duration=duration);
+			}
       }
       else
       {
@@ -164,33 +210,22 @@ messages:
          Post(oTarget,@ResetBehaviorFlags);
       }
 
-      Send(what,@MsgSendUser,#message_rsc=Dazzle_caster,
-           #parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
-      Send(oTarget,@StartEnchantment,#what=self,#time=iDuration);
+      if IsClass(who,&Player)
+		{
+			Send(who,@MsgSendUser,#message_rsc=Dazzle_caster,#parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
+		}
 
       return;
    }
 
-   GetDuration(iSpellPower=0,caster=$,target=$)
+   GetDuration(iSpellPower=0,target=$)
    {
-      local iDuration,iKarmaDif,iKarma;
+      local iDuration;
 
-      % 1-8 seconds based on spellpower.
-      iDuration = (iSpellPower/12);
-      if IsClass(caster,&Battler)
-      {
-         iKarma = Send(caster,@GetKarma);
-      }
-      else
-      {
-         % Non battlers, like the sun
-         iKarma = random(30,90);
-      }
-
-       % 1-10 seconds based on Karma difference.
-      iKarmaDif = (iKarma - Send(target,@GetKarma,#detect=TRUE))/20;
-      iDuration = bound(iDuration + iKarmaDif,3,15);  
-
+      % 4 to 8 seconds based on spellpower and between -2 and +2 seconds depending on the target's karma.
+      iDuration = 4000 + iSpellPower * 40 - 20 * Send(target,@GetKarma,#detect=TRUE);
+		iDuration = bound(iDuration,2000,8000);
+		
       return iDuration;
    }
    
@@ -203,14 +238,14 @@ messages:
             Send(who,@MsgSendUser,#message_rsc=Dazzle_off);
          }
 
-         Send(who,@EffectSendUserDuration,#effect=EFFECT_PAIN,#duration=8000);
+         Send(who,@EffectSendUserDuration,#effect=EFFECT_PAIN,#duration=2000);
          Send(who,@EffectSendUserXLat,#xlat=0);
-      } 
-      else  
+      }
+      else
       {
          % Class is monster
          % Post this so it's done AFTER the enchantment is gone from the
-         %  monster's ench list
+         % monster's ench list
          Post(who,@ResetBehaviorFlags);
       }
      

--- a/kod/object/passive/spell/Dazzle.kod
+++ b/kod/object/passive/spell/Dazzle.kod
@@ -222,8 +222,9 @@ messages:
    {
       local iDuration;
 
-      % 4 to 8 seconds based on spellpower and between -2 and +2 seconds depending on the target's karma.
-      iDuration = 4000 + iSpellPower * 40 - 20 * Send(target,@GetKarma,#detect=TRUE);
+      % 4 to 8 seconds based on spellpower and up to a 2 seconds bonus depending on the target's karma,
+		% to compensate for low spellpower. Capped at 8 seconds.
+      iDuration = 4000 + iSpellPower * 40 + 20 * bound(-Send(target,@GetKarma,#detect=TRUE),0,100);
 		iDuration = bound(iDuration,2000,8000);
 		
       return iDuration;

--- a/kod/object/passive/spell/blind.kod
+++ b/kod/object/passive/spell/blind.kod
@@ -30,6 +30,9 @@ resources:
       "Something burns in your eyes, causing excruciating pain and a loss "
       "of vision."
    blind_off = "Your eyes begin to function again."
+	blind_cannot_cast_yet = "You can use the blind spell again in %i seconds."
+	blind_victim_immune_caster = "Your target has temporarily grown immune to vision impairing effects!"
+	blind_victim_immune_target = "You have temporarily grown immune to vision impairing effects!"
 
    blind_sound = qblind.wav
 
@@ -42,10 +45,11 @@ classvars:
    viSpell_num = SID_BLIND
    viSchool = SS_QOR
    viSpell_level = 5
-   viMana = 15
+   viMana = 10
    viChance_To_Increase = 15
+	viPostCast_time = 0
 
-   viSpellExertion = 6
+   viSpellExertion = 0
 
    viOutlaw = TRUE
    viHarmful = TRUE
@@ -86,6 +90,13 @@ messages:
    CanPayCosts(who = $, lTargets = $, bItemCast = FALSE)
    {
       local target, i;
+		
+		% Can't cast if we are on internal cooldown.
+		if Send(who,@CanCastBlind) <> $
+      {
+			Send(who,@MsgSendUser,#message_rsc=blind_cannot_cast_yet,#parm1=Send(who,@GetBlindCooldown)/1000);
+         return FALSE;
+      }
       
       % Can cast spell if the 1 target item is a user
       if Length(lTargets) <> 1
@@ -132,41 +143,74 @@ messages:
 
    CastSpell(who = $, lTargets = $, iSpellPower = 0)
    {
-      local oTarget;
+      local oTarget, iDuration;
 
       oTarget = First(lTargets);
+		
+		iDuration = Send(self,@GetDuration,#iSpellPower=iSpellPower,#target=oTarget);
 
       % Spell effects
-      Send(self,@DoBlind,#what=who,#oTarget=oTarget,
-           #iDurationSecs=Send(self,@GetDuration,#iSpellPower=iSpellPower));
+      Send(self,@DoBlind,#who=who,#oTarget=oTarget,#duration=iDuration);
+		
+		% Internal Cooldown
+		Send(who,@InternalCooldown,#spellid=viSpell_num);
       
       propagate;
    }
 
-   DoBlind(what=$,oTarget=$,iDurationSecs=0)
+   DoBlind(who=$,oTarget=$,duration=0)
    {
-      local oSpell, iDuration;
+      local iBlinded, oSpell;
 
-      iDuration = iDurationSecs;
-      
+		% Let's see if the spell is suffering from diminishing returns.
+		iBlinded = Send(oTarget,@CanBeBlinded);
+		
+		if iBlinded > 0
+		{
+			duration = duration / 2;
+			
+			if iBlinded > 1
+			{
+				duration = duration / 2;
+				
+				if iBlinded > 2
+				{
+					% Target has grown immune to blind.
+					if who <> $
+					{
+						Send(who,@MsgSendUser,#message_rsc=blind_victim_immune_caster);
+					}
+					Send(oTarget,@MsgSendUser,#message_rsc=blind_victim_immune_target);
+					
+					return;
+				}
+			}
+		}
+		
+		% Increase the diminishing returns counter by 1.
+		Send(oTarget,@DiminishingReturns,#spellid=viSpell_num);
+		
+		% Reduce duration based on eagle eyes.
       oSpell = Send(SYS,@FindSpellByNum,#NUM=SID_EAGLE_EYES);
       if Send(oTarget,@IsEnchanted,#what=oSpell)
       {
-         iDuration = Send(oSpell,@DoEagleEyes,#oCaster=what,#oTarget=oTarget,
-                          #iDuration=iDuration);
-         if iDuration = $
-         {
-            % Resisted completely.
-            return;
-         }
+         duration = Send(oSpell,@DoEagleEyes,#oCaster=who,#oTarget=oTarget,#duration=duration);
       }
 
-      % Bound and convert duration to milliseconds
-      iDuration = bound(iDuration,3,20);
-      iDuration = iDuration * 1000;
+		if duration = 0
+		{
+			% Resisted completely.
+			return;
+		}
+
+      % Bound
+      duration = bound(duration,2000,$);
+		
+      Send(oTarget,@StartEnchantment,#what=self,#time=duration);
 
       if IsClass(oTarget,&Player)
       {
+			% Do not blind DMs.
          if NOT (IsClass(oTarget,&DM) AND Send(oTarget,@PlayerIsImmortal))
          {
             Send(oTarget,@MsgSendUser,#message_rsc=blind_on);
@@ -178,21 +222,24 @@ messages:
          % class is Monster
          Post(oTarget,@ResetBehaviorFlags);
       }
-
-      Send(what,@MsgSendUser,#message_rsc=blind_caster,
-           #parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
-      Send(oTarget,@StartEnchantment,#what=self,#time=iDuration);
+		
+      if IsClass(who,&Player)
+		{
+			Send(who,@MsgSendUser,#message_rsc=blind_caster,#parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
+		}
 
       return;
    }
 
-   GetDuration(iSpellPower=0)
+   GetDuration(iSpellPower=0,target=$)
    {
       local iDuration;
 
-      iDuration = (5 + iSpellPower/6);
-
-      return random(iDuration/2,iDuration);
+      % 5 to 10 seconds based on spellpower and between -2 and +2 seconds depending on the target's karma.
+      iDuration = 5000 + iSpellPower * 50 - 20 * Send(target,@GetKarma,#detect=TRUE);
+		iDuration = bound(iDuration,3000,10000);
+		
+      return iDuration;
    }
    
    EndEnchantment(who = $, report = TRUE)
@@ -224,7 +271,7 @@ messages:
    RestartEnchantmentEffect(who=$,state=$)
    {
       Send(who,@MsgSendUser,#message_rsc=blind_on);
-      Send(who,@EffectSendUser, #what=self, #effect=EFFECT_BLIND_ON);
+		Send(who,@EffectSendUser, #what=self, #effect=EFFECT_BLIND_ON);
       
       return;
    }

--- a/kod/object/passive/spell/blind.kod
+++ b/kod/object/passive/spell/blind.kod
@@ -235,8 +235,9 @@ messages:
    {
       local iDuration;
 
-      % 5 to 10 seconds based on spellpower and between -2 and +2 seconds depending on the target's karma.
-      iDuration = 5000 + iSpellPower * 50 - 20 * Send(target,@GetKarma,#detect=TRUE);
+      % 5 to 10 seconds based on spellpower and up to a 2 seconds bonus depending on the target's karma,
+		% to compensate for low spellpower. Capped at 10 seconds.
+      iDuration = 5000 + iSpellPower * 50 + 20 * bound(Send(target,@GetKarma,#detect=TRUE),0,100);
 		iDuration = bound(iDuration,3000,10000);
 		
       return iDuration;

--- a/kod/object/passive/spell/flash.kod
+++ b/kod/object/passive/spell/flash.kod
@@ -117,7 +117,7 @@ messages:
          else
          {
             % Is a monster, stun it.
-            send(oHold,@DoHold,#what=who,#otarget=i,#iDurationSecs=1,#bAllowFreeAction=FALSE);
+            send(oHold,@DoHold,#who=who,#otarget=i,#duration=3000,#bAllowFreeAction=FALSE);
          }
       }
       

--- a/kod/object/passive/spell/hold.kod
+++ b/kod/object/passive/spell/hold.kod
@@ -24,9 +24,12 @@ resources:
       "Requires purple mushrooms to cast."
    
    hold_already_enchanted = "%s%s is already held."
-   hold_caster = "%s%s is now held in place by a magical force."
+   hold_caster = "%s%s stops dead in %s tracks."
    hold_on = "A magical tingling pulses through your body.  You are unable to move."
    hold_off = "The magical hold lifts and you are able to move once more."
+	hold_cannot_cast_yet = "You can use the hold spell again in %i seconds."
+	hold_victim_immune_caster = "Your target has temporarily grown immune to movement impairing effects!"
+	hold_victim_immune_target = "You have temporarily grown immune to movement impairing effects!"
 
 classvars:
 
@@ -38,8 +41,9 @@ classvars:
    viSchool = SS_QOR
    viSpell_level = 4
 
-   viSpellExertion = 8
-   viMana = 15
+   viSpellExertion = 0
+   viMana = 10
+	viPostCast_time = 0
 
    viHarmful = TRUE
    viOutlaw = TRUE
@@ -72,6 +76,13 @@ messages:
    CanPayCosts(who = $, lTargets = $, bItemCast = FALSE)
    {
       local target, i;
+		
+		% Can't cast if we are on internal cooldown.
+		if Send(who,@CanCastHold) <> $
+      {
+			Send(who,@MsgSendUser,#message_rsc=hold_cannot_cast_yet,#parm1=Send(who,@GetHoldCooldown)/1000);
+         return FALSE;
+      }
       
       % Can cast spell if the 1 target item is a user
       if Length(lTargets) <> 1
@@ -119,44 +130,17 @@ messages:
 
    CastSpell(who=$, lTargets=$, iSpellpower=0)
    {
-      local oTarget,oSpell,iDuration;
+      local oTarget,iDuration;
 
       oTarget = First(lTargets);
+		
       iDuration = Send(self,@GetDuration,#ispellPower=iSpellPower);
 
-      oSpell = Send(SYS,@FindSpellByNum,#num=SID_FREE_ACTION);
-
-      % Check if the target has free action
-      if Send(oTarget,@IsEnchanted,#what=oSpell)
-      {
-         iDuration = Send(oSpell,@DoFreeAction,#oHoldCaster=who,
-                          #oTarget=oTarget,#iDuration=iDuration);
-         if iDuration = $
-         {
-            % Resisted completely
-            propagate;
-         }
-      }
-
-      Send(who,@MsgSendUser,#message_rsc=hold_caster,
-           #parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
-      Send(oTarget,@StartEnchantment,#what=self,#time=iDuration,#state=TRUE);
-
-      if IsClass(oTarget,&Player)
-      {
-         Send(oTarget,@MsgSendUser,#message_rsc=hold_on);    
-
-         % Do not paralyze DMs.
-         if NOT (IsClass(oTarget,&DM) AND Send(oTarget,@PlayerIsImmortal))
-         {
-            Send(oTarget,@EffectSendUser,#what=self,#effect=EFFECT_PARALYZE_ON);
-         }
-      }
-      else  
-      {
-         % class is &Monster
-         Send(oTarget,@ResetBehaviorFlags);
-      }
+		% Spell effects
+      Send(self,@DoHold,#who=who,#oTarget=oTarget,#duration=iDuration);
+		
+		% Internal Cooldown
+		Send(who,@InternalCooldown,#spellid=viSpell_num);
       
       propagate;
    }
@@ -198,66 +182,78 @@ messages:
    {
       local iDuration;
 
-      % about 2 - 6 seconds
-      iDuration = 2000 + (40 * iSpellPower);
+      % 3 to 6 seconds based on SP.
+      iDuration = 3000 + iSpellPower * 30;
 
-      return random(iDuration/2,iDuration);
+      return iDuration;
    }
 
-   DoHold(what = $, otarget = $, iDurationSecs = $, iDuration = $, report=TRUE,
-          bAllowFreeAction=TRUE)   
+   DoHold(who = $, otarget = $, duration = $, report=TRUE, bAllowFreeAction=TRUE)   
    "Holds target for durationsecs seconds."
    {
-      local i, oSpell, iTotalDuration;
-            
+      local i, oSpell, iTotalDuration, iHeld;
+		
+		% Deal with nil arguments being passed on.
       if otarget = $
       {
          return FALSE;
       }
-
-      % check for enchantment already applied
+		
+      % Check if the target is held here since Hold is also applied by other objects than the spell itself.
       if Send(otarget,@IsEnchanted,#what=self)
       {
          return FALSE;
       }
+	
+		% Let's see if the spell is suffering from diminishing returns.
+		iHeld = Send(oTarget,@CanBeHeld);
+		
+		if iHeld > 0
+		{
+			duration = duration / 2;
+			
+			if iHeld > 1
+			{
+				duration = duration / 2;
+				
+				if iHeld > 2
+				{
+					% Target has grown immune to hold.
+					if who <> $
+					{
+						Send(who,@MsgSendUser,#message_rsc=hold_victim_immune_caster);
+					}
+					Send(oTarget,@MsgSendUser,#message_rsc=hold_victim_immune_target);
+					
+					return;
+				}
+			}
+		}
 
-      % Use iDuration (in ms).  If it is nil, then covert iDurationSecs to ms.
-      if iDuration = $
-      {
-         if iDurationSecs = $
-         {
-            iTotalDuration = 5000;
-         }
-         else
-         {
-            iTotalDuration = iDurationSecs * 1000;
-         }
-      }
-      else
-      {
-         iTotalDuration = iDuration;
-      }
-
-      % check if the target has free action unless not allowed
+		% Increase the diminishing returns counter by 1.
+		Send(oTarget,@DiminishingReturns,#spellid=viSpell_num);
+		
+      % Check if the target has free action unless not allowed.
       if bAllowFreeAction
       {
-         oSpell = Send(SYS,@FindSpellByNum,#num=SID_FREE_ACTION);
-         if Send(otarget,@IsEnchanted,#what=oSpell)
-         {
-            iTotalDuration = Send(oSpell,@DoFreeAction,#oHoldCaster=what,
-                                  #oTarget=oTarget,#iDuration=iTotalDuration);
-            if iTotalDuration = $
-            {
-               % Resisted completely
-               return FALSE;
-            }
-         
-            iTotalDuration = bound(iTotalDuration,500,10000);
-         }
-      }
+			% Reduce duration based on free action.
+			oSpell = Send(SYS,@FindSpellByNum,#num=SID_FREE_ACTION);
+			if Send(oTarget,@IsEnchanted,#what=oSpell)
+			{
+				duration = Send(oSpell,@DoFreeAction,#oCaster=who,#oTarget=oTarget,#duration=duration);
+			}
+		}
+		
+		if duration = 0
+		{
+			% Resisted completely.
+			return;
+		}
+		
+      % Bound
+      duration = bound(duration,2000,$);
 
-      Send(oTarget,@StartEnchantment,#what=self,#time=iTotalDuration,
-           #report=report,#state=report);
+      Send(oTarget,@StartEnchantment,#what=self,#time=duration,#report=report,#state=report);
 
       if IsClass(oTarget,&Player)
       {
@@ -276,6 +272,11 @@ messages:
       {
          Send(oTarget,@ResetBehaviorFlags);
       }
+		
+      if IsClass(who,&Player)
+		{
+			Send(who,@MsgSendUser,#message_rsc=hold_caster,#parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName),#parm3=Send(oTarget,@GetHisHer));
+		}
       
       return;
    }

--- a/kod/object/passive/spell/persench.kod
+++ b/kod/object/passive/spell/persench.kod
@@ -54,6 +54,9 @@ classvars:
    vbCanCastonMonsters = FALSE 
 
    viPersonal_ench = TRUE
+	
+	% It is viPurge_factor times as hard to purge the spell.
+	viPurge_factor = 1
 
 properties:
 
@@ -249,7 +252,11 @@ messages:
    {
       return defense_power;
    }
-
+	
+	GetPurgeFactor()
+	{
+		return viPurge_factor;
+	}
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/persench/Eagleyes.kod
+++ b/kod/object/passive/spell/persench/Eagleyes.kod
@@ -74,20 +74,25 @@ messages:
       return;
    }
 
-   GetStateValue(who=$,iSpellpower=$,target = $)
+   GetStateValue(who = $, iSpellPower = 0, target = $)
    {
-      local iFactor;
-      
-      Send(target,@AddAttackModifier,#what=self);
-      iFactor = bound(iSpellPower+1,10,100);
-      
-      return iFactor;
-   }  
+		if Send(Target,@IsEnchanted,#what=Send(SYS,@FindSpellByNum,#num=SID_NIGHT_VISION)) 
+      {
+         Send(Target,@RemoveEnchantment,#what=Send(SYS,@FindSpellByNum,#num=SID_NIGHT_VISION),#report=FALSE);
+      } 
+	   
+      send(Target,@AddAim,#points=iSpellPower*20);
+	  
+      Send(Target,@GainLight,#amount=iSpellPower*3/2);
 
-   EndEnchantment(who=$,report=TRUE,state=$)
+      return iSpellPower;
+   }
+   
+   EndEnchantment( who = $, state = 0, report = TRUE )
    {
-      Send(who,@RemoveAttackModifier,#what=self);
-      
+      send(who,@AddAim,#points=-state*20);
+      send(who,@LoseLight,#amount=state*3/2);
+     
       propagate;
    }
 
@@ -113,18 +118,16 @@ messages:
       return &EagleEyesPotion;
    }
 
-   DoEagleEyes(oCaster=$, oTarget=$, iDuration=0, iFactor=1)
+   DoEagleEyes(oCaster=$, oTarget=$, duration=0, iFactor=1)
    "Calculates adjustment of blinding spell duration.  Returns $ if resisted "
    "completely.  iFactor is the factor by which we want to increase the effect."
    {
-      local iNewDuration, iChance, oEagleEyesStrength;
+      local iNewDuration, oEagleEyesStrength;
 
       oEagleEyesStrength = Send(oTarget,@GetEnchantedState,#what=self);
 
-      % Check if they repel the blinding spell outright 1-10% base chance,
-      %  modified by factor.
-      iChance = (oEagleEyesStrength * (SPELL_RESIST_PERCENT * iFactor)) / 100;
-      if Random(0,100) <= iChance
+      % Check if they repel the blinding spell outright 1-10% base chance
+      if Random(0,100) <= oEagleEyesStrength / 10
       {
          Send(oTarget,@MsgSendUser,#message_rsc=EagleEyes_evade);
          if IsClass(oCaster,&Player)
@@ -132,11 +135,11 @@ messages:
             Send(oCaster,@MsgSendUser,#message_rsc=EagleEyes_evade_caster);
          }
          
-         return $;
+         return 0;
       }
 
-      % Duration reduced 0-50%, depending on spellpower.
-      iNewDuration = iDuration - (iDuration * oEagleEyesStrength)/200;
+      % Duration reduced 0-20%, depending on spellpower.
+      iNewDuration = duration - (duration * oEagleEyesStrength / 500);
       Post(oTarget,@MsgSendUser,#message_rsc=EagleEyes_resist);
       
       if IsClass(oCaster,&Player)
@@ -146,41 +149,6 @@ messages:
 
       return iNewDuration;
    }
-
-   %%% Attack Modifier stuff
-
-   ModifyHitRoll(who = $,what = $,hit_roll = $)
-   {
-      local iFactor, oWeapon;
-
-      iFactor = Send(who,@GetEnchantedState,#what=self);
-
-      oWeapon = Send(who,@LookupPlayerWeapon);
-
-      if oWeapon <> $ AND IsClass(oWeapon,&RangedWeapon)
-      {
-         return hit_roll + iFactor;
-      }
-
-      return hit_roll;
-   }
-
-   ModifyDamage(who = $,what = $,damage = $)
-   {
-      local iFactor, oWeapon;
-
-      iFactor = Send(who,@GetEnchantedState,#what=self);
-
-      oWeapon = Send(who,@LookupPlayerWeapon);
-
-      if oWeapon <> $ AND IsClass(oWeapon,&RangedWeapon)
-      {
-         return damage + 1;
-      }
-
-      return damage;
-   }
-
-
+	
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/persench/Eagleyes.kod
+++ b/kod/object/passive/spell/persench/Eagleyes.kod
@@ -81,7 +81,7 @@ messages:
          Send(Target,@RemoveEnchantment,#what=Send(SYS,@FindSpellByNum,#num=SID_NIGHT_VISION),#report=FALSE);
       } 
 	   
-      send(Target,@AddAim,#points=iSpellPower*20);
+      send(Target,@AddAim,#points=iSpellPower/5);
 	  
       Send(Target,@GainLight,#amount=iSpellPower*3/2);
 
@@ -90,23 +90,20 @@ messages:
    
    EndEnchantment( who = $, state = 0, report = TRUE )
    {
-      send(who,@AddAim,#points=-state*20);
+      send(who,@AddAim,#points=-state/5);
       send(who,@LoseLight,#amount=state*3/2);
      
       propagate;
    }
 
-   GetDuration(iSpellpower = 0)
+   GetDuration(iSpellPower = 0)
    {
       local iDuration;
-
-      % 2 - 8.6 minutes max.
-      iDuration = 120 + (4 * iSpellPower);
-      % Convert to ms.
+      iDuration = 300 + (iSpellpower * 6);
       iDuration = iDuration * 1000;
       
       return iDuration;
-   }   
+   }  
 
    OfferToNewCharacters()
    {

--- a/kod/object/passive/spell/persench/bless.kod
+++ b/kod/object/passive/spell/persench/bless.kod
@@ -71,16 +71,11 @@ messages:
       return;
    }
 
-   CastSpell(who = $,iSpellPower= 0,ltargets=$)
-   {
-      Send(First(lTargets),@AddAttackModifier,#what=self);       
+   GetStateValue(who = $, iSpellPower = 0,target=$)      
+   {      
+      Send(target,@AddAttackModifier,#what=self);       
 
-      propagate;
-   }
-
-   GetStateValue(iSpellpower=$)
-   {
-      return iSpellpower;
+      return iSpellPower;
    }
 
    GetDuration(iSpellPower=0)

--- a/kod/object/passive/spell/persench/deflect.kod
+++ b/kod/object/passive/spell/persench/deflect.kod
@@ -87,15 +87,6 @@ messages:
       return;
    }
 
-   GetStateValue(who = $,iSpellPower= 0,Target=$)
-   {
-      local iReflectOdds;
-
-      iReflectOdds = iSpellPower * 3 / 4;
-
-      return bound(iReflectOdds,10,75);
-   }
-
    GetDuration(iSpellPower=0)
    {
       local iDuration;
@@ -115,7 +106,7 @@ messages:
          AND Send(oSpell,@GetNumSpellTargets) = 1
          AND IsClass(oSpell,&AttackSpell)
       {
-         chance = Send(victim,@GetEnchantedState,#what=self);
+         chance = Send(victim,@GetEnchantedState,#what=self)*3/4;
          if Random(0,100) < chance
          {
             Send(self,@SendMessageTryDeflectSuccess,#victim=victim,#caster=caster);

--- a/kod/object/passive/spell/persench/denial.kod
+++ b/kod/object/passive/spell/persench/denial.kod
@@ -28,6 +28,9 @@ resources:
       "least not at the same time."
 
    denial_off_rsc = "Ouch - you are reminded of your previous weariness."
+	
+	denial_warning = "Your realize that your wounds are too deep to keep going.  Your life begins to fade..."
+	
    denial_sound = rdenial.wav
 
 classvars:
@@ -46,14 +49,18 @@ classvars:
    viMana = 15
 
    viSpellExertion = 5
-   viCast_time = 1000
+   viCast_time = 0
 
    vbCanCastOnOthers = FALSE
 
    vrSucceed_wav = denial_sound
+	
+	% It is viPurge_factor times as hard to purge the spell.
+	viPurge_factor = 4
 
 properties:
 
+plDelusionalPeople = $
 
 messages:
 
@@ -80,54 +87,97 @@ messages:
 
       return;
    }
+	
+   CastSpell(who = $,iSpellPower=0,lTargets=$)
+   {
+      local i, iHPGain;
+      
+      iHPGain = send(who,@GetMaxHealth) - send(who,@GetHealth);
+		
+		for i in plDelusionalPeople
+		{
+			if Nth(i,1) = who
+			{
+				plDelusionalPeople = DelListElem(plDelusionalPeople,i);						
+			}
+		}
+		
+		plDelusionalPeople = Cons([who,iHPGain],plDelusionalPeople);
+		
+		propagate;
+	}
 
    GetDuration(iSpellPower = 0)
    {
-      local iDuration;
-
-      % 10 - 20 plus 1 second per spellpower
-      iDuration = random(10000,20000) + (iSpellPower * 1000);
-      iDuration=bound(iDuration,20000,120000);
-      
-      return iDuration;      
+      return 60000;      
    }
 
 
    GetStateValue(who = $, Target = $, iSpellPower = 1)
    {
-      local iHPGain;
-      
-      iHPGain = send(who,@GetMaxHealth) - send(who,@GetHealth);
+		local i, iHPGain;
+		
+		iHPGain = 0;
+		
+		for i in plDelusionalPeople
+		{
+			if Nth(i,1) = who
+			{
+				iHPGain = Nth(i,2);
+				break;
+			}
+		}
 		
 		iHPGain = iHPGain * iSpellPower / 100;
-		
+      
       send(who,@GainHealth,#amount=iHPGain);
 
-		% Make this way harder to purge: 4SP required to remove 1 HP.
-      return iHPGain*4;
+      return iSpellPower;
    }
 
 
    EndEnchantment(who = $, state=$, report = TRUE)
-   {      
-      post(self,@EndEnchantmentEffects,#who=who,#state=state);
+   {
+		local i, iHPGain;
+		
+		iHPGain = 0;
+		
+		for i in plDelusionalPeople
+		{
+			if Nth(i,1) = who
+			{
+				iHPGain = Nth(i,2);
+				
+				if report
+				{
+					plDelusionalPeople = DelListElem(plDelusionalPeople,i);						
+				}
+				
+				break;
+			}
+		}
+		
+		iHPGain = iHPGain * state / 100;
+	
+      post(self,@EndEnchantmentEffects,#who=who,#state=iHPGain,#report=report);
       
       propagate;
    }
 
-   EndEnchantmentEffects(who=$, state=$)
+   EndEnchantmentEffects(who=$, state=1, report=TRUE)
    {
-      if state
-      {
-			send(who,@LoseHealth,#amount=state/4);
-			
-         if send(who,@GetHealth) < 1
-	      {
-            % Don't die: too harsh; makes spell unusable.
-            send(who,@GainHealthNormal,#amount=1);
-	      }
-      }
-      
+		if report AND state >= send(who,@GetHealth)
+		{
+			Send(who,@MsgSendUser,#message_rsc=denial_warning);
+         Send(who,@SetPlayerFlag,#flag=PFLAG_NO_MOVE,#value=TRUE);
+         Send(who,@SetPlayerFlag,#flag=PFLAG_NO_FIGHT,#value=TRUE);
+         Send(who,@SetPlayerFlag,#flag=PFLAG_NO_MAGIC,#value=TRUE);
+			Send(who,@EffectSendUser,#effect=EFFECT_PARALYZE_ON);	
+			send(who,@StartDenialDeathTimer);
+		}
+		
+		send(who,@LoseHealth,#amount=state);
+		
       return;
    } 
 
@@ -135,8 +185,13 @@ messages:
    {
       return &DenialPotion;
    }
-
-
+	
+   IsIllusion()
+   {           
+		% No simple dispelling here. Makes the spell useless.
+      return FALSE;
+   }
+	
 end
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/persench/denial.kod
+++ b/kod/object/passive/spell/persench/denial.kod
@@ -20,7 +20,7 @@ resources:
    denial_desc_rsc = \
       "Causes the caster to unrealize their wounds, but beware when "
       "you realize its a hoax, because the wounds are still just as deep!  "
-      "Requires a firesand and solagh to cast."
+      "Requires solagh to cast."
 
    denial_on_rsc = "Your wounds suspiciously disappear."
    denial_failed_rsc = "Hmmm, you can't seem to convince yourself of perfect health."
@@ -76,7 +76,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&FireSand,2], plReagents);
       plReagents = Cons([&Solagh,1],plReagents);
 
       return;
@@ -96,14 +95,16 @@ messages:
 
    GetStateValue(who = $, Target = $, iSpellPower = 1)
    {
-      local iHPGain, iSpellpowerBonus;
+      local iHPGain;
       
       iHPGain = send(who,@GetMaxHealth) - send(who,@GetHealth);
+		
+		iHPGain = iHPGain * iSpellPower / 100;
+		
+      send(who,@GainHealth,#amount=iHPGain);
 
-      iSpellpowerBonus = (iSpellpower + 1) / 5;  %0 - 20, this is the percent of damage you don't get back when the enchantment fails.
-      iHPGain = send(who,@GainHealthNormal,#amount=iHPGain);
-
-      return iHPGain - (iSpellpowerBonus * iHPGain)/ 100 ;
+		% Make this way harder to purge: 4SP required to remove 1 HP.
+      return iHPGain*4;
    }
 
 
@@ -118,8 +119,8 @@ messages:
    {
       if state
       {
-         Send(who,@LoseHealth,#amount=state);
-      
+			send(who,@LoseHealth,#amount=state/4);
+			
          if send(who,@GetHealth) < 1
 	      {
             % Don't die: too harsh; makes spell unusable.

--- a/kod/object/passive/spell/persench/detinvis.kod
+++ b/kod/object/passive/spell/persench/detinvis.kod
@@ -44,7 +44,9 @@ classvars:
 
    viCast_time = 3000
    viChance_To_Increase = 15
-
+	
+	% It is viPurge_factor times as hard to purge the spell.
+	viPurge_factor = 2
 
 properties:
 
@@ -67,8 +69,7 @@ messages:
 	
    GetStateValue(who = $, iSpellPower = 0)      
    {      		
-		% Make this a lot harder to purge!
-      return iSpellPower*2;
+      return iSpellPower;
    }
 
    SetSpellPlayerFlag(who=$)

--- a/kod/object/passive/spell/persench/detinvis.kod
+++ b/kod/object/passive/spell/persench/detinvis.kod
@@ -64,6 +64,12 @@ messages:
       
       propagate;
    }
+	
+   GetStateValue(who = $, iSpellPower = 0)      
+   {      		
+		% Make this a lot harder to purge!
+      return iSpellPower*2;
+   }
 
    SetSpellPlayerFlag(who=$)
    {

--- a/kod/object/passive/spell/persench/eavesdrp.kod
+++ b/kod/object/passive/spell/persench/eavesdrp.kod
@@ -201,6 +201,14 @@ messages:
 
       return lRooms;
    }
+	
+   CanBeRemovedByPlayer()
+   "Returns if a spell can be removed by normal Purge/Purify"
+   {
+		% Not affected by purge. It's not a combat buff and an extreme pain to handle since the state is
+		% not the SP, as with every other PE, but a list containing draintime and listener object.
+      return FALSE;
+   }
 
 
 end

--- a/kod/object/passive/spell/persench/freeact.kod
+++ b/kod/object/passive/spell/persench/freeact.kod
@@ -79,14 +79,14 @@ messages:
 
    GetStateValue(who = $, iSpellPower = 0, target = $)
    {
-      send(Target,@AddAgility,#points=iSpellPower*20);
+      send(Target,@AddAgility,#points=iSpellPower/5);
 
       return iSpellPower;
    }
 	
    EndEnchantment( who = $, state = 0, report = TRUE )
    {
-      send(who,@AddAgility,#points=-state*20);
+      send(who,@AddAgility,#points=-state/5);
      
       propagate;
    }
@@ -102,12 +102,10 @@ messages:
       return;
    }
   
-   GetDuration(iSpellpower=0)
+   GetDuration(iSpellPower = 0)
    {
       local iDuration;
-
-      % 3 - 8 minutes max, converted to ms.
-      iDuration = 180 + (3 * iSpellPower);   
+      iDuration = 300 + (iSpellpower * 6);
       iDuration = iDuration * 1000;
       
       return iDuration;

--- a/kod/object/passive/spell/persench/freeact.kod
+++ b/kod/object/passive/spell/persench/freeact.kod
@@ -77,13 +77,29 @@ messages:
       return;
    }
 
-   GetStateValue(iSpellpower=$)
+   GetStateValue(who = $, iSpellPower = 0, target = $)
    {
-      local iFactor;
+      send(Target,@AddAgility,#points=iSpellPower*20);
 
-      iFactor = bound(iSpellPower/2+5,10,50);      
-
-      return iFactor;
+      return iSpellPower;
+   }
+	
+   EndEnchantment( who = $, state = 0, report = TRUE )
+   {
+      send(who,@AddAgility,#points=-state*20);
+     
+      propagate;
+   }
+   
+   SetSpellPlayerFlag(who=$)
+   {
+      if Send(who,@IsEnchanted,#what=Send(SYS,@FindSpellByNum,#num=SID_HASTE)) 
+      {
+         Send(who,@RemoveEnchantment,#what=Send(SYS,@FindSpellByNum,#num=SID_HASTE),#report=FALSE);
+      } 
+   
+      Send(who,@SetPlayerFlag,#flag=PFLAG2_HASTED,#flagset=2,#value=True);
+      return;
    }
   
    GetDuration(iSpellpower=0)
@@ -97,7 +113,7 @@ messages:
       return iDuration;
    }
 
-   DoFreeAction(oHoldCaster=$, oTarget=$, iDuration=0)
+   DoFreeAction(oCaster=$, oTarget=$, duration=0)
    "Calculates adjustment if hold duration.  Returns $ if resisted completely."
    {
       local iNewDuration, oFreeActionStrength;
@@ -105,23 +121,24 @@ messages:
       oFreeActionStrength = Send(oTarget,@GetEnchantedState,#what=self);
 
       % Check if they repel hold outright 1 - 15% chance.
-      if Random(0,100) <= ((oFreeActionStrength * SPELL_RESIST_PERCENT) / 100)
+      if Random(0,100) <= oFreeActionStrength / 10
       {
          Send(oTarget,@MsgSendUser,#message_rsc=FreeAction_evade);
-         if IsClass(oHoldCaster,&Player)
+         if IsClass(oCaster,&Player)
          {
-            Send(oHoldCaster,@MsgSendUser,#message_rsc=FreeAction_evade_caster);
+            Send(oCaster,@MsgSendUser,#message_rsc=FreeAction_evade_caster);
          }
          
-         return $;
+         return 0;
       }
-
-      iNewDuration = iDuration - (iDuration * oFreeActionStrength)/150;
+		
+      % Duration reduced 0-20%, depending on spellpower.
+      iNewDuration = duration - (duration * oFreeActionStrength / 500);
       Post(oTarget,@MsgSendUser,#message_rsc=FreeAction_resist);
       
-      if IsClass(oHoldCaster,&Player)
+      if IsClass(oCaster,&Player)
       {
-         Post(oHoldCaster,@MsgSendUser,#message_rsc=FreeAction_resist_caster);
+         Post(oCaster,@MsgSendUser,#message_rsc=FreeAction_resist_caster);
       }
 
       return iNewDuration;

--- a/kod/object/passive/spell/persench/gaze.kod
+++ b/kod/object/passive/spell/persench/gaze.kod
@@ -127,7 +127,7 @@ messages:
          Send(who,@MsgSendUser,#message_rsc=paralyze_caster,
               #parm1=send(what,@GetCapDef),#parm2=send(what,@GetName));
 
-         Send(oSpell,@DoHold,#what=who,#oTarget=what,#iDuration=iDuration,
+         Send(oSpell,@DoHold,#who=who,#oTarget=what,#duration=iDuration,
               #iSpellpower=iSpellpower);
       }
 

--- a/kod/object/passive/spell/persench/haste.kod
+++ b/kod/object/passive/spell/persench/haste.kod
@@ -61,7 +61,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Snack,5],plReagents);
+      plReagents = Cons([&Snack,1],plReagents);
 
       return;
    }
@@ -80,8 +80,9 @@ messages:
    GetDuration(iSpellpower = 0)
    {
       local iDuration;
-      iDuration = 5 + ((15 * iSpellPower) / 100);   % 5 - 20 minutes,
-      iDuration = iDuration * 1000 * 60;   % Convert to milliseconds
+      
+      iDuration = 1200 + 24 * iSpellPower;  %% 20 to 60 minutes
+      iDuration = iDuration * 1000;
       
       return iDuration;
    }

--- a/kod/object/passive/spell/persench/invis.kod
+++ b/kod/object/passive/spell/persench/invis.kod
@@ -78,7 +78,6 @@ messages:
       }
 
       Send(first(lTargets),@ResetPlayerFlagList);
-      Send(first(lTargets),@AddDefenseModifier,#what=self);
       
       propagate;
    }
@@ -101,9 +100,11 @@ messages:
       return iDuration;
    }
 
-   GetStateValue(iSpellpower=$)
-   {
-      return iSpellpower;
+   GetStateValue(who = $, iSpellPower = 0,target=$)      
+   {      
+      Send(target,@AddDefenseModifier,#what=self);       
+
+      return iSpellPower;
    }
 
    EndEnchantment(who = $, report = TRUE, state = 0)

--- a/kod/object/passive/spell/persench/karahol.kod
+++ b/kod/object/passive/spell/persench/karahol.kod
@@ -75,16 +75,11 @@ messages:
       return;
    }
 
-   CastSpell(who = $,iSpellPower= 0, ltargets = $)
-   {
-      Send(who,@AddAttackModifier,#what=self);
-     
-      propagate;
-   }
+   GetStateValue(who = $, iSpellPower = 0,target=$)      
+   {      
+      Send(target,@AddAttackModifier,#what=self);       
 
-   GetStateValue(iSpellpower=$)
-   {
-      return iSpellpower;
+      return iSpellPower;
    }
 
    GetDuration(iSpellPower=0)
@@ -101,17 +96,20 @@ messages:
       local oHoldSpell, iDuration;
 
       Send(who,@RemoveAttackModifier,#what=self);
-
-      % Now, for the side effect.  Hold 'em!
-      oHoldSpell = Send(SYS,@FindSpellByNum,#num=SID_HOLD);
-      if Send(who,@IsEnchanted,#what=oHoldSpell)
-      {
-         Send(who,@RemoveEnchantment,#what=oHoldSpell,#report=FALSE);
-      }
-      
-      % Hold duration is measured in seconds, not milliseconds.  Lasts 1/6 the time of the bonus.
-      iDuration = (Send(self,@GetDuration,#iSpellPower=state))/6;
-      Send(oHoldSpell,@DoHold,#what=self,#otarget=who,#iDuration=iDuration,#report=TRUE,#bAllowFreeAction=FALSE);
+		
+		if report = TRUE
+		{
+			% Now, for the side effect.  Hold 'em!
+			oHoldSpell = Send(SYS,@FindSpellByNum,#num=SID_HOLD);
+			if Send(who,@IsEnchanted,#what=oHoldSpell)
+			{
+				Send(who,@RemoveEnchantment,#what=oHoldSpell,#report=FALSE);
+			}
+			
+			% Hold duration is measured in milliseconds.  Lasts 1/6 the time of the bonus.
+			iDuration = Send(self,@GetDuration,#iSpellPower=state)/6;
+			Send(oHoldSpell,@DoHold,#who=self,#otarget=who,#duration=iDuration,#report=TRUE,#bAllowFreeAction=FALSE);
+		}
       
       propagate;
    }

--- a/kod/object/passive/spell/persench/mshield.kod
+++ b/kod/object/passive/spell/persench/mshield.kod
@@ -64,13 +64,6 @@ messages:
       return;
    }
 	 
-   CastSpell(who = $,lTargets = $)
-   {
-      Send(first(lTargets),@AddDefenseModifier,#what=self);
-      
-      propagate;
-   }
-
    GetDuration(iSpellPower=$)
    {
       local iDuration;
@@ -83,9 +76,11 @@ messages:
       return iDuration;
    }
 
-   GetStateValue(iSpellpower=$)
-   {
-      return iSpellpower;
+   GetStateValue(who = $, iSpellPower = 0,target=$)      
+   {      
+      Send(target,@AddDefenseModifier,#what=self);       
+
+      return iSpellPower;
    }
 
    EndEnchantment(who = $, report = TRUE, state = 0)

--- a/kod/object/passive/spell/persench/nightv.kod
+++ b/kod/object/passive/spell/persench/nightv.kod
@@ -62,12 +62,9 @@ messages:
 
    GetStateValue(who = $, iSpellPower = 0,target=$)
    {
-      local iState;
-
-      iState = iSpellPower + 50;
-      Send(target,@GainLight,#amount=iState);
+      Send(target,@GainLight,#amount=iSpellPower+50);
       
-      return iState;
+      return iSpellPower;
    }
    
    GetDuration(iSpellpower = 0)
@@ -83,7 +80,7 @@ messages:
 
    EndEnchantment(who = $, report = TRUE, state = 0)
    {
-      Send(who,@LoseLight,#amount=state);
+      Send(who,@LoseLight,#amount=state+50);
       
       propagate;
    }

--- a/kod/object/passive/spell/persench/nightv.kod
+++ b/kod/object/passive/spell/persench/nightv.kod
@@ -55,7 +55,7 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&ElderBerry,3],plReagents);
+      plReagents = Cons([&ElderBerry,1],plReagents);
 
       return;
    }
@@ -71,7 +71,7 @@ messages:
    {
       local iDuration;
       
-      iDuration = 1500 + 10 * iSpellPower;
+      iDuration = 1200 + 24 * iSpellPower;  %% 20 to 60 minutes
       iDuration = iDuration * 1000;
       
       return iDuration;

--- a/kod/object/passive/spell/persench/resist.kod
+++ b/kod/object/passive/spell/persench/resist.kod
@@ -49,11 +49,23 @@ messages:
       local iValue;
       
       iValue = send(self,@GetResistanceStrength,#iSpellPower=iSpellPower);
+		
       send(self,@AddResistances,#who=target,#value=iValue);
       
-      return iValue;
+      return iSpellPower;
    }
 
+   EndEnchantment(who = $, report = TRUE, state = 0)
+   {
+      local iValue;
+		
+      iValue = send(self,@GetResistanceStrength,#iSpellPower=state);
+
+      Send(self,@RemoveResistances,#who=who,#value=iValue);
+
+      propagate;
+   }
+	
    AddResistances(who=$,value=$)
    {
       Send(who,@AddResistance,#what=viResistanceType,#value=value);
@@ -75,14 +87,6 @@ messages:
       iDuration = iDuration * 1000;	  %% translate to milliseconds
       
       return iDuration;
-   }
-
-   EndEnchantment(who = $, report = TRUE, state = -1)
-   {
-      if state = -1  { DEBUG("Bad data!"); state = 0; }
-      Send(self,@RemoveResistances,#who=who,#value=state);
-
-      propagate;
    }
 
    RemoveResistances(who=$,value=$)

--- a/kod/object/passive/spell/persench/resist/resacid.kod
+++ b/kod/object/passive/spell/persench/resist/resacid.kod
@@ -73,8 +73,8 @@ messages:
 
    GetResistanceStrength(iSpellpower = 0)
    {
-      %% strength varies from 15 to 65
-      return iSpellPower/2 + 15;
+      %% strength varies from 0 to 65
+      return iSpellPower*65/100;
    }
 
    GetDuration(iSpellPower = 0)

--- a/kod/object/passive/spell/persench/resist/rescold.kod
+++ b/kod/object/passive/spell/persench/resist/rescold.kod
@@ -68,8 +68,8 @@ messages:
 
    GetResistanceStrength(iSpellpower = 0)
    {
-      %% strength varies from 5 to 55
-      return iSpellPower/2 + 5;
+      %% strength varies from 0 to 55
+      return iSpellPower*55/100;
    }
 
    GetDuration(iSpellPower = 0)

--- a/kod/object/passive/spell/persench/resist/resevil.kod
+++ b/kod/object/passive/spell/persench/resist/resevil.kod
@@ -69,8 +69,8 @@ messages:
 
    GetResistanceStrength(iSpellpower = 0)
    {
-      %% strength varies from 15 to 65
-      return iSpellPower/2 + 15;
+      %% strength varies from 0 to 65
+      return iSpellPower*65/100;
    }
 
    GetDuration(iSpellPower = 0)

--- a/kod/object/passive/spell/persench/resist/resfire.kod
+++ b/kod/object/passive/spell/persench/resist/resfire.kod
@@ -69,8 +69,8 @@ messages:
 
    GetResistanceStrength(iSpellpower = 0)
    {
-      %% strength varies from 15 to 65
-      return iSpellPower/2 + 25;
+      %% strength varies from 0 to 75
+      return iSpellPower*75/100;
    }
 
    GetDuration(iSpellPower = 0)

--- a/kod/object/passive/spell/persench/resist/resgood.kod
+++ b/kod/object/passive/spell/persench/resist/resgood.kod
@@ -68,8 +68,8 @@ messages:
 
    GetResistanceStrength(iSpellpower = 0)
    {
-      %% strength varies from 15 to 65
-      return iSpellPower/2 + 15;
+      %% strength varies from 0 to 65
+      return iSpellPower*65/100;
    }
 
    GetDuration(iSpellPower = 0)

--- a/kod/object/passive/spell/persench/resist/resmagic.kod
+++ b/kod/object/passive/spell/persench/resist/resmagic.kod
@@ -63,8 +63,8 @@ messages:
 
    GetResistanceStrength(iSpellpower = 0)
    {
-      %% strength varies from 7 to 40
-      return iSpellPower/3 + 7;
+      %% strength varies from 0 to 40
+      return iSpellPower*4/10;
    }
 
    GetDuration(iSpellPower = 0)

--- a/kod/object/passive/spell/persench/resist/resshock.kod
+++ b/kod/object/passive/spell/persench/resist/resshock.kod
@@ -68,8 +68,8 @@ messages:
 
    GetResistanceStrength(iSpellpower = 0)
    {
-      %% strength varies from 5 to 55
-      return iSpellPower/2 + 25;
+      %% strength varies from 0 to 75
+      return iSpellPower*75/100;
    }
 
    GetDuration(iSpellPower = 0)

--- a/kod/object/passive/spell/persench/respois.kod
+++ b/kod/object/passive/spell/persench/respois.kod
@@ -50,6 +50,9 @@ classvars:
    viCast_time = 2000
    viChance_To_Increase = 15
    vrSucceed_wav = resistpoison_sound
+	
+	% It is viPurge_factor times as hard to purge the spell.
+	viPurge_factor = 2
 
 properties:
 
@@ -64,7 +67,7 @@ messages:
 
    GetStateValue(iSpellPower=$)
    {
-      return iSpellPower*2;
+      return iSpellPower;
    }
   
    GetDuration(iSpellPower = 0)

--- a/kod/object/passive/spell/persench/respois.kod
+++ b/kod/object/passive/spell/persench/respois.kod
@@ -64,11 +64,7 @@ messages:
 
    GetStateValue(iSpellPower=$)
    {
-      local ifactor;    
-
-      iFactor = bound(iSpellPower,10,99);
-
-      return iFactor;
+      return iSpellPower*2;
    }
   
    GetDuration(iSpellPower = 0)

--- a/kod/object/passive/spell/persench/strength.kod
+++ b/kod/object/passive/spell/persench/strength.kod
@@ -64,14 +64,18 @@ messages:
    }
 
 
-   GetStateValue(who = $, iSpellPower = 0, Target = $)
+   GetStateValue(who = $, iSpellPower = 0, target = $)
    {
-      local iMightChange;
-      iMightChange = iSpellPower/5+1;
+      send(Target,@AddMight,#points=iSpellPower*20);
 
-      send(Target,@AddMight,#points=iMightChange);
+      return iSpellPower;
+   }
 
-      return iMightChange;
+   EndEnchantment( who = $, state = 0, report = TRUE )
+   {
+      send(who,@AddMight,#points=-state*20);
+     
+      propagate;
    }
 
    GetDuration(iSpellPower = 0)
@@ -81,13 +85,6 @@ messages:
       iDuration = iDuration * 1000;
       
       return iDuration;
-   }
-
-   EndEnchantment( who = $, state = 0, report = TRUE )
-   {
-      send(who,@AddMight,#points=-state);
-     
-      propagate;
    }
 
    GetPotionClass()

--- a/kod/object/passive/spell/persench/strength.kod
+++ b/kod/object/passive/spell/persench/strength.kod
@@ -66,14 +66,14 @@ messages:
 
    GetStateValue(who = $, iSpellPower = 0, target = $)
    {
-      send(Target,@AddMight,#points=iSpellPower*20);
+      send(Target,@AddMight,#points=iSpellPower/5);
 
       return iSpellPower;
    }
 
    EndEnchantment( who = $, state = 0, report = TRUE )
    {
-      send(who,@AddMight,#points=-state*20);
+      send(who,@AddMight,#points=-state/5);
      
       propagate;
    }

--- a/kod/object/passive/spell/purge.kod
+++ b/kod/object/passive/spell/purge.kod
@@ -15,9 +15,6 @@ constants:
 
    include blakston.khd
 
-	% What percentage of each spell's state will Purge remove?
-   PURGE_PERCENTAGE = 50
-
 resources:
 
    Purge_name_rsc = "purge"
@@ -214,24 +211,24 @@ messages:
 				iTime = GetTimeRemaining(oTimer);
 				iState = Nth(i,3);
 				
-				% Calculate the new state of the enchantment.
-				iState = iState - spellpower * PURGE_PERCENTAGE / 100;
+				% Calculate the new state and time of the enchantment.
+				iNewState = iState - spellpower / (2 * Send(oSpell,@GetPurgeFactor));
+				iTime = iTime * iNewState / iState;
 				
 				% Start the new enchantment with the time left and the new state,
-				% but only if iState is greater than 0.
-				if iState > 0
+				% but only if iNewState is greater than 0.
+				if iNewState > 0
 				{
 					% Remove the current enchantment, but don't report.
 					Send(who,@RemoveEnchantment,#what=oSpell,#report=FALSE);
-					Send(who,@StartEnchantment,#what=oSpell,#state=iState,#time=iTime,#lastcall=send(oSpell,@GetLastCall),#addicon=send(oSpell,@GetAddicon));
-					% This is a temporary solution for spells that add extra effects based on the state value, such as super strength.
-					% These extra effects are started in GetStateValue and removed by RemoveEnchantment.
-					Send(oSpell,@GetStateValue,#who=who,#iSpellPower=iState,#target=who);
+					% Extra effects like added stat points are handled in GetStateValue, so we have to call it here.
+					Send(oSpell,@GetStateValue,#who=who,#iSpellPower=iNewState,#target=who);
+					Send(who,@StartEnchantment,#what=oSpell,#state=iNewState,#time=iTime,#lastcall=send(oSpell,@GetLastCall),#addicon=send(oSpell,@GetAddicon));
 				}
 				else
 				{
 					% Remove the current enchantment and report.
-					Send(who,@RemoveEnchantment,#what=oSpell,#report=TRUE);
+					Send(who,@RemoveEnchantment,#what=oSpell,#report=TRUE,#eliminated=TRUE);
 					bRemovedSomething = TRUE;
 				}
 			}

--- a/kod/object/passive/spell/purge.kod
+++ b/kod/object/passive/spell/purge.kod
@@ -15,13 +15,8 @@ constants:
 
    include blakston.khd
 
-   % At least how many enchantments should there be on a player to check
-   %  for auto-remove?
-   MIN_ENCHANTMENTS_FOR_AUTOREMOVE = 2
-
-   % What's the minimum chance to remove spells we want before checking
-   %  for auto-remove?
-   MIN_CHANCE_FOR_AUTOREMOVE = 60
+	% What percentage of each spell's state will Purge remove?
+   PURGE_PERCENTAGE = 50
 
 resources:
 
@@ -48,7 +43,8 @@ classvars:
    viSpell_num = SID_PURGE
    viSchool = SS_SHALILLE
    viSpell_level = 5
-   viMana = 15
+   viMana = 20
+   viSpellExertion = 10
    viChance_To_Increase = 10
 
    viHarmful = TRUE
@@ -160,13 +156,12 @@ messages:
          }
       }
 
-      Send(self,@DoPurge,#who=oTarget,#iChance=iSpellPower);
+      Send(self,@DoPurge,#who=oTarget,#spellpower=iSpellPower);
 
       propagate;
    }
 
-   % Override this to allow for non-outlaw self-casting of spell on Sacred
-   %  Haven.
+   % Override this to allow for non-outlaw self-casting of spell on Sacred Haven.
    GetAttackTargets(who=$, lTargets=$, report=TRUE)
    "Returns a list of targets the caster can attack."
    {
@@ -180,72 +175,70 @@ messages:
       propagate;
    }
 
-   DoPurge(who=$, iChance=$)
+   DoPurge(who=$, spellpower=$)
    "Remove positive enchantments on who with a given chance to remove each one."
    {
-      local iNumEnchantments, lEnchantments, iModifiedChance, oEnchantment,
-            oSpell, lList, bRemovedSomething;
-
+		local i, lEnchantments, oTimer, iTime, oSpell, iState, iNewState, bRemovedSomething;
+		
+		
       % Can't do this to nobody or to non-players.
-      if who = $
-         OR NOT IsClass(who,&Player)
+      if who = $ OR NOT IsClass(who,&Player)
       {
          return FALSE;
       }
 
-      % Chance of $ means that we want to remove it all.
-      if iChance = $
+		bRemovedSomething = FALSE;
+		
+      % A spellpower of $ means that we want to remove it all.
+      if spellpower = $
       {
          Send(who,@RemoveAllPersonalEnchantments);
+			
+			bRemovedSomething = TRUE;
          
          return TRUE;
       }
+		
+		lEnchantments = Send(who,@GetEnchantmentList);
+		
+		for i in lEnchantments
+		{
+			oSpell = Nth(i,2);
 
-      bRemovedSomething = FALSE;
-      lEnchantments = $;
-      lList = Send(who,@GetEnchantmentList);
-
-      for oEnchantment in lList
-      {
-         oSpell = Nth(oEnchantment,2);
-
-         if Send(oSpell,@IsPersonalEnchantment)
-            AND Send(oSpell,@CanBeRemovedByPlayer)
-            AND NOT Send(oSpell,@IsHarmful)
-         {
-            lEnchantments = cons(oSpell,lEnchantments);
-         }
-      }
-      
-      iNumEnchantments = length(lEnchantments);
-
-      % Anti-clumpy code: If there is at least two enchantments on a player
-      %  and the chance to dispell is greater than 60%, then auto-remove one
-      %  enchantment.
-      if iNumEnchantments >= MIN_ENCHANTMENTS_FOR_AUTOREMOVE
-         AND iChance >= MIN_CHANCE_FOR_AUTOREMOVE
-      {
-         oEnchantment = Nth(lEnchantments,random(1,iNumEnchantments));
-         Send(who,@RemoveEnchantment,#what=oEnchantment);
-         lEnchantments = DelListElem(lEnchantments,oEnchantment);
-         iNumEnchantments = iNumEnchantments - 1;
-         bRemovedSomething = TRUE;
-      }
-
-      iModifiedChance = iChance;
-
-      for oEnchantment in lEnchantments
-      {
-         if iChance = $ OR iModifiedChance > random(1,100)
-         {
-            Send(who,@RemoveEnchantment,#what=oEnchantment);
-            bRemovedSomething = TRUE;
-         }
-      }
+			if Send(oSpell,@IsPersonalEnchantment)
+				AND Send(oSpell,@CanBeRemovedByPlayer)
+				AND NOT Send(oSpell,@IsHarmful)
+			{				
+				% Get the current state of the enchantment.
+				oTimer = Nth(i,1);
+				iTime = GetTimeRemaining(oTimer);
+				iState = Nth(i,3);
+				
+				% Calculate the new state of the enchantment.
+				iState = iState - spellpower * PURGE_PERCENTAGE / 100;
+				
+				% Start the new enchantment with the time left and the new state,
+				% but only if iState is greater than 0.
+				if iState > 0
+				{
+					% Remove the current enchantment, but don't report.
+					Send(who,@RemoveEnchantment,#what=oSpell,#report=FALSE);
+					Send(who,@StartEnchantment,#what=oSpell,#state=iState,#time=iTime,#lastcall=send(oSpell,@GetLastCall),#addicon=send(oSpell,@GetAddicon));
+					% This is a temporary solution for spells that add extra effects based on the state value, such as super strength.
+					% These extra effects are started in GetStateValue and removed by RemoveEnchantment.
+					Send(oSpell,@GetStateValue,#who=who,#iSpellPower=iState,#target=who);
+				}
+				else
+				{
+					% Remove the current enchantment and report.
+					Send(who,@RemoveEnchantment,#what=oSpell,#report=TRUE);
+					bRemovedSomething = TRUE;
+				}
+			}
+		}
       
       return bRemovedSomething;
    }
-   
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/roomench.kod
+++ b/kod/object/passive/spell/roomench.kod
@@ -48,8 +48,7 @@ messages:
       
       if send(oRoom,@IsEnchanted,#what=self)
       {
-         Send(who,@MsgSendUser,#message_rsc=spell_already_in_effect,
-              #parm1=vrName);
+         Send(who,@MsgSendUser,#message_rsc=spell_already_in_effect,#parm1=vrName);
 
          return FALSE;
       }

--- a/kod/object/passive/spell/roomench/light.kod
+++ b/kod/object/passive/spell/roomench/light.kod
@@ -65,32 +65,26 @@ messages:
       return 0;
    }
 
-   CanPayCosts(who = $, lTargets = $)
-   {
-      local oRoom;
-
-      oRoom = Send(who,@GetOwner);
-      % check if room already has light
-      if Send(oRoom,@IsEnchanted,#what=self)
-      {
-	 Send(who,@MsgSendUser,#message_rsc=light_unnecessary);
-	 return False;
-      }
-
-      propagate;
-   }
-
-
    CastSpell( who = $, iSpellPower = 0 )
    "Initiation point for the spell."
    {
       local oRoom;
 
       oRoom = Send(who,@GetOwner);
+		
       if Send(oRoom,@IsEnchanted,#what=self)
       {
-        Send(who,@MsgSendUser,#message_rsc=light_unnecessary);
-        return;
+			% Allow recasting with equal or greater SP. Just a quality of life improvement, since
+			% the duration of the spell has been significantly increased.
+			if Send(oRoom,@GetEnchantmentState,#what=self) > iSpellpower + 25
+			{
+				Send(who,@MsgSendUser,#message_rsc=light_unnecessary);
+				return;
+			}
+			else
+			{
+				Send(oRoom,@RemoveEnchantment,#what=self);
+			}
       }
 
       % global effects of the enchantment
@@ -107,10 +101,10 @@ messages:
    {
       local iDuration;
 
-      iDuration = 45 + (iSpellPower*3);  %% 30 - 228 seconds
+      iDuration = 600 + 12 * iSpellPower;  %% 10 to 30 minutes
       iDuration = iDuration * 1000;      %% convert to seconds            
 
-      return random(iDuration/2,iDuration);
+      return;
    }
 
    StartEnchantmentNewOccupant( who = $ )

--- a/kod/object/passive/spell/walspell/summweb.kod
+++ b/kod/object/passive/spell/walspell/summweb.kod
@@ -197,7 +197,7 @@ messages:
       propagate;
    }
 
-   DoHold(what = $, otarget = $, idurationsecs = $, report=TRUE)
+   DoHold(who = $, otarget = $, idurationsecs = $, report=TRUE)
    "Holds target for durationsecs seconds."
    {
       local i;


### PR DESCRIPTION
The values below reflect scaling with SP. There is no random factor.

_Changes in Spells:_

PURGE: Reduces power of enchantments by 0% to 50% (both state and duration), removes enchantments if power hits 0. 20 mana, 10 vigor.
BLIND: 30 sec CD, 5 to 10 sec duration, up to +2 secs from target's karma, does not exceed 10 secs, no post cast delay, 10 mana, 0 vigor. If you try to cast the spell before the cooldown has expired, you will be notified of when the spell can be cast again.
DAZZLE: 30 sec CD, 4 to 8 sec duration,up to +2 secs from target's karma, does not exceed 8 secs, no post cast delay, 10 mana, 0 vigor. If you try to cast the spell before the cooldown has expired, you will be notified of when the spell can be cast again.
HOLD: 20 sec CD, 3 to 6 sec duration, no post cast delay, 10 mana, 0 vigor. If you try to cast the spell before the cooldown has expired, you will be notified of when the spell can be cast again.
FREE ACTION: Reduces hold by 0% to 20%, grants haste, grants 0 to 20 AGI. Lasts up to 15 mins.
EAGLE EYES: Reduces blind/dazzle by 0% to 20%, grants nightvision, grants 0 to 20 AIM. Lasts up to 15 mins.
HASTE: Cost reduced to one edible to retain its usefulness over free action. Duration up to 1 hour.
NIGHTVISION: Cost reduced to one elderberry to retain its usefulness over free action. Duration up to 1 hour.
LIGHT: Duration increased to up to 30 minutes to be a real choice versus night vision. Can be overwritten by an equal or higher power light spell to allow practicing in the same room.
DETECT INVISIBLE: Only loses half of its power from purge.
RESIST POISON: Only loses half of its power from purge.
DENIAL: Fixed 60 seconds duration, instant cast, can't be removed with dispel illusion, restores up to 100% of your missing health. Purging will incrementally weaken denial and remove some restored health with every cast. If your denial ends and your hps are reduced to zero, you enter a state of limbo for 10 seconds, in which you can't move and are a sitting duck. If you don't get killed in that time, you can move again.

_Changes in Game Mechanics:_

DIMINISHING RETURNS: When a player is the victim of a blind (or dazzle), a 30 second timer starts. The next blind (or dazzle) during that time will be 50% duration and reset the timer. The third blind (or dazzle) will have a duration of 25% and reset the timer. Any further attempt to blind (or dazzle) will fail entirely and no longer reset the timer. Thus, a player will lose his temporary protection 30 seconds after the last successful blind (or dazzle) has landed. Note: 30 seconds is also the duration of the internal CD of blind and dazzle, so a player that fights alone will never experience diminishing returns.

Hold has the exactly same mechanic, but on a 20 second timer, which, again, is the same as the internal cooldown of hold.

_Reasoning_:

Meridian's PvP suffers from a complete dominance of two gameplay elements that drown out any other strategic considerations: CC spamming and Purge. This change curbs the negative excesses of both mechanics, while retaining the power of the spells to a large degree. 

Blind, dazzle and hold are still extremely effective CC tools. While the CCs have a somewhat lenghty CD, their mana, vigor and opportunity cost has been greatly reduced and their reliability has gone up big time. Their relative cheapness allows the caster to spend the mana elsewhere, and even opens up the possibility to build Qor with somewhat low mysticism.

Two casts of a max SP purge will still clear all buffs from your target, and even if they haven't been cleared, their effect is reduced by 50% (unless it is a binary effect like detect invis). As your spellpower drops, you will require more casts obviously. The power of reducing the effectiveness of all of the target's buffs by 50% with a single cast is reflected by the somewhat steep cost of 20 mana and 10 vigor. It is still a great tradeoff, provided that the target has enoug buffs and you have enough spellpower. What this curbs, however, is the effectiveness of purge to remove single essential buffs and you will not be too successful, trying to simply "purge your target clean". This is further aided by the fact that resist poison and detect invisible will only lose half as much power as other enchantments. In short, DI will not simply drop to the first or second purge and leave the player unable to even participate in the fight.
