### PR TITLE
Solo builder Advancement Fix

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8273,6 +8273,7 @@ messages:
                AND NOT group_member_kill
                AND killing_blow
                AND Send(self,@CheckPlayerFlag,#flag=PFLAG_TOOK_DAMAGE)
+               AND monster_level > piBase_Max_health
             {
                gain = gain + 1;
             }


### PR DESCRIPTION
Put a level check on monsters for the solo builder bonus. Otherwise,
players could advance slightly on low mobs.
