### PR TITLE
Changed daenks.org to openmeridian.org in client connect string

### DIFF
--- a/clientd3d/config.c
+++ b/clientd3d/config.c
@@ -117,7 +117,7 @@ static char INIQuickStart[]   = "QuickStart";
 
 static int   DefaultRedialDelay   = 60;
 static char  DefaultHostname[]    = "cheater";
-static char  DefaultDomainFormat[] = "meridian%d.daenks.org"; // MUST have a %d in it somewhere.
+static char  DefaultDomainFormat[] = "meridian%d.openmeridian.org"; // MUST have a %d in it somewhere.
 static char  DefaultSockPortFormat[] = "59%.2d";
 static int   DefaultServerNum     = -1;
 static int   DefaultTimeout       = 1440; // 1 day in minutes (60*24)


### PR DESCRIPTION
For new EC2 infrastructure as well as professionalism.
