### PR TITLE
Fix for Death breaking Radius Enchantments

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -2798,8 +2798,10 @@ messages:
 
    EnchantmentTimer(timer = $)
    {
-      local i,oEnchanter;
+      local i,oEnchanter, bDoReset;
  
+      bDoReset = FALSE;
+       
       for i in plEnchantments
       {
          if First(i) = timer
@@ -2812,13 +2814,23 @@ messages:
             {
                Send(Nth(i,2),@EndEnchantment,#who=self);
             }
+            
+            if NOT IsClass(Nth(i,2),&RadiusEnchantment)
+            {
+               bDoReset = TRUE;
+            }
 
             Send(self,@ShowRemoveEnchantment,#what=Nth(i,2),
                  #type=ENCHANTMENT_PLAYER);
 
             % TODO: i no longer exists at this point?  EndEnchantment removing it?
             plEnchantments = DelListElem(plEnchantments,i);
-            Send(self,@ResetPlayerFlagList,#who=self);
+            
+            If bDoReset
+            {
+               Send(self,@ResetPlayerFlagList,#who=self);
+            }
+
             if poOwner <> $
             {
                Send(poOwner,@SomethingChanged,#what=self);


### PR DESCRIPTION
This will prevent RemoveAllEnchantments from ending Radius Enchantments
(which have their own ending mechanisms for room change, which comes
with death).
