### PR TITLE
Send users with outdated clients to Patcher download page.

### DIFF
--- a/clientd3d/download.c
+++ b/clientd3d/download.c
@@ -733,7 +733,6 @@ void DownloadExit(void)
 void DownloadNewClient(char *hostname, char *filename)
 {
   SHELLEXECUTEINFO shExecInfo;
-  char update_program_path[MAX_PATH];
 
   if (AreYouSure(hInst, hMain, YES_BUTTON, IDS_NEEDNEWVERSION))
   {


### PR DESCRIPTION
Removed the code for opening club.exe if the client is outdated. Instead, users will be directed to download the new Patcher, and should run that to update their client. Client will exit after opening the page.
