### PR TITLE
Jala oversight fixes

### DIFF
--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -2187,14 +2187,17 @@ messages:
          %  with normal combat, etc.
          % Secondary bonus is based off of HPs.  Non-mules get bigger bonuses.
          iPrimaryBonus = Send(who,@GetInstrumentLevel);
-         iSecondaryBonus = Send(who,@GetMaxHealth)/12;
+         iSecondaryBonus = Send(who,@GetBaseMaxHealth)/12;
       }
 
       iPowerBonus = Send(Send(SYS,@GetParliament),@GetFactionSpellPowerBonus,
                          #who=who,#theSpell=self);
 
       % Bind the bonuses to reasonable values.
-      iPrimaryBonus = bound(iPrimaryBonus,0,30);
+      if viSchool <> SS_JALA
+      {
+         iPrimaryBonus = bound(iPrimaryBonus,0,30);
+      }
       iSecondaryBonus = bound(iSecondaryBonus,0,10);
 
       iSpellPower = iPrimaryBonus + iSecondaryBonus + iPowerBonus + iBase;


### PR DESCRIPTION
True lutes will now give +40 spellpower rather than +30 (equal to a fine
lute).

Jala's secondary bonus is now based on base max health, rather than max
health.
