### PR TITLE
Allow groundworms/queens to be hit with maces, add failure to hit msg.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/grdworm.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/grdworm.kod
@@ -48,6 +48,8 @@ resources:
    GroundWorm_sound_death = gwrmdie.wav
    GroundWorm_sound_aware = gwrm1awr.wav
 
+   groundworm_cannot_hit = "You are unable to reach the groundworm with your attacks."
+
 classvars:
 
    vrKocName = GroundWorm_koc_name_rsc
@@ -390,9 +392,11 @@ messages:
       {
          if use_weapon = $
             OR NOT (IsClass(use_weapon,&Hammer)
-                    OR IsClass(use_weapon,&SpiritualHammer))
+               OR IsClass(use_weapon,&SpiritualHammer)
+               OR IsClass(use_weapon,&Mace))
          { 
-            return FALSE; 
+            Send(who,@MsgSendUser,#message_rsc=groundworm_cannot_hit);
+            return FALSE;			
          }
       }
 


### PR DESCRIPTION
As title says, allow maces to hit groundworms and queens in addition to larvae, also add a message if the current/no weapon cannot hit the groundworm so newbies know they can't hit it. I was tempted to expand the message with a reference to perhaps using a blunt weapon, but I think most players would already try a different weapon, or ask other players why it didn't work.
