### PR TITLE
Gear Resistance Changes

### DIFF
--- a/kod/object/item/passitem/defmod/armor/chain.kod
+++ b/kod/object/item/passitem/defmod/armor/chain.kod
@@ -56,10 +56,11 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_THRUST,5],
-               [ATCK_WEAP_PIERCE,25],
-               [ATCK_WEAP_BLUDGEON,15],
-               [ATCK_WEAP_SLASH,20]
+      return [ [ATCK_WEAP_THRUST,15],
+               [ATCK_WEAP_BLUDGEON,10],
+               [ATCK_WEAP_SLASH,25],
+               [-ATCK_SPELL_SHOCK,-10],
+               [-ATCK_SPELL_FIRE,-5]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/armor/leather.kod
+++ b/kod/object/item/passitem/defmod/armor/leather.kod
@@ -46,7 +46,7 @@ classvars:
    vrIcon_male = Leatherarmor_male_icon_rsc
    vrIcon_female = Leatherarmor_female_icon_rsc
 
-   viDefense_base = 50
+   viDefense_base = 200
    viDamage_base = 0
 
 properties:
@@ -60,7 +60,14 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_ALL,5]
+      return [ [ATCK_WEAP_THRUST,10],
+               [ATCK_WEAP_BLUDGEON,10],
+               [ATCK_WEAP_SLASH,10],
+               [ATCK_WEAP_PIERCE,10],
+               [-ATCK_SPELL_SHOCK,15],
+               [-ATCK_SPELL_COLD,20],
+               [-ATCK_SPELL_FIRE,-10],
+               [-ATCK_SPELL_ACID,-20]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/armor/plate.kod
+++ b/kod/object/item/passitem/defmod/armor/plate.kod
@@ -58,8 +58,8 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [-ATCK_SPELL_FIRE,-10],
-               [-ATCK_SPELL_SHOCK,-15]
+      return [ [-ATCK_SPELL_ALL,-20],
+               [ATCK_WEAP_ALL,15]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/armor/scale.kod
+++ b/kod/object/item/passitem/defmod/armor/scale.kod
@@ -58,7 +58,10 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_BLUDGEON,10]
+      return [ [ATCK_WEAP_BLUDGEON,10],
+               [ATCK_WEAP_PIERCE,25],
+               [-ATCK_SPELL_ALL,-10],
+               [-ATCK_SPELL_COLD,10]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/helmet/ivycircl.kod
+++ b/kod/object/item/passitem/defmod/helmet/ivycircl.kod
@@ -65,8 +65,7 @@ messages:
    GetResistanceModifiers()
    {
       return [ [-ATCK_SPELL_FIRE,-10],
-               [-ATCK_SPELL_SHOCK,20],
-               [-ATCK_SPELL_UNHOLY,20]
+               [-ATCK_SPELL_UNHOLY,-20]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/helmet/simphelm.kod
+++ b/kod/object/item/passitem/defmod/helmet/simphelm.kod
@@ -42,7 +42,7 @@ classvars:
    viInventory_group = 2
    viBroken_group = 4
 
-   viDefense_base = 20
+   viDefense_base = 50
    viDamage_base = 1
 
 properties:
@@ -66,7 +66,7 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_BLUDGEON,-10]
+      return [ [ATCK_WEAP_BLUDGEON,10]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/shield/goldshld.kod
+++ b/kod/object/item/passitem/defmod/shield/goldshld.kod
@@ -46,8 +46,8 @@ classvars:
    viInventory_group = 1
    viBroken_group = 4
 
-   viDefense_base = 10
-   viDamage_base = 1
+   viDefense_base = 20
+   viDamage_base = 2
 
 properties:
 
@@ -55,9 +55,8 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_SLASH,10],
-               [ATCK_WEAP_BLUDGEON,10],
-               [ATCK_WEAP_THRUST,10]
+      return [ [ATCK_WEAP_BLUDGEON,15],
+               [-ATCK_SPELL_FIRE,-10]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/shield/guilshld.kod
+++ b/kod/object/item/passitem/defmod/shield/guilshld.kod
@@ -552,7 +552,9 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_PIERCE,10] ];
+      return [ [ATCK_WEAP_PIERCE,10],
+               [-ATCK_SPELL_SHOCK,-10]
+             ];
    }
 
    GetBaseSpellModifier(oSpell=$)

--- a/kod/object/item/passitem/defmod/shield/knhtshld.kod
+++ b/kod/object/item/passitem/defmod/shield/knhtshld.kod
@@ -46,7 +46,7 @@ classvars:
    viGround_group = 3
    viInventory_group = 1
 
-   viDefense_base = 15
+   viDefense_base = 20
    viDamage_base = 2
 
 properties:
@@ -55,8 +55,8 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [-ATCK_SPELL_ALL,-20],
-               [ATCK_WEAP_PIERCE,10]
+      return [ [ATCK_WEAP_THRUST,15],
+               [-ATCK_SPELL_SHOCK,-10]
              ];
    }
 

