### PR TITLE
Shrine save over recreateall fixed (for real).

### DIFF
--- a/kod/object/passive/shrine.kod
+++ b/kod/object/passive/shrine.kod
@@ -79,7 +79,7 @@ properties:
 
    % This records the school the shrine boosts.
    piAllegiance = 0
-   
+
 messages:
 
    Constructor(shrine_num=0,name_rsc=$)
@@ -91,7 +91,7 @@ messages:
 
       piShrine_num = shrine_num;
       Send(SYS,@AddShrine,#oShrine=self,#num=shrine_num);
-	
+
       propagate;
    }
 
@@ -106,12 +106,12 @@ messages:
       }
       else
       {
-	      AddPacket(4,shrine_dedicated);
-	      AddPacket(4,Send(self,@GetName));
+         AddPacket(4,shrine_dedicated);
+         AddPacket(4,Send(self,@GetName));
 
          % Find any spell, any will give us the school string.
          oSpell = Send(SYS,@FindSpellByNum,#num=SID_BLINK);
-         AddPacket(4,Send(oSpell,@GetSchoolStr,#ischool=piAllegiance));
+         AddPacket(4,Send(oSpell,@GetSchoolStr,#iSchool=piAllegiance));
       }
 
       return;
@@ -123,35 +123,35 @@ messages:
 
       if piShrine_num = 0
       {
-         debug("this shrine node was not assigned an ID!  Invalid!");
+         Debug("this shrine node was not assigned an ID!  Invalid!");
 
          return FALSE;
-      }      
+      }
 
-      if isClass(what,&Offering)
+      if IsClass(what,&Offering)
       {
          Send(self,@MakeOffering,#oOffering=what);
       }
       else
       {
          % Show our disappointment
-         Send(poOwner,@Someonesaid,#type=SAY_MESSAGE,#what=self,
-              #string=Shrine_unsatisfied);          
+         Send(poOwner,@SomeoneSaid,#type=SAY_MESSAGE,#what=self,
+               #string=Shrine_unsatisfied);
       }
 
       return;
    }
-      
+
    MakeOffering(oOffering=$)
    {
       piAllegiance = Send(oOffering,@GetAllegiance);
       Send(SYS,@RecomputeShrineTotals);
-      
+
       % If we find one, then switch over to that god.
       Send(poOwner,@SomeoneSaid,#type=SAY_MESSAGE,#what=self,
-           #string=Shrine_satisfied,#parm1=Send(oOffering,@Getname));         
+            #string=Shrine_satisfied,#parm1=Send(oOffering,@GetName));
       Send(self,@TellServer);
-      
+
       % Remove the offering - the gods eat it.
       Send(oOffering,@Delete);
       Send(poOwner,@ShrineUsed);
@@ -175,7 +175,7 @@ messages:
          rSound = Shrine_Qor_sound;
       }
 
-      if piAllegiance = SS_KRAANAN    
+      if piAllegiance = SS_KRAANAN
       {
          rRsc = Shrine_Kraanan_text;
          rSound = Shrine_Kraanan_sound;
@@ -198,13 +198,13 @@ messages:
          rRsc = Shrine_Jala_text;
          rSound = Shrine_Jala_sound;
       }
-      
+
       for iUserCntr in Send(SYS,@GetUsersLoggedOn)
       {
          Post(iUserCntr,@MsgSendUser,#message_rsc=rRsc);
          Post(iUserCntr,@WaveSendUser,#wave_rsc=rSound);
       }
-      
+
       return;
    }
 
@@ -223,7 +223,7 @@ messages:
       return piAllegiance;
    }
    
-   SetAllegiance(allegiance = $)
+   SetAllegiance(allegiance=$)
    {
       piAllegiance = allegiance;
       return;
@@ -241,7 +241,5 @@ messages:
       propagate;
    }
 
-
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -688,7 +688,6 @@ messages:
       piRecreate_State = RECREATE_PHASE_FIVE;
 
       Send(self,@RecreateLearnAdvice);
-      Send(self,@RecomputeShrineTotals);
       Send(self,@RecreateMonsterTemplates);
       Send(self,@RecreateItemTemplates);
       Send(self,@RecreateMoneyTemplates);
@@ -2883,12 +2882,12 @@ messages:
    ReturnShrineAllegiance()
    {
       % Returns proper shrine allegiance at RecreateAll phase 5
-	  
+
       local i, n;
       if plShrine_Allegiances <> $
       {
          n = 5;
-         
+
          for i in plShrines
          {
             Send(i,@SetAllegiance,#allegiance=(Nth(plShrine_Allegiances,n)));
@@ -2896,10 +2895,13 @@ messages:
          }
       }
       plShrine_Allegiances = $;
-      
+
+      % We have to recalculate the allegiance if we want the power to register
+      Send(self,@RecomputeShrineTotals);
+
       return;
    }
-   
+
    GetShrineBonus(school=$)
    {
       if school = $ OR school <> bound(school,SS_SHALILLE,SS_JALA)


### PR DESCRIPTION
The last fix I put in was returning the correct allegiance to the shrines, but it turns out there's another function that recalculates the power each shrine is giving and makes it 'active', and this was still running earlier in RecreateAll than the allegiance return function (so all powers were set to 0). This is now confirmed to work correctly, which I can now actually check thanks to my spellpower readouts :) Also, I cleaned up shrine.kod for whitespace/grammar since I was there anyway looking for answers.

Thanks to the players who didn't give up when they were sure something was wrong, you are really the ones who fixed this bug.
