### PR TITLE
Crystalize Mana imp rate buffed

### DIFF
--- a/kod/object/passive/spell/crysmana.kod
+++ b/kod/object/passive/spell/crysmana.kod
@@ -58,7 +58,9 @@ classvars:
    viMana = 20
 
    viSpellExertion = 30
-   viChance_To_Increase = 25
+   
+   % This spell is very slow and difficult to work, so it should improve well.
+   viChance_To_Increase = 60
 
    vrSucceed_wav = Surge_sound
    viFlash = FLASH_GOOD


### PR DESCRIPTION
This spell (which begs to be botted otherwise) has had its imp rate
dramatically boosted. Formerly 25%, it is now 60%, which should
allow it to improve almost every cast with high Intellect.
