### PR TITLE
Defensive spell fix

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -3364,7 +3364,7 @@ messages:
          {
             plDefense_modifiers = DelListElem(plDefense_modifiers,i);
             bFound = TRUE;
-			return;
+            return;
          }
       }
 


### PR DESCRIPTION
Fix for a bug. Currently defensive spell effects are not being handled properly if the spells are cast multiple times on the same player. This should only be affecting magic shield and invisibility at the moment.

Specifically, if you cast magic shield/invisibility on yourself and you already have the spell up, the defensive mod will be removed but not readded (I believe because this function did not return correctly and so removed both 1st and 2nd casts of the enchantment).
