### PR TITLE
Cyberjunk's guild password fix, also allow DMs to teleport players anywhere except 901.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -7598,14 +7598,6 @@ messages:
          iFineCol = Send(what,@GetFineCol);
       }
 
-      % Security check:
-      % Regular players cannot be teleported to new region with this function
-      if NOT IsClass(self,&DM)
-         AND (Send(poOwner,@GetRegion) <> Send(oNew_room,@GetRegion))
-      {
-         return FALSE;
-      }
-
       if iRow = $ OR iCol = $
       {
          Debug("Got bad row or column for object",what);


### PR DESCRIPTION
From pull #336:

This is a small security fix.

Right now the guildpassword is transferred to any member, including the lowest ranks.
It's just not visible in the original client because the whole "guildmaster" tab is not displayed.

With this fix the password is only transferred to the guildmaster.
