### PR TITLE
Allow Caramo to post pardons in book, fix for money taken.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.kod
@@ -178,7 +178,7 @@ messages:
        
 	     return true;      
       }
-      send(oMoney,@SubtractNumber,#number=amount);
+      send(oMoney,@SubtractNumber,#number=Send(Send(SYS,@GetSettings),@GetPardonIndulgenceCost));
       send(self,@PerformIndulgencePardonMurderer,#who=who);
       post(poOwner,@SomeoneSaid,#what=self,#string=indulgence_success,#type=SAY_RESOURCE);
       return true;

--- a/kod/object/passive/news/newsjust.kod
+++ b/kod/object/passive/news/newsjust.kod
@@ -28,7 +28,17 @@ properties:
 messages:
 
    GetNewsPermission(what = $)
-   {
+   { 
+      local oCaramo;
+
+      oCaramo = Send(SYS,@GetCaramo);
+
+      if what=oCaramo
+         OR IsClass(what,&DM)
+      {	 
+         return NEWS_PERMISSION_READ_WRITE;
+      }
+      
       return NEWS_PERMISSION_READ;
    }
 


### PR DESCRIPTION
The ability of Caramo to post pardons in the Book of Jala was removed in commit https://github.com/Daenks/Meridian59_103/commit/2ea9198d137fd430723e7b4340c18e611c5f5429 but I'm not 100% sure why, as it doesn't seem to cause errors. Adding it back in unless there's a reason for her not to post them. 

Also, when a player pays for a pardon the current behavior is to remove the amount of money offered when the pardon is  completed, so if a player offers her 50 million gold the code checks that it is above the amount required (1 mil) then removes the entire lot from the player. This fixes it to check the offered amount against the required amount and if successful, removes the required amount.
