### PR TITLE
Fix char bio crashes, increment client version number.

### DIFF
--- a/clientd3d/client.c
+++ b/clientd3d/client.c
@@ -28,7 +28,7 @@ char *szAppName;
 /************************************************************************/
 void _cdecl dprintf(char *fmt,...)
 {
-	char s[200];
+	char s[300];
 	va_list marker;
 	DWORD written;
 
@@ -36,7 +36,7 @@ void _cdecl dprintf(char *fmt,...)
 	vsprintf(s,fmt,marker);
 	va_end(marker);
 
-	assert(strlen(s)<200);	/* overflowed local stack buffer, increase sizeof s buffer */
+	assert(strlen(s)<300);	/* overflowed local stack buffer, increase sizeof s buffer */
 
 	_RPT1(_CRT_WARN,"dprintf() says : %s",s);
 

--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -49,7 +49,7 @@ typedef unsigned char Bool;
 enum {False = 0, True = 1};
 
 #define MAJOR_REV 50   /* Major version of client program */
-#define MINOR_REV 4  /* Minor version of client program; must be in [0, 99] */
+#define MINOR_REV 5  /* Minor version of client program; must be in [0, 99] */
 
 #define MAXAMOUNT 9     /* Max # of digits in a server integer */
 #define MAXSTRINGLEN 255 /* Max length of a string loaded from string table */


### PR DESCRIPTION
Stops the rare crashes from too many lines in a player's bio (the 'honor strings' section). Increment client version number.
