### PR TITLE
Force removal of newbie tag at two meridian years.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1642,7 +1642,8 @@ messages:
          AND NOT (piFlags & PFLAG_TUTORIAL)
       {
          Send(self,@SetPlayerFlag,#flag=PFLAG_TUTORIAL,#value=TRUE);
-         if StringEqual(psHonor,player_newbie_honor_string)
+         if psHonor <> $
+            AND StringEqual(psHonor,player_newbie_honor_string)
          {
             Send(self,@SetHonorString);
          }

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -1238,8 +1238,14 @@ messages:
 
    NewYear()
    {
+      local i;
       Send(self,@NewYearClean);
       piYear = piYear + 1;
+	  
+	  for i in plUsers
+         {
+            Send(i,@GetAge);
+         }
 
       return;
    }


### PR DESCRIPTION
NewYear() in system.kod now calls GetAge() for each player, which will remove newbie tags from all players over 2 meridian years old who still have it. This should fix most instances of the bug where this can remain on a player, and I currently am unable to replicate other instances of this bug locally.
