### PR TITLE
Skill & Spell Softcap Settings

### DIFF
--- a/kod/object/passive/skill.kod
+++ b/kod/object/passive/skill.kod
@@ -14,9 +14,6 @@ constants:
 
    include blakston.khd
 
-   % The number to divide by when we are over our softcap of 2 * Requisite Stat.
-   SOFTCAP_PENALTY = 5
-
 resources:
 
    skill_name_rsc = "skill"
@@ -420,7 +417,7 @@ messages:
       % Are we above the spells requisite stat?  Apply the "soft cap".
       if iability > ((2*iRequisiteStat)-1)
       {
-         final = final / SOFTCAP_PENALTY;
+         final = final / bound(Send(Send(SYS,@GetSettings),@GetSkillSoftcapPenalty),1,$);
       }
 
       final = bound(final,1,$);

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -17,9 +17,6 @@ constants:
 
    SPELL_MURMUR_SQUARED = 64
 
-   % The number to divide by when over our softcap of 2 * Requisite Stat.
-   SOFTCAP_PENALTY = 4
-
    % How many castings of the same level of spell count toward a 1%
    %  bonus to improve the spell?
    CASTS_PER_PERCENT_BONUS = 7
@@ -1743,7 +1740,7 @@ messages:
       % Are we above the spells requisite stat?  Apply the "soft cap".
       if iability > ((2*requisitestat)-1)
       {
-         final = final / SOFTCAP_PENALTY;
+         final = final / bound(Send(Send(SYS,@GetSettings),@GetSpellSoftcapPenalty),1,$);
       }     
 
       final = bound(final,1,$);

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -183,6 +183,12 @@ properties:
    % Alternate Justicar system - buying a pardon with an indulgence
    % is now possible for a flat fee (initially 1 million).
    piPardonIndulgenceCost = 1000000
+   
+   % The divisor for all skill post-softcap imp rates. Higher means harder. One means softcaps don't matter at all.
+   piSkillSoftcapPenalty = 5
+   
+   % The divisor for all spell post-softcap imp rates.
+   piSpellSoftcapPenalty = 4
 
 messages:
 
@@ -455,6 +461,16 @@ GetPardonIndulgenceCost()
       return piPardonIndulgenceCost;
    }
 
+   GetSkillSoftcapPenalty()
+   {
+      return piSkillSoftcapPenalty;
+   }
+   
+   GetSpellSoftcapPenalty()
+   {
+      return piSpellSoftcapPenalty;
+   }
+   
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 


### PR DESCRIPTION
piSkillSoftcapPenalty and piSpellSoftcapPenalty are the divisors for the
softcap penalty when a player has more %s in a spell than double his
primary stat.

Currently, the spell penalty is / 4, and the skill penalty is / 5.

Setting either of these to 1 will effectively eliminate the softcap
penalty. Lower numbers are better. A spell softcap penalty of 2 means
imp chances are only halved, rather than quartered.

Values less than 1 will be bound to 1.

I recommend this be set to / 2 for spells under 103's current imp rates.
That will effectively halve the post-softcap penalty.
The current skill penalty seems fine.
