### PR TITLE
Health, mana and vigor changes on death.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8465,16 +8465,16 @@ messages:
       if Send(SYS,@GetChaosNight)
       {
          % It's a frenzy!  Give us a leg up.
-         piHealth = piMax_Health / 2;
-         piMana = piMax_Mana / 2;
-         piVigor = 100;
+         piHealth = 4*(piMax_Health/5);
+         piMana = 4*(piMax_Mana/5);
+         piVigor = 200;
       }
       else
       {
          % We're not in a frenzy.  Give us the bare minimums.
          piMana = 1;
          piHealth = 1;
-         piVigor = bound(piVigor/4,0,50);   
+         piVigor = bound(piVigor/4,15,50);   
       }
       
       Send(self,@NewHealth);


### PR DESCRIPTION
Changed the amount of vigor remaining on death (arrival in underworld) to be bound between 15 and 40, instead of 0 and 40. This will mainly impact newer characters who have low vigor; now they won't be forced to painfully walk straight away.

Also changed the health, mana and vigor remaining on death in frenzies to be 80% max health and mana up from 50%, and vigor to 200 up from 100. Deaths are still penalised by having to rebuff spells and return to the fight, but this should lower the need for some players to use two or more characters to avoid the healing/mana regen time, and even the playing field for those with a single character.