--- a/kod/object/item/passitem/defmod/shield/metlshld.kod
+++ b/kod/object/item/passitem/defmod/shield/metlshld.kod
@@ -44,8 +44,8 @@ classvars:
    viGround_group = 3
    viInventory_group = 1
 
-   viDefense_base = 5
-   viDamage_base = 1
+   viDefense_base = 20
+   viDamage_base = 2
 
 properties:
 
@@ -53,7 +53,8 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [ATCK_WEAP_SLASH,10]
+      return [ [ATCK_WEAP_SLASH,15],
+               [-ATCK_SPELL_COLD,-10]
              ];
    }
 

--- a/kod/object/item/passitem/ring/resring.kod
+++ b/kod/object/item/passitem/ring/resring.kod
@@ -50,7 +50,7 @@ classvars:
 properties:
 
    piResistanceType = 0
-   piResistanceChange = 50
+   piResistanceChange = 70
 
 messages:
 
@@ -117,9 +117,10 @@ messages:
       return;
    }
 
+   % Resist rings lower the 4 major elemental damage types by 20, but boost one by 70, for a net change of +50.
    GetResistanceModifiers()
    {
-      return [[piResistanceType,piResistanceChange]];
+      return [[piResistanceType,piResistanceChange],[-ATCK_SPELL_FIRE,-20],[-ATCK_SPELL_SHOCK,-20],[-ATCK_SPELL_COLD,-20],[-ATCK_SPELL_ACID,-20]];
    }
 
    DefendingHit()

--- a/kod/object/item/passitem/ring/resring/acidring.kod
+++ b/kod/object/item/passitem/ring/resring/acidring.kod
@@ -41,7 +41,6 @@ classvars:
 properties:
 
    piResistanceType = -ATCK_SPELL_ACID
-   piResistanceChange = 50
 
 messages:
 

--- a/kod/object/item/passitem/ring/resring/coldring.kod
+++ b/kod/object/item/passitem/ring/resring/coldring.kod
@@ -41,7 +41,6 @@ classvars:
 properties:
 
    piResistanceType = -ATCK_SPELL_COLD
-   piResistanceChange = 50
 
 messages:
 

--- a/kod/object/item/passitem/ring/resring/firering.kod
+++ b/kod/object/item/passitem/ring/resring/firering.kod
@@ -41,7 +41,6 @@ classvars:
 properties:
 
    piResistanceType = -ATCK_SPELL_FIRE
-   piResistanceChange = 50
 
 messages:
 

--- a/kod/object/item/passitem/ring/resring/shokring.kod
+++ b/kod/object/item/passitem/ring/resring/shokring.kod
@@ -41,7 +41,6 @@ classvars:
 properties:
 
    piResistanceType = -ATCK_SPELL_SHOCK
