### PR TITLE
Fix for damage types turning screen black

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3283,7 +3283,7 @@ messages:
    {
       if aspell & ATCK_SPELL_QUAKE
       {
-         Send(self,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=duration,#xlat=27);
+         Send(self,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=duration,#xlat=65);
       }
       if aspell & ATCK_SPELL_HOLY
       {
@@ -3291,11 +3291,11 @@ messages:
       }
       if aspell & ATCK_SPELL_UNHOLY
       {
-         Send(self,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=duration,#xlat=56);
+         Send(self,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=duration,#xlat=112);
       }
       if aspell & ATCK_SPELL_ACID
       {
-         Send(self,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=duration,#xlat=79);
+         Send(self,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,#duration=duration,#xlat=86);
       }
       if aspell & ATCK_SPELL_COLD
       {


### PR DESCRIPTION
Changed the xlat value for acid, unholy and quake damage types as these were causing the screen to turn black while using hardware renderer. Tested using both versions locally. The quake damage is now light red, unholy is grey/white and acid is bright green (unfortunately there are no "nicer" greens that work for me under hardware mode).
