### PR TITLE
Allows swinging while on spell cooldown.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -955,6 +955,7 @@ properties:
    piJustified_kill_count = 0
 
    ptAttackTimer = $
+	ptCastTimer = $
 
    psHonor = $
 
@@ -1068,6 +1069,12 @@ messages:
       {
          DeleteTimer(ptAttackTimer);
          ptAttackTimer = $;
+      }
+		
+      if ptCastTimer <> $
+      {
+         DeleteTimer(ptCastTimer);
+         ptCastTimer = $;
       }
 
       Send(self,@RemoveAllEnchantments,#report=FALSE);
@@ -4188,7 +4195,11 @@ messages:
       if NOT Send(self,@IsOkayAttackTime) 
       {
          return FALSE;
-      }  
+      }
+
+		Send(self,@StartAttackTimer);
+		
+		Send(self,@StartCastTimer);
 
       % Is it in the same room?
       if poOwner <> Send(what,@GetOwner) 
@@ -5648,42 +5659,78 @@ messages:
       return;
    }
 
-   IsOkayAttackTime(time = 1000, seconds = $)
-   "Have we waited long enough since the last attack/spell?  Sets new valid attack time."
-   "(time in msec, default 1 second)"
+   IsOkayAttackTime()
    {
-      local i;
-
       if ptAttackTimer <> $
       {
          return FALSE;
       }
 
-      if seconds <> $
+      return TRUE;
+   }
+	
+   StartAttackTimer(time=1000)
+   {
+		if ptAttackTimer <> $
+		{
+			if time > GetTimeRemaining(ptAttackTimer)
+			{
+				DeleteTimer(ptAttackTimer);
+				ptAttackTimer = $;
+			}
+		}
+		
+      if time > 0 AND ptAttackTimer = $
       {
-         i = seconds*1000;
-      }
-      else
-      {
-         i = time;
-      }
-
-      if i > 0
-      {
-         ptAttackTimer = CreateTimer(self,@AttackTimer,i);
+         ptAttackTimer = CreateTimer(self,@AttackTimer,time);
       }
       
-      return TRUE;
+      return;
    }
 
    AttackTimer()
-   "Sets the attack timer variable to NIL so we know it's okay to attack again."
    {
       ptAttackTimer = $;
 
       return;
    }
 
+   IsOkayCastTime()
+   {
+      if ptCastTimer <> $
+      {
+         return FALSE;
+      }
+
+      return TRUE;
+   }
+	
+   StartCastTimer(time=1000)
+   {
+		if ptCastTimer <> $
+		{
+			if time > GetTimeRemaining(ptCastTimer)
+			{
+				DeleteTimer(ptCastTimer);
+				ptCastTimer = $;
+			}
+		}
+		
+      if time > 0 AND ptCastTimer = $
+      {
+         ptCastTimer = CreateTimer(self,@CastTimer,time);
+      }
+      
+      return;
+   }
+
+   CastTimer()
+   {
+      ptCastTimer = $;
+
+      return;
+   }
+	
    SendAttackOutOfRangeMessage(what = $, use_weapon = $, stroke_obj = $)
    {
       if use_weapon <> $
@@ -12839,6 +12886,12 @@ messages:
       {
          DeleteTimer(ptAttackTimer);
          ptAttackTimer = $;
+      }
+		
+      if ptCastTimer <> $
+      {
+         DeleteTimer(ptCastTimer);
+         ptCastTimer = $;
       }
 
       time = GetTime();

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -4875,6 +4875,10 @@ messages:
       {
          return;
       }
+		
+		Send(self,@StartAttackTimer);
+		
+		Send(self,@StartCastTimer);
 
       if action = UA_WAVE
       {

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -744,13 +744,6 @@ messages:
          }
       }
       
-      if NOT Send(who,@IsOkayAttackTime,#seconds=viPostCast_Time)
-      {
-         return FALSE;
-      }
-
-      oRoom = Send(who,@GetOwner);
-
       oVictim = $;
       % Only have a victim if we're not aiming at a group.
       if lTargets <> $
@@ -758,6 +751,27 @@ messages:
       {
          oVictim = First(lTargets);
       }
+
+      if NOT Send(who,@IsOkayAttackTime)
+      {		
+         return FALSE;
+      }
+		
+      if NOT Send(who,@IsOkayCastTime)
+      {
+			if oVictim <> $ AND viHarmful
+			{
+				Send(who,@UserAttack,#what=oVictim);
+			}
+			
+         return FALSE;
+      }
+		
+		Send(who,@StartAttackTimer);
+
+		Send(who,@StartCastTimer,#time=viPostCast_time*1000);
+
+      oRoom = Send(who,@GetOwner);
 
       % Do they have a token?  Avoid token PKing or mule abuse.
       if (oVictim = $ OR oVictim <> who)


### PR DESCRIPTION
..but still mainstains a mutual lockout of 1 second. If a post cast delay is longer than that, you can swing a weapon while waiting for your spell to go off CD instead of being inactive. Also, if you are casting a harmful targeted spell, but your spell is currently on cooldown, you instead try to attack with your current weapon. This means that holding down the splash hotkey will alternately cast the splash spell and swing at the enemy.

The point of this is:
1) A quality of life improvement.
2) Making splash spells more viable, since they now replace one auto attack, instead of two.
3) Allowing post cast delays to be used for spell lockouts, instead of completely rendering a player inactive for the time of the post cast delay. This means we can now balance spells over cast delays properly. i.e. we could give Karahol a 20 second post cast delay, forcing the player to swing only without being able to cast. Generally, the framework is easier to work with.

This is simply to see if we generally like the concept and if we want to go that route. There are tons of modifications that can be made. 
