### PR TITLE
Set vigor to max for arena fights.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/tostwn/tswatch.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/tostwn/tswatch.kod
@@ -1901,7 +1901,7 @@ messages:
             Send(what,@GainMana,#amount=iAmount);
          }
 
-         Send(what,@AddExertion,#settothreshold=TRUE);
+         Send(what,@AddExertion,#amount=-2000000);
       }
       else
       {


### PR DESCRIPTION
This change would set the vigor of arena combatants to 200 when being teleported to the arena floor. Currently, the vigor is set to the player's resting vigor, but in the interests of making the arena more attractive to use I believe this change is necessary.

Note that original vigor will be restored if leaving the arena (and penalised if the fight is lost to prevent abuses for free vigor).
