### PR TITLE
Mirth and melancholy fixes.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -323,10 +323,11 @@ messages:
    % For a monster, the stroke_obj is itself.
    TryAttack(what = $,stroke_obj=$)
    {
-      local iChanceToHit, iDamage, oWeapon;
+      local iAddChance, iChanceToHit, iDamage, lRadiusState, oWeapon;
 
       oWeapon = Send(self,@GetWeapon);
-
+      iAddChance = 0;
+	  
       % Derived class should have checked all specific restrictions by this
       %  point.
 
@@ -336,8 +337,27 @@ messages:
                       * EQUAL_CHANCE_HIT)
                      / Send(what,@GetDefense,#what=self,
                             #stroke_obj=stroke_obj);
-      iChanceToHit = bound(iChanceToHit,10,95);
-      if iChanceToHit >= random(1,100)
+      
+      % Check for mirth and melancholy here, to avoid errors in GetOffense()
+      if IsClass(self,&Player)
+      {
+         if Send(self,@IsAffectedByRadiusEnchantment,#byClass=&Melancholy)
+         {
+            lRadiusState = Send(self,@GetMostPowerfulRadiusEnchantmentState,#byClass=&Melancholy);
+            iAddChance = Send(Nth(lRadiusState,1),@AddChanceToHit,#who=self,#what=what,#lRadiusState=lRadiusState);
+         }
+      
+         if Send(self,@IsAffectedByRadiusEnchantment,#byClass=&Mirth)
+         {
+            lRadiusState = Send(self,@GetMostPowerfulRadiusEnchantmentState,#byClass=&Mirth);
+            iAddChance = Send(Nth(lRadiusState,1),@AddChanceToHit,#who=self,#what=what,#lRadiusState=lRadiusState);
+         }
+      }
+	  
+	  iChanceToHit = iChanceToHit + iAddChance;
+	  	 	  
+	  iChanceToHit = bound(iChanceToHit,10,95);
+	  if iChanceToHit >= random(1,100)
       {
          % We hit!
          iDamage = Send(what,@AssessDamage,#what=self,

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4490,19 +4490,7 @@ messages:
       {
          iOffense = Send(i,@ModifyHitRoll,#who=self,#what=what,
                          #hit_roll=iOffense,#stroke_obj=stroke_obj);
-      }
-      
-      if Send(self,@IsAffectedByRadiusEnchantment,#byClass=&Melancholy)
-      {
-         lRadiusState = Send(self,@GetMostPowerfulRadiusEnchantmentState,#byClass=&Melancholy);
-         iOffense = Send(Nth(lRadiusState,1),@ModifyHitRoll,#who=self,#what=what,#hit_roll=iOffense);
-      }
-      
-      if Send(self,@IsAffectedByRadiusEnchantment,#byClass=&Mirth)
-      {
-         lRadiusState = Send(self,@GetMostPowerfulRadiusEnchantmentState,#byClass=&Mirth);
-         iOffense = Send(Nth(lRadiusState,1),@ModifyHitRoll,#who=self,#what=what,#hit_roll=iOffense);
-      }
+      }      
 
       iOffense = iOffense + Send(Send(SYS,@GetParliament),
                                  @GetFactionHitrollBonus,#who=self);

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -568,7 +568,11 @@ messages:
          AND action <= UA_WRY
       {
          piAction = action;
-         Send(poOwner,@SomethingDidAction,#what=self,#action=action);
+         
+         if poOwner <> $
+         {
+            Send(poOwner,@SomethingDidAction,#what=self,#action=action);
+         }
       }
 
       return;

--- a/kod/object/passive/spell/radiusench/jala/melcholy.kod
+++ b/kod/object/passive/spell/radiusench/jala/melcholy.kod
@@ -96,16 +96,20 @@ messages:
 
    % Stuff we handle to be an attack modifier.
 
-   ModifyHitRoll(who = $,what = $,hit_roll = $)
+   AddChanceToHit(who=$,what=$,lRadiusState=0)
    {
+      local addChance;
+	  
+      addChance = 0;
+	  
       % Only affect the good ones...
       if Send(what,@GetKarma,#detect=TRUE) > 0
       {
-         % Give a small bonus
-         return hit_roll + 100;
+         % Add 1-5% chance to hit, based on spellpower
+         addChance = ((Nth(lRadiusState,2))+1)/20;
       }
 
-      return hit_roll;
+      return addChance;
    }
    
    ModifyDamage(who = $,what = $,damage = $)
@@ -120,6 +124,10 @@ messages:
       return damage;
    }
 
+   ModifyHitRoll(who=$,what=$,damage=$)
+   {
+      return damage;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/radiusench/jala/mirth.kod
+++ b/kod/object/passive/spell/radiusench/jala/mirth.kod
@@ -96,16 +96,20 @@ messages:
 
    % Stuff we handle to be an attack modifier.
 
-   ModifyHitRoll(who = $,what = $,hit_roll = $)
+   AddChanceToHit(who=$,what=$,lRadiusState=0)
    {
+      local addChance;
+	  
+      addChance = 0;
+	 
       % Only affect the evil ones...
       if Send(what,@GetKarma,#detect=TRUE) < 0
       {
-         % Give a small bonus
-         return hit_roll + 100;
+         % Add 1-5% chance to hit, based on spellpower
+         addChance = ((Nth(lRadiusState,2))+1)/20;
       }
 
-      return hit_roll;
+      return addChance;
    }
    
    ModifyDamage(who = $,what = $,damage = $)
@@ -120,6 +124,10 @@ messages:
       return damage;
    }
 
-
+   ModifyHitRoll(who=$,what=$,damage=$)
+   {
+      return damage;
+   }
+   
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Mirth and melancholy were returning a large amount of errors due to giving +hitroll in GetOffense(). The issue is because ModifyHitRoll() in the mirth and melancholy kod files tries to retrieve the karma from the target, so when GetOffense() is called with no target to draw the player's stat bar, it gives an error trying to get the karma of a $ object. There are several ways to solve this issue (and perhaps some simpler than what I implemented) however since the offense bar will either be inaccurate vs good or evil targets with the spell up, I've moved the mirth/melancholy check to battler.kod and made it add spellpower/20 chance to hit (1-5%, total still bound at 95%).

This will probably be modified in the next revamp of radius enchantments but for now it's an error free, 100% working implementation. I would have left it as-is but for the amount of generated errors.

I also stopped SetAction() in user.kod from trying to send SomethingDidAction to a $ room when mirth/melancholy reset the player's facial expression when a player logs off.
