### PR TITLE
Fix for admin weight bar errors.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -6867,8 +6867,17 @@ messages:
       local iCapacity_send, iMaxCapacity_send;
       
       iCapacity_send = Send(self,@GetWeightHold);
-      iMaxCapacity_send = Send(self,@GetWeightMax);
       
+      % GetWeightMax returns NIL in dm.kod, 3100 is capacity at 70 might
+      if IsClass(self,&DM)
+      {
+         iMaxCapacity_send = 3100;
+      }
+      else
+      {
+         iMaxCapacity_send = Send(self,@GetWeightMax);
+      }
+	  
       AddPacket(1,8, 4,user_stat_capacity, 1,STAT_VALUE, 1,STAT_INTEGER,
                 4,iCapacity_send, 4,0, 4,iMaxCapacity_send, 4,iCapacity_send);
 


### PR DESCRIPTION
DMs have no limit to how much can be held in inventory due to GetWeightMax() returning NIL in dm.kod. As a result, this was setting iMaxCapacity_send to NIL and causing lots of error messages whenever the Weight Carried bar was redrawn on a DM character. On DMs, this variable is now set to 3100 which is the max inventory space currently available to a 70 might character, so the bar fills at that point now.
