### PR TITLE
Shroud changes/bugfix: only cast on weapons/armor, cast timer lowered, overwriteable.

### DIFF
--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -1369,34 +1369,41 @@ messages:
 
       iSpell = Send(oSpell,@GetSpellNum);
       if iSpell = SID_HOLY_WEAPON
-         OR iSpell = SID_UNHOLY_WEAPON 
+         OR iSpell = SID_UNHOLY_WEAPON
          OR iSpell = SID_ENCHANT_WEAPON
          OR iSpell = SID_CURSE_WEAPON
       {
          return FALSE;
       }
-      
-      for i in plItem_Attributes
+
+      if iSpell = SID_SHROUD
+      AND (IsClass(self,&Weapon)
+         OR IsClass(self,&DefenseModifier))
       {
-         iNum = Send(self,@GetNumFromCompound,#compound=First(i));
-         oItemAtt = Send(SYS,@FindItemAttByNum,#num=iNum);
-                         
-         if oItemAtt = $
+         for i in plItem_Attributes
          {
-            Debug("Illegal ItemAtt in list!");
+            iNum = Send(self,@GetNumFromCompound,#compound=First(i));
+            oItemAtt = Send(SYS,@FindItemAttByNum,#num=iNum);
+                            
+            if oItemAtt = $
+            {
+               Debug("Illegal ItemAtt in list!");
+               
+               continue;
+            }
             
-            continue;
+            if NOT Send(oItemAtt,@ItemCanEnchant,#oItem=self)
+            {
+               return FALSE;
+            }
          }
-         
-         if NOT Send(oItemAtt,@ItemCanEnchant,#oItem=self)
-         {
-            return FALSE;
-         }
+
+         return TRUE;
       }
-      
-      return TRUE;
+
+      return FALSE;
    }
-   
+
    DropOnDeath()
    "Most items are dropped on death.  But, assassin's blades and a few other "
    "things are not."

--- a/kod/object/passive/itematt/iashroud.kod
+++ b/kod/object/passive/itematt/iashroud.kod
@@ -68,7 +68,7 @@ messages:
 
    ItemCanEnchant()
    {
-      return FALSE;
+      return TRUE;
    }
 
    ItemCanSwap()
@@ -109,13 +109,13 @@ messages:
 
       oPlayer = Send(oItem,@getOwner);
         if oPlayer <> $
-         AND isClass(oPlayer,&user)
+         AND IsClass(oPlayer,&User)
       {
          Send(oPlayer,@MsgSendUser,#message_rsc=iashroud_gone,
                #parm1=Send(oItem,@GetName));
       }
 
-      Send(self,@RemoveFromItem,#oItem=oItem, #lData = lData);
+      Send(self,@RemoveFromItem,#oItem=oItem,#lData=lData);
 
       return;
    }
@@ -133,7 +133,7 @@ messages:
 
       if Send(self,@ReqAddToItem,#oItem=oItem)
       {
-         Send(self,@AddToItem,#oItem=oItem, 
+         Send(self,@AddToItem,#oItem=oItem,
                #timer_duration = random(3600000,86400000));
       }
 

--- a/kod/object/passive/spell/itemench/shroud.kod
+++ b/kod/object/passive/spell/itemench/shroud.kod
@@ -41,7 +41,7 @@ classvars:
    viSpell_level = 3
    viMana = 10
    viSpellExertion = 10
-   viCast_time = 8000
+   viCast_time = 6000
 
    viChance_To_Increase = 25
 
@@ -79,7 +79,7 @@ messages:
 
    CastSpell(who=$,lTargets=$,iSpellPower=0)
    {
-      local oItem, oItemAtt;
+      local iCurrentSpell, oItem, oItemAtt;
 
       oItem = First(lTargets);
 
@@ -92,6 +92,12 @@ messages:
       }
 
       oItemAtt = Send(SYS,@FindItemAttByNum,#num=IA_SHROUD);
+      iCurrentSpell = Send(oItem,@GetAttributeData,#ItemAtt=IA_SHROUD);
+
+      if iCurrentSpell <> $
+      {
+         Send(oItemAtt,@RemoveFromItem,#oItem=oItem);
+      }
 
       Send(oItemAtt,@AddToItem,#oItem=oItem,
             #timer_duration = Send(self,@GetDuration,#iSpellPower=iSpellPower),


### PR DESCRIPTION
Shroud was also causing errors with dangling timers similar to Artifice, so I've changed this spell to only cast on weapons or armor. To soften the blow a little bit, the cast time is lowered to six seconds, and the spell will now overwrite itself so you could cast on the same item over and over again if you wished. Shrouded weapons can now also be enchanted (but not identified or revealed).
