### PR TITLE
Radius Ench's Caster PE icon flicker stopped

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -2797,8 +2797,12 @@ messages:
                Send(Nth(i,2),@EndEnchantment,#who=self);
             }
 
-            Send(self,@ShowRemoveEnchantment,#what=Nth(i,2),
-                 #type=ENCHANTMENT_PLAYER);
+            % Radius Enchantments clear their own icon at the end of the spell
+            if NOT IsClass(Nth(i,2),&RadiusEnchantment)
+            {
+               Send(self,@ShowRemoveEnchantment,#what=Nth(i,2),
+                    #type=ENCHANTMENT_PLAYER);
+            }
 
             % TODO: i no longer exists at this point?  EndEnchantment removing it?
             plEnchantments = DelListElem(plEnchantments,i);
@@ -3197,6 +3201,11 @@ messages:
    {
       plRadiusEnchantments = Cons([what,iPower,caster],plRadiusEnchantments);
       Send(self,@ShowAddEnchantment,#what=what,#type=ENCHANTMENT_ROOM);
+
+      if caster = self
+      {
+         Send(self,@ShowAddEnchantment,#what=what,#type=ENCHANTMENT_PLAYER);
+      }
       
       return;
    }
@@ -3214,6 +3223,12 @@ messages:
             AND Nth(i,3) = caster
          {
             Send(self,@ShowRemoveEnchantment,#what=Nth(i,1),#type=ENCHANTMENT_ROOM);
+            
+            if caster = self
+            {
+               Send(self,@ShowRemoveEnchantment,#what=Nth(i,1),#type=ENCHANTMENT_PLAYER);
+            }
+            
             plRadiusEnchantments = DelListElem(plRadiusEnchantments,i);
             bFound = TRUE;
          }

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -243,7 +243,8 @@ messages:
 
       % Put spell maintenance info in caster's enchantment list.
       Send(who,@StartEnchantment,#what=self,#time=RADIUS_CHECK_TIME,
-           #state=[iDrain,lEnchanted,iPower,iRange]);      
+           #state=[iDrain,lEnchanted,iPower,iRange],
+           #addicon=FALSE);      
 
       propagate;
    }
@@ -403,7 +404,8 @@ messages:
       }
 
       Send(who,@StartEnchantment,#what=self,#time=RADIUS_CHECK_TIME,
-          #state=[iDrain + (((viManaDrain*1000 / viDrainTime)*1000) / (1000 / RADIUS_CHECK_TIME)),lEnchanted,iPower,iRange],#Report=FALSE);
+          #state=[iDrain + (((viManaDrain*1000 / viDrainTime)*1000) / (1000 / RADIUS_CHECK_TIME)),lEnchanted,iPower,iRange],
+          #addicon=FALSE);
 
       return;
    }


### PR DESCRIPTION
The PE icon for a Radius Enchantment that you are maintaining will no
longer flicker every 250 ms.
