### PR TITLE
Match resist spell descriptions to reagent cost.

### DIFF
--- a/kod/object/passive/spell/persench/resist/resacid.kod
+++ b/kod/object/passive/spell/persench/resist/resacid.kod
@@ -21,7 +21,7 @@ resources:
    ResistAcid_desc_rsc = \
       "Coats your body in a magical goo which "
       "absorbs damage from acid attacks for several minutes.  "
-      "Requires herbs and entroot berries."
+      "Requires one entroot berry to cast."
 
    ResistAcid_intro = "Shal'ille Lv. 2: Coats your body in a magical goo which "
       "absorbs damage from acid attacks."

--- a/kod/object/passive/spell/persench/resist/rescold.kod
+++ b/kod/object/passive/spell/persench/resist/rescold.kod
@@ -21,8 +21,8 @@ resources:
    resistcold_desc_rsc = \
       "Infuses the target with the magical fire of Faren, "
       "reducing damage from cold attacks for several minutes.  "
-      "Requires mushrooms and red mushrooms to cast."
-   
+      "Requires one red mushroom to cast."
+
    resistcold_already_enchanted = "You are already resistant to cold."
 
    resistcold_on = "The magical fire of Faren enters your body."

--- a/kod/object/passive/spell/persench/resist/resevil.kod
+++ b/kod/object/passive/spell/persench/resist/resevil.kod
@@ -19,11 +19,11 @@ resources:
    resistevil_name_rsc = "holy resolve"
    resistevil_icon_rsc = iholyres.bgf
    resistevil_desc_rsc = \
-     "Shal'ille is summoned to fortify the soul against unholy damage.  "
-	  "Requires solagh and fairy wings to cast."
+      "Shal'ille is summoned to fortify the soul against unholy damage.  "
+      "Requires a single fairy wing to cast."
 
    resistevil_spell_intro = "Shal'ille Level 1: Protects you from damage from unholy sources."
-	  
+
    resistevil_success = "You fortify %s%s against evil."
    resistevil_already_enchanted = "You already have holy resolve."
 

--- a/kod/object/passive/spell/persench/resist/resfire.kod
+++ b/kod/object/passive/spell/persench/resist/resfire.kod
@@ -21,7 +21,7 @@ resources:
    resistfire_desc_rsc = \
       "Infuses your body with cool magical energy which "
       "reduces damage from fire attacks for several minutes.  "
-      "Requires mushrooms and red mushrooms."
+      "Requires one red mushroom."
    
    resistfire_already_enchanted = "You are already resisting fire."
    resistfire_success = "You bathe %s%s in magical protection from fire."

--- a/kod/object/passive/spell/persench/resist/resgood.kod
+++ b/kod/object/passive/spell/persench/resist/resgood.kod
@@ -20,7 +20,7 @@ resources:
    resistgood_icon_rsc = iresgood.bgf
    resistgood_desc_rsc = \
       "Summons the vile force of Qor to protect the user from holy damage.  "
-      "Requires solagh and fairy wings to cast."
+      "Requires a single fairy wing to cast."
 
    resistgood_spell_intro = "Qor Level 1: Protects you from damage from holy sources."
 

--- a/kod/object/passive/spell/persench/resist/resmagic.kod
+++ b/kod/object/passive/spell/persench/resist/resmagic.kod
@@ -20,7 +20,7 @@ resources:
    resistmagic_icon_rsc = iresmagc.bgf
    resistmagic_desc_rsc = \
       "The war god fortifies you against magic attacks.  "
-      "Requires blue dragon scale to cast."
+      "Requires a blue dragon scale to cast."
    
    resistmagic_already_enchanted = "You are already resisting magic."
    resistmagic_success = "Kraanan fortifies %s%s against magic attacks."

--- a/kod/object/passive/spell/persench/resist/resshock.kod
+++ b/kod/object/passive/spell/persench/resist/resshock.kod
@@ -24,8 +24,8 @@ resources:
    resistshock_icon_rsc = iresshok.bgf
    resistshock_desc_rsc = \
       "The grizzled nature god gives the target some relief from shock attacks.  "
-      "Requires mushrooms and blue mushrooms to cast."
-   
+      "Requires one blue mushroom to cast."
+
    resistshock_already_enchanted = "You are already resisting shocks."
    resistshock_success = "Faren fortifies %s%s against shock attacks."
    resistshock_on = "Faren fortifies you against shock attacks."


### PR DESCRIPTION
Reagent cost was lowered for the resist spells in a previous update but the descriptions weren't changed. Also, the updated reagents aren't active on 103; it might need a recreateall or send c spell resetreagents.
