### PR TITLE
Lost Soldier Shield Graphics Fix

### DIFF
--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -1568,7 +1568,7 @@ messages:
             Send(poOwner,@ResetPlayerLegs,#alldone=FALSE);
          }
          
-         Send(poOwner,@RefreshPlayerVisualGear);
+         Post(poOwner,@RefreshPlayerVisualGear);
          
          oRoom = Send(poOwner,@GetOwner);
          if oRoom <> $


### PR DESCRIPTION
The bug was as follows:
- Delete was called in soldier shield first. At the end of delete, it
  called NewUnused on itself.
- NewUnused removes from back and removes stats, then propagates.
- NewUnused in defmod.kod removes the graphic, then propagates.
- NewUnused in item.kod calls UndoPlayerArt on itself
- UndoPlayerArt called RefreshPlayerVisualGear, my function for showing
  and layering all gear appropriately.
- RefreshPlayerVisualGear slings the soldier shield back on the player's
  back and puts the overlay back in.
- Everything returns, and Delete finally deletes the soldier shield.
  Unfortunately, the overlay was still there!

To fix this, I changed RefreshPlayerVisualGear's call so that it will
Post rather than Send. That way, gear will be refreshed AFTER everything
returns, and the soldier shield will no longer exist at that time.

The only reason this bug was limited to soldier shields is the fact that they
are the only armor that delete right off of a player's body. Theoretically,
this could have been done with any equipped item using the spell Shatter.
That would certainly have had potential to look goofy.
