### PR TITLE
Fix for detect good/evil not adding state to enchantment list.

### DIFF
--- a/kod/object/passive/spell/persench/detevil.kod
+++ b/kod/object/passive/spell/persench/detevil.kod
@@ -114,19 +114,7 @@ messages:
 
    GetPotionClass()
    {
-      RETURN &DetectEvilPotion;
-   }
-
-   EffectDesc(who=$)
-   {
-      AppendTempString("\n\n");
-      AppendTempString("Your current ");
-      AppendTempString(Send(self,@GetName));
-      AppendTempString(" enchantment allows you to see those who serve evil for ");
-      AppendTempString(2400 * (100+Send(who,@GetEnchantedState,#what=self)));
-      AppendTempString(" milliseconds.");
-
-      return;
+      return &DetectEvilPotion;
    }
 
 end

--- a/kod/object/passive/spell/persench/detgood.kod
+++ b/kod/object/passive/spell/persench/detgood.kod
@@ -115,19 +115,7 @@ messages:
 
    GetPotionClass()
    {
-      RETURN &DetectGoodPotion;
-   }
-
-   EffectDesc(who=$)
-   {
-      AppendTempString("\n\n");
-      AppendTempString("Your current ");
-      AppendTempString(Send(self,@GetName));
-      AppendTempString(" enchantment allows you to see the good of heart for ");
-      AppendTempString(2400 * (100+Send(who,@GetEnchantedState,#what=self)));
-      AppendTempString(" milliseconds.");
-
-      return;
+      return &DetectGoodPotion;
    }
 
 end


### PR DESCRIPTION
Currently these spells don't have a function to retrieve the state when cast (in this case, state = spellpower). This is causing an error to be logged on the server, so I added the function and cleaned up the files a bit.
