### PR TITLE
Proper resizing of IDC_APPLY (use buttons).

### DIFF
--- a/clientd3d/dialog.c
+++ b/clientd3d/dialog.c
@@ -35,6 +35,7 @@ static ChildPlacement desc_controls[] = {
 	{ IDC_URLLABEL,    RDI_BOTTOM },
 	{ IDC_URLBUTTON,   RDI_BOTTOM },
 	{ IDC_URL,         RDI_BOTTOM },
+	{ IDC_APPLY,       RDI_BOTTOM },
 	{ 0,               0 },   // Must end this way
 };
 


### PR DESCRIPTION
For some reason, IDC_APPLY (the use button when an item has the flag APPLY_YES) was not being resized to the bottom of dialog boxes like other buttons were. This is an issue for any item with a decently long description. This fix adds IDC_APPLY to the list of child features resized when a dialog box gets bigger or smaller.
