### PR TITLE
Touch spells give the caster some light

### DIFF
--- a/kod/object/passive/spell/persench/touchatk.kod
+++ b/kod/object/passive/spell/persench/touchatk.kod
@@ -115,6 +115,15 @@ messages:
       %  we've checked for re-enchantment in CanPayCosts.
       Send(who,@RemoveEnchantmentClass,#class=&TouchAttackSpell);
       
+      Send(who,@GainLight,#amount=20);
+      
+      propagate;
+   }
+
+   EndEnchantment(who = $, report = TRUE, state = 0)
+   {
+      Send(who,@LoseLight,#amount=20);
+      
       propagate;
    }
 


### PR DESCRIPTION
Casting touch spells will give their wielder 20 light, because their
hands are glowing.