-   piResistanceChange = 50
 
 messages:
 


### PR DESCRIPTION
With the upcoming ability to see your resistances, gear can be made more
complex without massively confusing people.
- Resistance rings still boost one of the 4 major elements by 50% as
  before, but now lower the other three by -20% at the same time. A Resist
  Fire ring, for example, will give you 50% Fire, -20% Cold, -20% Shock,
  and -20% Acid.
- Plate Armor was falling behind as a body armor, and has been improved
  against weapons, gaining 15% Weapon resistance in addition to its
  current 6 armor. However, it now has -20% Magic resistance. You will
  want to cover this with Resist Magic, seriously. Note that resist rings
  cover specific elements, and don't stack with this weakness. Plate's
  Weapon resistance also does not stack with specific bludgeon, thrust,
  slash, or pierce resists. If you can manage to get one, a Magic Spirit Helm
  will pretty much cover the Magic weakness of Plate.
- Scale armor has been terrible for years. In an attempt to boost it and
  make armors more sensible, Scale has been given the 25% Pierce
  resistance from Chain armor (which no longer has it). Scale armor now
  resists 10% bludgeon and 25% pierce in addition to its 4 armor. It is
  also weak to Magic by -10%, but resists Cold by 10%. You will want to
  wear this armor as a sort of mini-plate. For half the defense penalty
  and slightly less armor, you get 10% more pierce resistance, as well as
  less weakness to magic. Not recommended if you're going toe-to-toe
  with Scimitars, though.
- Nerudite Armor remains the same, giving 20% resistance to the 4 major
  elements (which will stack and cancel the penalty of resist rings).
  Note, however, Nerudite is -20% weak to Quake. You are not necessarily
  safe from clever mages.
- Chain Armor was too strong, and has lost its pierce resistance. It has
  also gained -10% to shock and -5% to fire. It remains a great melee
  armor, with 25% slash resist, 15% thrust resist, and 10% bludgeon
  resist, which does stack with shields. Clever fighters will notice that
  chain and scale together weigh the same as a plate armor - and
  one is specialized vs melee, while one is specialized vs arrows. If
  you're skilled enough, you can get more returns on your armor by
  switching mid-combat. Assuming, of course, that your opponent
  doesn't switch weapons faster than you switch armors.
- Leather Armor has always been horrible. Its defense has now been
  boosted to 200, and it has been given 10% resistance to slash, bludgeon,
  thrust, and pierce, which do stack with shields, although Leather has no
  actual direct armor. It resists shock by 15% and cold by 20%, but is
  -10% weak to fire and -20% weak to acid. As the only armor with no
  spellpower penalty and an actual boost to defense rating, Leather is
  uniquely suited for mages or players intending to capitalize on evasion.
- Ivy Circlet lost its gratuitous shock resistance, and its 20% unholy
  resistance is now a -20% weakness to unholy.
- All shields now offer the same 2 armor and 20 defense. However, Herald
  Shields are now -10% weak to Shock (but keep their 10% pierce resist).
  Knight's Shields lost their -20% weakness to all magic, but gained -10%
  weakness to shock, and now have 15% thrust resistance. Gold Shields now
  have 15% bludgeon resistance, but are -10% weak to fire. Finally, small
  round shields are 15% resistant to Slash, but -10% weak to cold. Orc
  Shields remain 15% resistant to Pierce and -20% weak to Holy.
- Helms now give 50 defense and 10% resistance to bludgeon. They're not
  worthless crap anymore. Before they actually made you MORE vulnerable to
  bludgeon!

Notable combinations are Scale + Orc Shield for 40% pierce resistance,
Chain + Small Round Shield for 40% slash resistance, Nerudite Armor
& Resist Rings to counteract the new -20% penalty to other elements from
the rings, and any bludgeon resist armor + Gold Round Shield + Helm to
reach 35% bludgeon resistance.
