### PR TITLE
No safe zones 6 minutes after murder

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -191,6 +191,8 @@ resources:
    player_assgame_soon = \
       "~kRoq tells you, \"~IA new Assassin's Circle shall be initiated "
       "shortly.\""
+   murderer_no_enter = \
+      "You have just committed a murder, you may not enter a safe haven yet!"
 
    player_tougher_wav_rsc = tougher.wav
    player_missed_something_wave_rsc = swordmis.wav
@@ -966,6 +968,7 @@ properties:
    ptBondedItemReport = $
 
    piLastDeathTime = 0
+   piLastKillTime = 0
 
    % This keeps the duration of our Second Wind skill's "downtime"
    ptSecondWind = $
@@ -5198,6 +5201,7 @@ messages:
                % Apply penalties for someone NOT holding a token
                if Send(what,@FindUsing,#class=&Token) = $
                {
+                  piLastKillTime = GetTime();
                   if Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
                   {
                      Send(self,@MsgSendUser,#message_rsc=player_killed_player);
@@ -12074,10 +12078,23 @@ messages:
 
          return FALSE;
       }
+
+      if (Send(oRoom,@GetPermanentFlags) & ROOM_NO_COMBAT)
+      AND ((Send(self,@GetLastKillTime)+ 360) > GetTime())
+      AND NOT Send(SYS,@GetChaosNight)
+      {
+         Send(self,@MsgSendUser,#message_rsc=murderer_no_enter);
+         return FALSE; 
+      }
       
       return TRUE;
    }
 
+   GetLastKillTime()
+   {
+      return piLastKillTime;
+   }   
+   
    GivePlayerAllSpells(school = 0, level = -1, upto = TRUE, iability = 99,
                        override = FALSE)
    "Used only for testing."
@@ -12809,7 +12826,7 @@ messages:
       }
 
       time = GetTime();
-   
+      piLastKillTime = time;   
       piLastDeathTime = time;
       piGuildRejoinTimestamp = time;
       piLast_restart_time = time;


### PR DESCRIPTION
This request adds a piLastKillTime to players, which records the game time when they killed an innocent player. After killing an innocent, the murderer cannot enter a safe zone for six minutes. This is turned off during a frenzy. This will increase PvP by not having PKs able to hide immediately after a kill.

Note to commenters: this is intended to increase PvP between PKs and hunters. If you don't think this is a good idea, please state why you would like less PvP, or provide an alternative to this pull request that increases PvP. Comments about potential murderer-safe zones or issues with the timer, or exceptions I've missed are welcome.
