### PR TITLE
Ammo use will mirror reagent use, or no arrow cost in Arena unless tournament is held.

### DIFF
--- a/kod/object/passive/skill/stroke/fire.kod
+++ b/kod/object/passive/skill/stroke/fire.kod
@@ -142,8 +142,9 @@ messages:
 
    PayCosts(who=$)
    {
-      local oAmmo;
+      local oAmmo, oRoom;
 
+      oRoom = Send(who,@GetOwner);
       oAmmo = Send(self,@FindLikelyAmmo,#who=who);
       if oAmmo = $
       {


### PR DESCRIPTION
Set SubtractNumber in fire.kod to only be called if pbNoReagents is false. Now when reagent use is turned off for a room (arena when tournaments aren't in session, or frenzies) ammo use is also turned off. Players will still need to have at least one arrow of the type they want to use.
