### PR TITLE
Add PE timers, clean up PE descriptions and files.

### DIFF
--- a/kod/object/passive/spell/persench.kod
+++ b/kod/object/passive/spell/persench.kod
@@ -23,14 +23,18 @@ resources:
 
    PersonalEnchantment_already_enchanted_rsc = "You are already enchanted."
    PersonalEnchantment_On_rsc = "Your body tingles with magical energy."
-   PersonalEnchantment_Off_rsc = "You feel your magical field crackle and dissipate."
+   PersonalEnchantment_Off_rsc = \
+      "You feel your magical field crackle and dissipate."
    PersonalEnchantment_Success_rsc = "You enchant %s%s."
-   PersonalEnchantment_Target_Already_Enchanted_rsc = "%s%s tried to cast %s%s on you."
-   PersonalEnchantment_Other_Already_Enchanted_rsc = "%s%s is already affected by that magic."
+   PersonalEnchantment_Target_Already_Enchanted_rsc = \
+      "%s%s tried to cast %s%s on you."
+   PersonalEnchantment_Other_Already_Enchanted_rsc = \
+      "%s%s is already affected by that magic."
    PersonalEnchantment_bad_target = "You cannot enchant %s%s."
 
-   PersonalEnchantment_bad_location = "You cannot cast enchantments upon others here."
-  
+   PersonalEnchantment_bad_location = \
+      "You cannot cast enchantments upon others here."
+
    spell_blank_template = "%q"
 
 classvars:
@@ -45,7 +49,8 @@ classvars:
    vrEnchantment_Off = PersonalEnchantment_Off_rsc
    vrSuccess = PersonalEnchantment_Success_rsc
 
-   % These messages don't need to be overwritten.  But I put them here to leave the option open.
+   % These messages don't need to be overwritten.
+   % But I put them here to leave the option open.
    vrOtherAlreadyEnchanted = PersonalEnchantment_Other_Already_Enchanted_rsc
    vrTargetAlreadyEnchanted = PersonalEnchantment_Target_Already_Enchanted_rsc
 
@@ -56,7 +61,7 @@ classvars:
    vbCanCastonMonsters = FALSE 
 
    viPersonal_ench = TRUE
-   
+
    viDefensive = FALSE
    viOffensive = FALSE
    viResistanceType = 0
@@ -75,76 +80,76 @@ messages:
       {
          return 0;
       }
-      
+
       return;
    }
 
-   CanPayCosts(who = $, lTargets = $, bItemCast = FALSE)
+   CanPayCosts(who=$,lTargets=$,bItemCast=FALSE)
    {
-      local otarget, i;
+      local oTarget, i;
 
       if lTargets = $
       {
          lTargets = [who];
       }
-   
+
       if Length(lTargets) <> 1
       {
          return FALSE;
       }
 
-      otarget = First(lTargets);
+      oTarget = First(lTargets);
 
-      % Targetable enchantment, not from a potion.  If we want to have wand effects
-      %  for these spells we will need to split bItemcast to differentiate between
-      %  wands and potions.
+      % Targetable enchantment, not from a potion.  If we want to have wand
+      % effects for these spells we will need to split bItemcast to
+      % differentiate between wands and potions.
       if vbCanCastOnOthers
       {
          if NOT bItemCast
-            AND NOT IsClass(otarget, &User)
-            AND NOT (vbCanCastOnMonsters AND IsClass(otarget,&monster))
+            AND NOT IsClass(oTarget,&User)
+            AND NOT (vbCanCastOnMonsters AND IsClass(oTarget,&Monster))
          {
             Send(who,@MsgSendUser,#message_rsc=PersonalEnchantment_bad_target,
                  #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
-                 
+
             return FALSE;
          }
 
          % Cannot cast buffs on others in any permanently safe rooms.
          if who <> oTarget
-            AND (send(send(who,@GetOwner),@GetPermanentFlags) & ROOM_NO_COMBAT)
+            AND (Send(Send(who,@GetOwner),@GetPermanentFlags) & ROOM_NO_COMBAT)
          {
             Send(who,@MsgSendUser,#message_rsc=PersonalEnchantment_bad_location);
-            
+
             return FALSE;
          }
       }
 
-      % check for enchantment already applied
-      if Send(otarget,@IsEnchanted,#what=self)
+      % Check for enchantment already applied
+      if Send(oTarget,@IsEnchanted,#what=self)
       {
          % Can you override an existing enchantment on yourself?
          if who = oTarget AND
-            Send(Send(SYS, @GetSettings), @CanRecastSelfEnchantment)
+            Send(Send(SYS,@GetSettings),@CanRecastSelfEnchantment)
          {
             propagate;
-         } 
+         }
 
          if NOT bItemCast
          {
             % Casting on self.
             if who = otarget
-            {   
+            {
                Send(who,@MsgSendUser,#message_rsc=vrAlreadyEnchanted);
             }
             else
             {
                % Casting on someone else.
                Send(who,@MsgSendUser,#message_rsc=vrOtherAlreadyEnchanted,
-               #parm1=send(oTarget,@GetCapDef),#parm2=send(oTarget,@GetName));
+               #parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
                Send(oTarget,@MsgSendUser,#Message_rsc=vrTargetAlreadyEnchanted,
-               #parm1=send(who,@GetCapDef),#parm2=send(who,@GetName),
-               #Parm3=send(self,@GetCapDef),#Parm4=send(self,@GetName));
+               #parm1=Send(who,@GetCapDef),#parm2=Send(who,@GetName),
+               #Parm3=Send(self,@GetCapDef),#Parm4=Send(self,@GetName));
             }
          }
          
@@ -154,7 +159,7 @@ messages:
       propagate;
    }
 
-   CastSpell(who = $,iSpellPower=0,lTargets=$)
+   CastSpell(who=$,iSpellPower=0,lTargets=$)
    {
 
       local oTarget, lType;
@@ -163,7 +168,7 @@ messages:
 
       if lTargets <> $
       {
-         oTarget=first(lTargets);      
+         oTarget=First(lTargets);
       }
       else
       {
@@ -172,7 +177,7 @@ messages:
 
       % Double check if our target is still logged on.
       If IsClass(oTarget,&Player)
-         AND NOT send(oTarget,@IsLoggedOn)
+         AND NOT Send(oTarget,@IsLoggedOn)
       {
          Send(who,@MsgSendUser,#message_rsc=PersonalEnchantment_bad_target,
               #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
@@ -184,27 +189,29 @@ messages:
       if Send(otarget,@IsEnchanted,#what=self) AND
          Send(Send(SYS, @GetSettings), @CanRecastSelfEnchantment)
       {
-         Send(oTarget, @RemoveEnchantment, #what = self, #report = FALSE);
-      } 
-   
+         Send(oTarget,@RemoveEnchantment,#what=self,#report=FALSE);
+      }
+
       Send(oTarget,@MsgSendUser,#message_rsc=vrEnchantment_On);
- 
+
       Send(oTarget,@StartEnchantment,#what=self,
-           #state=send(self,@GetStateValue,#iSpellpower=iSpellpower,#who=who,#target=oTarget),
-           #time=send(self,@GetDuration,#iSpellPower=iSpellPower),
-           #lastcall=send(self,@GetLastCall),#addicon=send(self,@GetAddicon),#who=who,#ltype=lType);
-           
-      % GetStateValue is sometimes (eg used for pre-enchantment behaviors, who is the caster, target is the target (sometimes the same as who).
+            #state=Send(self,@GetStateValue,#iSpellpower=iSpellpower,#who=who,
+            #target=oTarget),#time=Send(self,@GetDuration,#iSpellPower=iSpellPower),
+            #lastcall=Send(self,@GetLastCall),#addicon=Send(self,@GetAddicon),#who=who,#ltype=lType);
+
+      % GetStateValue is sometimes (eg used for pre-enchantment behaviors,
+      % who is the caster, target is the target (sometimes the same as who).
 
       if oTarget <> who
       {
-         Send(who,@MsgSendUser,#message_rsc=vrSuccess,#parm1=send(otarget,@GetCapDef),#parm2=send(otarget,@Getname));
+         Send(who,@MsgSendUser,#message_rsc=vrSuccess,
+               #parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
       }
 
       propagate;
    }
- 
-   EndEnchantment(who = $, report = TRUE, state = 0)
+
+   EndEnchantment(who=$,report=TRUE,state=0)
    {
       if report
       {
@@ -212,7 +219,7 @@ messages:
       }
 
       Post(who,@DrawResistances);
-      
+
       return;
    }
 
@@ -235,12 +242,12 @@ messages:
 
    %%% Defense and attack modifier stuff.
 
-   ModifyDamage(damage = $)
+   ModifyDamage(damage=$)
    {
       return damage;
    }
 
-   ModifyHitRoll(who = $,what = $,hit_roll = $)
+   ModifyHitRoll(who=$,what=$,hit_roll=$)
    {
       return hit_roll;
    }
@@ -250,18 +257,55 @@ messages:
       return;
    }
 
-   ModifyDefenseDamage(damage = $)
+   ModifyDefenseDamage(damage=$)
    {
       return damage;
    }
 
-   ModifyDefensePower(who = $, what = $,defense_power = $)
+   ModifyDefensePower(who=$,what=$,defense_power=$)
    {
       return defense_power;
    }
 
    EffectDesc(who=$)
    {
+      local i, iDuration, iMinutes, iSeconds, oSpell, oList;
+
+      oSpell = GetClass(self);
+      oList = Send(who,@GetEnchantmentList);
+      
+      for i in oList
+      {
+         if Nth(i,2) = self
+         {
+            iDuration = GetTimeRemaining(Nth(i,1));
+         }
+      }
+
+      iDuration = iDuration / 1000;
+      iMinutes = iDuration / 60;
+      iSeconds = iDuration MOD 60;
+
+      AppendTempString("\n\n");
+      AppendTempString("Your current ");
+      AppendTempString(Send(self,@GetName));
+      AppendTempString(" enchantment will last for ");
+      if iMinutes > 0
+      {
+         AppendTempString(iMinutes);
+         if iMinutes = 1
+         {
+            AppendTempString(" minute and ");
+         }
+         else
+         {
+            AppendTempString(" minutes and ");
+         }
+      }
+
+      AppendTempString(iSeconds);
+      AppendTempString(" seconds.");
+
       return;
    }
 
@@ -278,10 +322,10 @@ messages:
 
       return;
    }
-   
+
    GetStatsDesc(who=$)
    {
-      Send(self,@CreateStatsDesc,#who=who);      
+      Send(self,@CreateStatsDesc,#who=who);
 
       return GetTempString();
    }

--- a/kod/object/passive/spell/persench/Eagleyes.kod
+++ b/kod/object/passive/spell/persench/Eagleyes.kod
@@ -15,7 +15,7 @@ constants:
    include blakston.khd
 
    % What percent of spellpower should we take in order to give the player a chance
-   %  to completely resist a blinding spell?
+   % to completely resist a blinding spell?
    SPELL_RESIST_PERCENT = 5
 
 resources:
@@ -24,18 +24,22 @@ resources:
    EagleEyes_icon_rsc = ieagleye.bgf
    EagleEyes_desc_rsc = \
       "Bestows a supernatural acuity of vision on the caster, protecting "
-      "against spells that attack sight and improving accuracy at long range.  "
-      "Requires mushrooms and purple mushrooms."
+      "against spells that attack sight and improving accuracy at long "
+      "range.  Requires three mushrooms and one purple mushroom."
    
-   EagleEyes_on_rsc = "Your eyes burn and the world leaps into surreal clarity."
+   EagleEyes_on_rsc = \
+      "Your eyes burn and the world leaps into surreal clarity."
    EagleEyes_off_rsc = "The world seems somehow less distinct and vivid."
    EagleEyes_already_enchanted_rsc = "You already have Eagle Eyes."
    EagleEyes_Success_rsc = "You grant %s%s preternatural sight."
 
-   EagleEyes_resist = "Krannan's magic fights to penetrate the veil of darkness."
+   EagleEyes_resist = \
+      "Krannan's magic fights to penetrate the veil of darkness."
    EagleEyes_evade = "The magic of Krannan preserves your sight."
-   EagleEyes_resist_caster = "You sense a force resisting your blinding spell."
-   EagleEyes_evade_caster = "The magic of Krannan preserves the sight of your target."
+   EagleEyes_resist_caster = \
+      "You sense a force resisting your blinding spell."
+   EagleEyes_evade_caster = \
+      "The magic of Krannan preserves the sight of your target."
 
    EagleEyes_sound = keagleye.wav
 
@@ -69,30 +73,30 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = cons([&Mushroom,3],plReagents);
-      plReagents = cons([&PurpleMushroom,1],plReagents);
+      plReagents = Cons([&Mushroom,3],plReagents);
+      plReagents = Cons([&PurpleMushroom,1],plReagents);
 
       return;
    }
 
-   GetStateValue(who=$,iSpellpower=$,target = $)
+   GetStateValue(who=$,iSpellpower=$,target=$)
    {
       local iFactor;
-      
+
       Send(target,@AddAttackModifier,#what=self);
-      iFactor = bound(iSpellPower+1,10,100);
-      
+      iFactor = Bound(iSpellPower+1,10,100);
+
       return iFactor;
-   }  
+   }
 
    EndEnchantment(who=$,report=TRUE,state=$)
    {
       Send(who,@RemoveAttackModifier,#what=self);
-      
+
       propagate;
    }
 
-   GetDuration(iSpellpower = 0)
+   GetDuration(iSpellpower=0)
    {
       local iDuration;
 
@@ -100,9 +104,9 @@ messages:
       iDuration = 120 + (4 * iSpellPower);
       % Convert to ms.
       iDuration = iDuration * 1000;
-      
+
       return iDuration;
-   }   
+   }
 
    OfferToNewCharacters()
    {
@@ -114,7 +118,7 @@ messages:
       return &EagleEyesPotion;
    }
 
-   DoEagleEyes(oCaster=$, oTarget=$, iDuration=0, iFactor=1)
+   DoEagleEyes(oCaster=$,oTarget=$,iDuration=0,iFactor=1)
    "Calculates adjustment of blinding spell duration.  Returns $ if resisted "
    "completely.  iFactor is the factor by which we want to increase the effect."
    {
@@ -132,7 +136,7 @@ messages:
       }
 
       % Check if they repel the blinding spell outright 1-10% base chance,
-      %  modified by factor.
+      % modified by factor.
       iChance = (oEagleEyesStrength * (SPELL_RESIST_PERCENT * iFactor)) / 100;
       if Random(0,100) <= iChance
       {
@@ -159,7 +163,7 @@ messages:
 
    %%% Attack Modifier stuff
 
-   ModifyHitRoll(who = $,what = $,hit_roll = $)
+   ModifyHitRoll(who=$,what=$,hit_roll=$)
    {
       local iFactor, oWeapon;
 
@@ -175,7 +179,7 @@ messages:
       return hit_roll;
    }
 
-   ModifyDamage(who = $,what = $,damage = $)
+   ModifyDamage(who=$,what=$,damage=$)
    {
       local iFactor, oWeapon;
 
@@ -199,8 +203,8 @@ messages:
       AppendTempString(" enchantment adds ");
       AppendTempString(Send(who,@GetEnchantedState,#what=self));
       AppendTempString(" offense and 1 damage to your ranged attacks.");
-      
-      return;
+
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/bless.kod
+++ b/kod/object/passive/spell/persench/bless.kod
@@ -21,7 +21,7 @@ resources:
    bless_desc_rsc = \
       "Invokes Kraanan's blessing, increasing the accuracy "
       "and damage of attacks.  "
-      "Requires mushrooms and sapphires to cast."
+      "Requires two mushrooms and two sapphires to cast."
    
    bless_already_enchanted_rsc = "You are already blessed."
    bless_on_rsc = "Kraanan fills you with the spirit of battle."
@@ -58,11 +58,11 @@ classvars:
    viMeditate_ratio = 20
 
    viFlash = FLASH_GOOD_SELF
-   
+
    viOffensive = TRUE
 
 properties:
-   
+
 messages:
 
    ResetReagents()
@@ -74,9 +74,9 @@ messages:
       return;
    }
 
-   CastSpell(who = $,iSpellPower= 0,ltargets=$)
+   CastSpell(who=$,iSpellPower=0,lTargets=$)
    {
-      Send(First(lTargets),@AddAttackModifier,#what=self);       
+      Send(First(lTargets),@AddAttackModifier,#what=self);
 
       propagate;
    }
@@ -96,25 +96,25 @@ messages:
       return iDuration;
    }
 
-   EndEnchantment(who=$, report=TRUE, state=0)
+   EndEnchantment(who=$,report=TRUE,state=0)
    {
       Send(who,@RemoveAttackModifier,#what=self);
-      
+
       propagate;
    }
 
-   % stuff we handle to be an attack modifier
+   % Stuff we handle to be an attack modifier
 
-   ModifyHitRoll(who = $,what = $,hit_roll = $)
+   ModifyHitRoll(who=$,what=$,hit_roll=$)
    {
       return hit_roll + Send(who,@GetEnchantedState,#what=self);
    }
    
-   ModifyDamage(who = $,what = $,damage = $)
+   ModifyDamage(who=$,what=$,damage=$)
    {
       return damage + Random(0,send(who,@GetEnchantedState,#what=self)/33);
    }
-  
+
    EffectDesc(who=$)
    {
       AppendTempString("\n\n");
@@ -125,8 +125,8 @@ messages:
       AppendTempString(" offense and 0-");
       AppendTempString(Send(who,@GetEnchantedState,#what=self)/33);
       AppendTempString(" attack damage.");
-      
-      return;
+
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/cloak.kod
+++ b/kod/object/passive/spell/persench/cloak.kod
@@ -19,10 +19,11 @@ resources:
    Cloak_name_rsc = "cloak"
    Cloak_icon_rsc = icloak.bgf
    Cloak_desc_rsc = \
-   "Qor shrouds your astral body in shifting shadows, allowing you to elude magical tracking.  "
-   "Requires entroot berries to cast."
-   
-   Cloak_on_rsc = "It feels as though your very spirit has become somehow indistinct."
+      "Qor shrouds your astral body in shifting shadows, allowing you to "
+      "elude magical tracking. .Requires two entroot berries to cast."
+
+   Cloak_on_rsc = \
+      "It feels as though your very spirit has become somehow indistinct."
    Cloak_off_rsc = "You feel more conspicuous."
    Cloak_already_enchanted_rsc = "You are already cloaked."
    Cloak_Succeed_rsc = "You wrap a magical cloak around %s%s."
@@ -66,7 +67,7 @@ messages:
    {
       local iFactor;
 
-      iFactor = bound(iSpellPower/2 + 5,10,50);
+      iFactor = Bound(iSpellPower/2 + 5,10,50);
 
       return iFactor;
    }
@@ -76,47 +77,43 @@ messages:
       local lRoomList,oRoom,i;
 
       lRoomlist = Send(SYS,@GetRooms);
-      oRoom = send(SYS,@Findroombynum,#num=RID_GODROOM);
+      oRoom = Send(SYS,@FindRoomByNum,#num=RID_GODROOM);
       i = 1;
 
-      while (send(oRoom,@SeanceCheck) = FALSE) AND (i < 20)
+      while (Send(oRoom,@SeanceCheck) = FALSE) AND (i < 20)
       {
          oRoom = Nth(lRoomlist,Random(1,Length(lRoomlist)));
          if oRoom = $ OR i = $
          {
-            oRoom = send(SYS,@FindRoomByNum,#num=RID_TOS_INN);
+            oRoom = Send(SYS,@FindRoomByNum,#num=RID_TOS_INN);
             break;
          }
          i = i + 1;
       }
-      
+
       if i = 20
       {
-         oRoom = send(SYS,@FindRoomByNum,#num=RID_TOS_INN);
+         oRoom = Send(SYS,@FindRoomByNum,#num=RID_TOS_INN);
       }
 
       return oRoom;
-
    }
 
-  
-   GetDuration(iSpellpower = 0)
+   GetDuration(iSpellpower=0)
    {
       local iDuration;
       iDuration = (116 + 4*iSpellPower) * 1000;    %%% 2-8.5 minutes
       return iDuration;
    }
-   
 
    OfferToNewCharacters()
    {
-      %% 
       return FALSE;
    }
 
    GetPotionClass()
    {
-      RETURN &CloakPotion;
+      return &CloakPotion;
    }
   
    EffectDesc(who=$)
@@ -127,8 +124,8 @@ messages:
       AppendTempString(" enchantment will keep you hidden from enemy scrying ");
       AppendTempString(Send(who,@GetEnchantedState,#what=self));
       AppendTempString("\% of the time.");
-      
-      return;
+
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/deflect.kod
+++ b/kod/object/passive/spell/persench/deflect.kod
@@ -19,11 +19,11 @@ resources:
    Deflect_name_rsc = "deflect"
    Deflect_icon_rsc = imirror.bgf
    Deflect_desc_rsc = \
-      "Calls upon Kraanan's will to form a protective barrier around the target "
-      "which protects them from direct damaging attack magics, but not from "
-      "other magics, such as enchantments.  "
-      "Requires solagh and kriipa claws to cast."
-   
+      "Calls upon Kraanan's will to form a protective barrier around the "
+      "target which protects them from direct damaging attack magics, but "
+      "not from other magics, such as enchantments.  "
+      "Requires a vial of solagh and one kriipa claw to cast."
+
    Deflect_already_enchanted_rsc = "You are already enchanted by deflect."
 
    Deflect_on_rsc = "A magical barrier surrounds you."
@@ -76,7 +76,7 @@ classvars:
    vrSucceed_wav = Deflect_sound
 
 properties:
-   
+
 messages:
 
    ResetReagents()
@@ -88,13 +88,13 @@ messages:
       return;
    }
 
-   GetStateValue(who = $,iSpellPower= 0,Target=$)
+   GetStateValue(who=$,iSpellPower=0,Target=$)
    {
       local iReflectOdds;
 
       iReflectOdds = iSpellPower * 3 / 4;
 
-      return bound(iReflectOdds,10,75);
+      return Bound(iReflectOdds,10,75);
    }
 
    GetDuration(iSpellPower=0)
@@ -107,7 +107,7 @@ messages:
       return iDuration;
    }
 
-   TryDeflect(caster = $, victim = $, oSpell = $)
+   TryDeflect(caster=$,victim=$,oSpell=$)
    "Returns TRUE if the spell is deflected."
    {
       local i, chance;
@@ -119,12 +119,12 @@ messages:
          % Give players a decent chance to improve the spell!
          for i in Send(victim,@GetPassiveImprovementList)
          {
-            if First(i) = self AND random(1,3) = 3
+            if First(i) = self AND Random(1,3) = 3
             {
                Post(First(i),@ImproveAbility,#who=victim);
             }
          }
-      
+
          chance = Send(victim,@GetEnchantedState,#what=self);
          if Random(0,100) < chance
          {
@@ -170,7 +170,7 @@ messages:
       AppendTempString(Send(who,@GetEnchantedState,#what=self));
       AppendTempString("\% of the time.");
       
-      return;
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/denial.kod
+++ b/kod/object/passive/spell/persench/denial.kod
@@ -20,11 +20,13 @@ resources:
    denial_desc_rsc = \
       "Causes the caster to unrealize their wounds, but beware when "
       "you realize its a hoax, because the wounds are still just as deep!  "
-      "Requires a firesand and solagh to cast."
+      "Requires two firesand and a vial of solagh to cast."
 
    denial_on_rsc = "Your wounds suspiciously disappear."
-   denial_failed_rsc = "Hmmm, you can't seem to convince yourself of perfect health."
-   denial_already_enchanted_rsc = "You can't fool yourself twice about something like this, at "
+   denial_failed_rsc = \
+      "Hmmm, you can't seem to convince yourself of perfect health."
+   denial_already_enchanted_rsc = \
+      "You can't fool yourself twice about something like this, at "
       "least not at the same time."
 
    denial_off_rsc = "Ouch - you are reminded of your previous weariness."
@@ -58,22 +60,22 @@ properties:
 
 messages:
 
-   CanPayCosts(who = $, lTargets = $, bItemCast = FALSE)
+   CanPayCosts(who=$,lTargets=$,bItemCast=FALSE)
    {
-      % if they are already boosted above max health, then return FALSE
-      if send(who,@GetHealth) >= send(who,@GetMaxHealth) 
+      % If they are already boosted above max health, then return FALSE
+      if Send(who,@GetHealth) >= Send(who,@GetMaxHealth)
       {
          if NOT bItemCast
          {
-	         send(who,@MsgSendUser,#message_rsc=denial_failed_rsc);
+            Send(who,@MsgSendUser,#message_rsc=denial_failed_rsc);
          }
-	      
-	      return FALSE;
+
+         return FALSE;
       }
 
       propagate;
    }
-   
+
    ResetReagents()
    {
       plReagents = $;
@@ -83,71 +85,60 @@ messages:
       return;
    }
 
-   GetDuration(iSpellPower = 0)
+   GetDuration(iSpellPower=0)
    {
       local iDuration;
 
       % 10 - 20 plus 1 second per spellpower
-      iDuration = random(10000,20000) + (iSpellPower * 1000);
-      iDuration=bound(iDuration,20000,120000);
-      
-      return iDuration;      
+      iDuration = Random(10000,20000) + (iSpellPower * 1000);
+      iDuration=Bound(iDuration,20000,120000);
+
+      return iDuration;
    }
 
 
-   GetStateValue(who = $, Target = $, iSpellPower = 1)
+   GetStateValue(who=$,Target=$,iSpellPower=1)
    {
       local iHPGain, iSpellpowerBonus;
-      
-      iHPGain = send(who,@GetMaxHealth) - send(who,@GetHealth);
 
-      iSpellpowerBonus = (iSpellpower + 1) / 5;  %0 - 20, this is the percent of damage you don't get back when the enchantment fails.
-      iHPGain = send(who,@GainHealthNormal,#amount=iHPGain);
+      iHPGain = Send(who,@GetMaxHealth) - Send(who,@GetHealth);
+
+      % 0 - 20, this is the percent of damage you don't
+      % get back when the enchantment fails.
+      iSpellpowerBonus = (iSpellpower + 1) / 5;
+      iHPGain = Send(who,@GainHealthNormal,#amount=iHPGain);
 
       return iHPGain - (iSpellpowerBonus * iHPGain)/ 100 ;
    }
 
 
-   EndEnchantment(who = $, state=$, report = TRUE)
-   {      
-      post(self,@EndEnchantmentEffects,#who=who,#state=state);
-      
+   EndEnchantment(who=$,state=$,report=TRUE)
+   {
+      Post(self,@EndEnchantmentEffects,#who=who,#state=state);
+
       propagate;
    }
 
-   EndEnchantmentEffects(who=$, state=$)
+   EndEnchantmentEffects(who=$,state=$)
    {
       if state
       {
          Send(who,@LoseHealth,#amount=state);
-      
-         if send(who,@GetHealth) < 1
-	      {
+
+         if Send(who,@GetHealth) < 1
+         {
             % Don't die: too harsh; makes spell unusable.
-            send(who,@GainHealthNormal,#amount=1);
-	      }
+            Send(who,@GainHealthNormal,#amount=1);
+         }
       }
-      
+
       return;
-   } 
+   }
 
    GetPotionClass()
    {
       return &DenialPotion;
    }
 
-   EffectDesc(who=$)
-   {
-      AppendTempString("\n\n");
-      AppendTempString("Your current ");
-      AppendTempString(Send(self,@GetName));
-      AppendTempString(" enchantment allows you to deny reality for ");
-      AppendTempString(random(10000,20000) + (Send(who,@GetEnchantedState,#what=self) * 1000));
-      AppendTempString(" milliseconds.");
-      
-      return;
-   }
-
 end
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/persench/dethlink.kod
+++ b/kod/object/passive/spell/persench/dethlink.kod
@@ -26,8 +26,8 @@ resources:
    deathlink_desc_rsc = \
       "This dark spell feeds off the souls of any poor creature that should "
       "happen to fall in your vicinity.  Any lives you take are merely "
-      "transfers of energy - good and evil mean nothing.  "
-      "Requires a vial of shaman blood and a single polished seraphym to cast."
+      "transfers of energy - good and evil mean nothing.  Requires a vial "
+      "of shaman blood and a single polished seraphym to cast."
    
    deathlink_already_enchanted_rsc = \
       "You are already linked with death."
@@ -151,6 +151,11 @@ messages:
    ModifyDamage(who=$,what=$,damage=$)
    {
       return damage;
+   }
+
+   EffectDesc()
+   {
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/detinvis.kod
+++ b/kod/object/passive/spell/persench/detinvis.kod
@@ -19,10 +19,12 @@ resources:
    DetectInvisible_name_rsc = "detect invisible"
    DetectInvisible_icon_rsc = idetinvi.bgf
    DetectInvisible_desc_rsc = \
-   "Allows you to see those whom others cannot.  Requires solagh."
+      "Allows you to see those whom others cannot.  "
+      "Requires two vials of solagh."
    DetectInvisible_on_rsc = "You can feel your eyes tingle."
    DetectInvisible_off_rsc = "Your eyesight returns to its former mundanity."
-   DetectInvisible_already_enchanted_rsc = "You can already see the invisible."
+   DetectInvisible_already_enchanted_rsc = \
+      "You can already see the invisible."
    DetectInvisible_Success_rsc = "%s%s eyes pulse briefly."
 
 classvars:
@@ -58,43 +60,48 @@ messages:
       return;
    }
 
-   CastSpell(who = $,iSpellPower=0)
+   CastSpell(who=$,iSpellPower=0)
    {
-      %% post this so it's after the flag being applied.
-      post(who,@ToCliRoomContents);
-      
+      %% Post this so it's after the flag being applied.
+      Post(who,@ToCliRoomContents);
+
       propagate;
    }
 
    SetSpellPlayerFlag(who=$)
    {
       Send(who,@SetPlayerFlag,#flag=PFLAG2_DETECT_INVIS,#flagset=2,#value=True);
-      
+
       return;
    }
-   
-   GetDuration(iSpellpower = 0)
+
+   GetDuration(iSpellpower=0)
    {
       local iDuration;
       iDuration = 2400 * (100 + iSpellPower);   % 4 - 8 minutes max,
-      
+
       return iDuration;
    }
-   
-   EndEnchantment(who = $, report = TRUE, state = 0)
+
+   EndEnchantment(who=$,report=TRUE,state=0)
    {
-      if send(who,@IsLoggedOn)
+      if Send(who,@IsLoggedOn)
       {
-	      %% must post this so it's after the flag being removed.
-	      post(who,@ToCliRoomContents);
+         %% Must post this so it's after the flag being removed.
+         Post(who,@ToCliRoomContents);
       }
-     
+
       propagate;
    }
 
    GetPotionClass()
    {
-      RETURN &DetectInvisibilityPotion;
+      return &DetectInvisibilityPotion;
+   }
+
+   EffectDesc()
+   {
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/eavesdrp.kod
+++ b/kod/object/passive/spell/persench/eavesdrp.kod
@@ -19,12 +19,13 @@ resources:
    Eavesdrop_name_rsc = "eavesdrop"
    Eavesdrop_icon_rsc = ieavesdr.bgf
    Eavesdrop_desc_rsc = \
-      "Riija grants the ability to hear distant conversations, allowing you to spy on others.  "
-      "Requires dragonfly eyes."
+      "Riija grants the ability to hear distant conversations, allowing you "
+      "to spy on others.  Requires two dragonfly eyes."
    
    Eavesdrop_on_rsc = "The sounds of a nearby room fill your mind."
    Eavesdrop_off_rsc = "The distant sounds become impossible to hear."
-   Eavesdrop_already_enchanted_rsc = "You are already listening to another room."
+   Eavesdrop_already_enchanted_rsc = \
+      "You are already listening to another room."
    Eavesdrop_no_rooms = "There seem to be no nearby rooms you can listen to."
    Eavesdrop_Success_rsc = "You grant %s%s the ability to eavesdrop."
 
@@ -67,12 +68,12 @@ messages:
       return;
    }
 
-   CanPayCosts(who = $, lTargets = $, iSpellPower = 0)
+   CanPayCosts(who=$,lTargets=$,iSpellPower=0)
    {
       local lRooms;
 
       lRooms = send(self,@GetYellList,#who=who);
-      
+
       if Length(lRooms) = 0
       {
          Send(who,@MsgSendUser,#message_rsc=Eavesdrop_no_rooms);
@@ -83,62 +84,63 @@ messages:
       propagate;
    }
 
-   StartPeriodicEnchantment( who = $, state = $ )
+   StartPeriodicEnchantment(who=$,state=$)
    {
       % If caster runs out of mana or loses trance, spell ends.
-      if send(who,@GetMana) < viManaDrain * 2
+      if Send(who,@GetMana) < viManaDrain * 2
       {
          Send(who,@StartEnchantment,#what=self,#time=nth(state,1),
-              #state=state,#addicon=False,#lastcall=True);
+               #state=state,#addicon=False,#lastcall=True);
       }
       else
-      {      
+      {
          Send(who,@StartEnchantment,#what=self,#time=nth(state,1),
-              #state=state,#addicon=False,#lastcall=False);
+               #state=state,#addicon=False,#lastcall=False);
       }
-      
+
       Send(who,@LoseMana,#amount=viManaDrain);
-      
+
       return;
    }
    
-   EndEnchantment(who=$, state=0)
+   EndEnchantment(who=$,state=0)
    {
-      Send(nth(state,2),@Delete);
-      
+      Send(Nth(state,2),@Delete);
+
       propagate;
    }
 
-   BreakTrance( who = $, state = $, event = $, what = $ )
+   BreakTrance(who=$,state=$,event=$,what=$)
    {
       if event = EVENT_CAST AND what = self
       {
          propagate;
       }
-      
-      Send(nth(state,2),@Delete);
+
+      Send(Nth(state,2),@Delete);
       Send(who,@RemoveEnchantment,#what=self,#state=state);
-      
+
       propagate;
    }
 
    SetSpellPlayerFlag(who=$,state=$)
    {
       Send(who,@SetTranceFlag);
-      
+
       return;
    }
 
    GetDuration(iSpellPower=0)
    {
       local iPower;
-      
+
       iPower = (iSpellPower / 10) * 100;
-      
+
       return 500 + iPower;
    }
 
-   % State value is: list containing the drain time as the first element, and the listener object as the second element.
+   % State value is: list containing the drain time as the first element,
+   % and the listener object as the second element.
    %   IE [ drain time (in ms), listener object ]
 
    GetStateValue(iSpellPower=$,who=$)
@@ -146,7 +148,7 @@ messages:
    {
       local oRoom, lRooms, ilength, iRow, iCol, iDrainTime, oListener;
 
-      lRooms = send(self,@GetYellList,#who=who);
+      lRooms = Send(self,@GetYellList,#who=who);
 
       iLength = Length(lRooms);
       if iLength = 0
@@ -162,9 +164,9 @@ messages:
       iCol = Send(oRoom,@GetTeleportCol);
 
       oListener = Create(&Listener,#Enchanted=who,#iSpellpower=iSpellpower);
-      Send(oRoom,@NewHold,#what=oListener, #new_row=iRow,#new_col=iCol);
+      Send(oRoom,@NewHold,#what=oListener,#new_row=iRow,#new_col=iCol);
    
-      return [send(self,@GetDuration,#iSpellpower=iSpellpower),oListener];
+      return [Send(self,@GetDuration,#iSpellpower=iSpellpower),oListener];
    }
 
    OfferToNewCharacters()
@@ -177,18 +179,18 @@ messages:
    {
       return FALSE;
    }
-   
+
    GetYellList(who=$)
    "Returns a list of rooms in the yell zone of who's current location."
    {
       local oRoom, lRooms;
-   
+
       %% Get yell list from current room and select a room to eavesdrop.
       oRoom = Send(who,@GetOwner);
       lRooms = Send(oRoom,@GetYellZone);
       
       %% Eliminate the room we're in, unless there is no yell list.
-      if FindListElem(lRooms,Send(oRoom,@GetRoomNum))  
+      if FindListElem(lRooms,Send(oRoom,@GetRoomNum))
       {
          if lRooms = $ OR length(lRooms) < 2
          {

--- a/kod/object/passive/spell/persench/freeact.kod
+++ b/kod/object/passive/spell/persench/freeact.kod
@@ -25,7 +25,7 @@ resources:
    FreeAction_desc_rsc = \
       "Kraanan's love of battle helps repel magic which might hinder "
       "your movements, and thus the liberal dispensation of lusty blows.  "
-      "Requires red mushrooms and purple mushrooms to cast."
+      "Requires one red mushroom and one purple mushroom to cast."
    
    FreeAction_on_rsc = \
       "You feel a rush of energy and fluid motion throughout your body."
@@ -82,23 +82,23 @@ messages:
    {
       local iFactor;
 
-      iFactor = bound(iSpellPower/2+5,10,50);      
+      iFactor = bound(iSpellPower/2+5,10,50);
 
       return iFactor;
    }
-  
+
    GetDuration(iSpellpower=0)
    {
       local iDuration;
 
       % 3 - 8 minutes max, converted to ms.
-      iDuration = 180 + (3 * iSpellPower);   
+      iDuration = 180 + (3 * iSpellPower);
       iDuration = iDuration * 1000;
-      
+
       return iDuration;
    }
 
-   DoFreeAction(oHoldCaster=$, oTarget=$, iDuration=0)
+   DoFreeAction(oHoldCaster=$,oTarget=$,iDuration=0)
    "Calculates adjustment if hold duration.  Returns $ if resisted completely."
    {
       local i, iNewDuration, oFreeActionStrength;
@@ -128,7 +128,7 @@ messages:
 
       iNewDuration = iDuration - (iDuration * oFreeActionStrength)/150;
       Post(oTarget,@MsgSendUser,#message_rsc=FreeAction_resist);
-      
+
       if IsClass(oHoldCaster,&Player)
       {
          Post(oHoldCaster,@MsgSendUser,#message_rsc=FreeAction_resist_caster);
@@ -159,7 +159,7 @@ messages:
       AppendTempString(100 * Send(who,@GetEnchantedState,#what=self) / 150);
       AppendTempString("\%.");
       
-      return;
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/gaze.kod
+++ b/kod/object/passive/spell/persench/gaze.kod
@@ -22,13 +22,16 @@ resources:
    paralyze_icon_rsc = iparalyz.bgf
    paralyze_desc_rsc = \
       "Grants the caster the ability to paralyze any who meet his gaze.  "
-      "Requires yrxl sap and purple mushrooms to cast."
+      "Requires one yrxl sap and one purple mushroom to cast."
 
    paralyze_on_rsc = "Your eyes seem to swell and pulse with magical energy."
    paralyze_off_rsc = "Your eyes return to normal."
-   paralyze_already_enchanted_rsc = "Your already have the gaze of the basilisk."
+   paralyze_already_enchanted_rsc = \
+      "You already have the gaze of the basilisk."
    paralyze_caster = "%s%s meets your gaze and freezes in place."
-   paralyze_target_on = "As you meet %s%s's terrible gaze you feel your limbs stiffen and freeze."
+   paralyze_target_on = \
+      "As you meet %s%s's terrible gaze you feel your limbs stiffen "
+      "and freeze."
 
    paralyze_no_soul = "You can't detect a soul in %s%s to turn to stone!"
 
@@ -38,8 +41,8 @@ classvars:
 
    viSpell_num = SID_GAZE_OF_THE_BASILISK
    viSchool = SS_QOR
-   viMana = 15          
-   viCast_Time = 5000   
+   viMana = 15
+   viCast_Time = 5000
    viSpell_Exetion = 15
    viSpell_level = 6
 
@@ -55,7 +58,7 @@ classvars:
    vrEnchantment_Off = paralyze_Off_rsc
 
    vrSucceed_wav = paralyze_sound
-   
+
    viFlash = FLASH_BAD
 
    vbCanCastonOthers = FALSE
@@ -76,19 +79,19 @@ messages:
       return;
    }
 
-   GetDuration(iSpellPower = 0)
+   GetDuration(iSpellPower=0)
    {
       local iDuration;
 
       % Duration in seconds, from 1-33.
-      iDuration = bound(iSpellPower/3,1,33);
+      iDuration = Bound(iSpellPower/3,1,33);
       
       return iSpellpower * 1000;
    }
 
-   GetStateValue(who = $, iSpellPower = 0)      
-   {      
-      Send(who,@AddDefenseModifier,#what=self);      
+   GetStateValue(who=$,iSpellPower=0)
+   {
+      Send(who,@AddDefenseModifier,#what=self);
 
       return iSpellPower;
    }
@@ -109,7 +112,7 @@ messages:
          if IsClass(what,&Revenant)
          {
             Send(who,@MsgSendUser,#message_rsc=paralyze_no_soul, 
-                 #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName));
+                  #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName));
          }
          else
          {
@@ -127,20 +130,20 @@ messages:
                }
 
                Send(what,@MsgSendUser,#message_rsc=paralyze_target_on,
-                    #parm1=Send(who,@GetDef),#parm2=Send(who,@GetName));
+                     #parm1=Send(who,@GetDef),#parm2=Send(who,@GetName));
             }
 
             Send(who,@MsgSendUser,#message_rsc=paralyze_caster,
-                 #parm1=Send(what,@GetCapDef),#parm2=Send(what,@GetName));
+                  #parm1=Send(what,@GetCapDef),#parm2=Send(what,@GetName));
 
             Send(oSpell,@DoHold,#what=who,#oTarget=what,#iDuration=iDuration);
          }
       }
-  
+
       return defense_power;
    }
 
-   EndEnchantment(who = $, report = TRUE, state = 0)
+   EndEnchantment(who=$,report=TRUE,state=0)
    {
       Send(who,@RemoveDefenseModifier,#what=self);
 
@@ -157,8 +160,8 @@ messages:
       AppendTempString("-");
       AppendTempString(Bound(Send(who,@GetEnchantedState,#what=self) * 25,500,2500));
       AppendTempString(" milliseconds. Opponents attacking at range have a 50\% chance to avoid your paralyzing gaze.");
-      
-      return;
+
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/gort.kod
+++ b/kod/object/passive/spell/persench/gort.kod
@@ -21,15 +21,18 @@ resources:
    ArmorOfGort_desc_rsc = \
       "Surrounds the caster with a powerful field which deflects "
       "damage from extreme blows.  "
-      "Requires blue dragon scale to cast."
+      "Requires two blue dragon scales to cast."
    
    ArmorOfGort_already_enchanted_rsc = "You already have the Armor of Gort."
 
-   ArmorOfGort_on_rsc = "Your skin feels taut as the Armor of Gort forms around you."
+   ArmorOfGort_on_rsc = \
+      "Your skin feels taut as the Armor of Gort forms around you."
    ArmorOfGort_off_rsc = "Your Armor of Gort dissipates."
-   ArmorOfGort_success_rsc = "%s%s's skin tightens as the Armor of Gort forms."
+   ArmorOfGort_success_rsc = \
+      "%s%s's skin tightens as the Armor of Gort forms."
 
-   ArmorOfGort_spell_intro = "Kraanan Level 5: Magical armor that protects the caster."
+   ArmorOfGort_spell_intro = \
+      "Kraanan Level 5: Magical armor that protects the caster."
 
 classvars:
 
@@ -57,7 +60,7 @@ classvars:
 
    viDefensive = TRUE
 
-properties:    
+properties:
 
 messages:
 
@@ -69,25 +72,25 @@ messages:
       return;
    }
 
-   GetDuration(iSpellPower = 0)
+   GetDuration(iSpellPower=0)
    {
-      local iDuration; 
+      local iDuration;
 
       iDuration = iSpellPower/8 + 1;
-      % Convert to minutes
+      % Convert to milliseconds
       iDuration = iDuration * 60 * 1000;
-      
+
       return iDuration;
    }
 
-   GetStateValue(who = $, iSpellPower = 0, Target = $)      
+   GetStateValue(who=$,iSpellPower=0,Target=$)
    {
       Send(Target,@AddDefenseModifier,#what=self);
-       
+
       return iSpellPower;
    }
 
-   PriorityModifyDefenseDamage(who = $, what = $, damage = $, atype = 0, aspell = 0)
+   PriorityModifyDefenseDamage(who=$,what=$,damage=$,atype=0,aspell =0)
    {
       local iSpellPower, iAbsorbed, iMax;
 
@@ -114,15 +117,15 @@ messages:
          }
       }
 
-      return bound(damage-iAbsorbed,1,iMax);
+      return Bound(damage-iAbsorbed,1,iMax);
    }
 
-   ModifyDefenseDamage(who = $, what = $, damage = $, atype = 0, aspell = 0)
+   ModifyDefenseDamage(who=$,what=$,damage=$,atype=0,aspell=0)
    {
       return damage;
    }
 
-   EndEnchantment(who = $, report = TRUE, state = 0)
+   EndEnchantment(who=$,report=TRUE,state=0)
    {
       Send(who,@RemoveDefenseModifier,#what=self);
 
@@ -138,8 +141,8 @@ messages:
       AppendTempString(Send(who,@GetEnchantedState,#what=self)/25);
       AppendTempString(" armor or reduces non-magical damage to 15, partially magical damage to 20, and fully magical damage to 25. ");
       AppendTempString(" Only the better of these two effects applies. Armor of Gort modifies damage received before any other armor or spells.");
-      
-      return;
+
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/haste.kod
+++ b/kod/object/passive/spell/persench/haste.kod
@@ -20,14 +20,20 @@ resources:
    Haste_icon_rsc = ihaste.bgf
    Haste_desc_rsc = \
       "Reduces the fatigue of running at full clip.  "
-      "Requires edible mushrooms to cast."
+      "Requires five edible mushrooms to cast."
    
-   Haste_on_rsc = "Your blood begins to tingle, cleansing your leg muscles of fatigue with every heartbeat."
-   Haste_off_rsc = "Your feel the tide of energy in your blood recede, and running seems suddenly more taxing."
-   Haste_already_enchanted_rsc = "You're already resistant to running fatigue."
+   Haste_on_rsc = \
+      "Your blood begins to tingle, cleansing your leg muscles of fatigue "
+      "with every heartbeat."
+   Haste_off_rsc = \
+      "Your feel the tide of energy in your blood recede, and running seems "
+      "suddenly more taxing."
+   Haste_already_enchanted_rsc = \
+      "You're already resistant to running fatigue."
    Haste_success_rsc = "%s%s is charged with your magical energy."
 
-   Haste_spell_intro = "Kraanan Lv. 2: Allows you to use less stamina as you run."
+   Haste_spell_intro = \
+      "Kraanan Lv. 2: Allows you to use less stamina as you run."
 
    Haste_sound = khaste.wav
 
@@ -75,21 +81,23 @@ messages:
    SetSpellPlayerFlag(who=$)
    {
       Send(who,@SetPlayerFlag,#flag=PFLAG2_HASTED,#flagset=2,#value=True);
+
       return;
    }
-   
-   GetDuration(iSpellpower = 0)
+
+   GetDuration(iSpellpower=0)
    {
       local iDuration;
+
       iDuration = 5 + ((15 * iSpellPower) / 100);   % 5 - 20 minutes,
       iDuration = iDuration * 1000 * 60;   % Convert to milliseconds
-      
+
       return iDuration;
    }
 
    GetPotionClass()
    {
-      RETURN &HastePotion;
+      return &HastePotion;
    }
 
    EffectDesc(who=$)
@@ -101,7 +109,7 @@ messages:
       AppendTempString(Send(who,@GetEnchantedState,#what=self));
       AppendTempString("\%.");
       
-      return;
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/invis.kod
+++ b/kod/object/passive/spell/persench/invis.kod
@@ -21,7 +21,7 @@ resources:
    invisibility_desc_rsc = \
      "Qor cloaks your body with a shimmering field leaving you "
      "invisible for a brief period.  "
-     "Requires dark angel feathers to cast."
+     "Requires one dark angel feather to cast."
    
    invisibility_already_enchanted_rsc = "You are already invisible."
 
@@ -30,7 +30,6 @@ resources:
       "The shimmering field around you dissolves, leaving you "
       "visible once more."
    invisibility_success_rsc = "%s%s disappears from view."
-      
 
    invisibility_sound = qinvis.wav
 
@@ -72,7 +71,7 @@ messages:
       return;
    }
 
-   CastSpell(who = $,iSpellPower=0, lTargets = $)
+   CastSpell(who=$,iSpellPower=0,lTargets=$)
    {
       % If it's only self cast, spoof self as target for following code
       if NOT vbCanCastonOthers
@@ -80,9 +79,9 @@ messages:
          lTargets = Cons(who, lTargets);
       }
 
-      Send(first(lTargets),@ResetPlayerFlagList);
-      Send(first(lTargets),@AddDefenseModifier,#what=self);
-      
+      Send(First(lTargets),@ResetPlayerFlagList);
+      Send(First(lTargets),@AddDefenseModifier,#what=self);
+
       propagate;
    }
 
@@ -109,30 +108,30 @@ messages:
       return iSpellpower;
    }
 
-   EndEnchantment(who = $, report = TRUE, state = 0)
+   EndEnchantment(who=$,report=TRUE,state=0)
    {
-      send(who,@RemoveDefenseModifier,#what=self);
-      
+      Send(who,@RemoveDefenseModifier,#what=self);
+
       propagate;
    }
 
    % Stuff we handle to be a defense modifier.
 
-   ModifyDefensePower(who = $,what = $,defense_power = 0)
+   ModifyDefensePower(who=$,what=$,defense_power=0)
    {
       local iSpellpower;
 
-      iSpellpower = send(who,@GetEnchantedState,#what=self);
-      
+      iSpellpower = Send(who,@GetEnchantedState,#what=self);
+
       return (defense_power + 25 + iSpellpower);
    }
 
-   ModifyDefenseDamage(who = $,what = $,damage = $)
+   ModifyDefenseDamage(who=$,what=$,damage=$)
    {
       return damage;
    }
 
-   DefendingHit(who = $,what = $)
+   DefendingHit(who=$,what=$)
    {
       return;
    }
@@ -150,8 +149,8 @@ messages:
       AppendTempString(" enchantment adds ");
       AppendTempString(25 + Send(who,@GetEnchantedState,#what=self));
       AppendTempString(" defense.");
-      
-      return;
+
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/karahol.kod
+++ b/kod/object/passive/spell/persench/karahol.kod
@@ -23,15 +23,18 @@ resources:
       "Kara'hol for a brief period, enhancing the ferocity of "
       "your attacks.  When the spirit departs, your body "
       "is temporarily paralyzed from shock.  "
-      "Requires the sacrifice of a few entroot berries to cast."
+      "Requires the sacrifice of two entroot berries to cast."
    
    KaraholsCurse_on = \
       "The spirit of Kara'hol descends upon you making your "
       "blood boil and your muscles twitch with newfound vigor."
-   KaraholsCurse_off = "Your body freezes as total exhaustion grips your limbs."
-   KaraholsCurse_already_enchanted_rsc = "Your blood already boils with Kara'hol's spirit!"
+   KaraholsCurse_off = \
+      "Your body freezes as total exhaustion grips your limbs."
+   KaraholsCurse_already_enchanted_rsc = \
+      "Your blood already boils with Kara'hol's spirit!"
 
-   Karahols_spell_intro = "Qor Lv. 2: Temporarily gives you berserker combat abilities, but with a price to pay later."
+   Karahols_spell_intro = "Qor Lv. 2: Temporarily gives you berserker combat "
+   "abilities, but with a price to pay later."
 
    KaraholsCurse_sound = qkcurse.wav
 
@@ -67,7 +70,7 @@ classvars:
    viOffensive = TRUE
 
 properties:
-   
+
 messages:
 
    ResetReagents()
@@ -78,10 +81,10 @@ messages:
       return;
    }
 
-   CastSpell(who = $,iSpellPower= 0, ltargets = $)
+   CastSpell(who=$,iSpellPower=0,lTargets=$)
    {
       Send(who,@AddAttackModifier,#what=self);
-     
+
       propagate;
    }
 
@@ -99,7 +102,7 @@ messages:
       return iDuration;
    }
 
-   EndEnchantment(who=$, report=TRUE, state=0)
+   EndEnchantment(who=$,report=TRUE,state=0)
    {
       local oHoldSpell, iDuration;
 
@@ -111,28 +114,30 @@ messages:
       {
          Send(who,@RemoveEnchantment,#what=oHoldSpell,#report=FALSE);
       }
-      
-      % Hold duration is measured in seconds, not milliseconds.  Lasts 1/6 the time of the bonus.
+
+      % Hold duration is measured in seconds, not milliseconds.
+      % Lasts 1/6 the time of the bonus.
       iDuration = (Send(self,@GetDuration,#iSpellPower=state))/6;
-      Send(oHoldSpell,@DoHold,#what=self,#otarget=who,#iDuration=iDuration,#report=TRUE,#bAllowFreeAction=FALSE);
-      
+      Send(oHoldSpell,@DoHold,#what=self,#oTarget=who,#iDuration=iDuration,
+            #report=TRUE,#bAllowFreeAction=FALSE);
+
       propagate;
    }
 
-   % stuff we handle to be an attack modifier
-   ModifyHitRoll(who = $,what = $,hit_roll = $)
-   {      
-      return hit_roll + 100 + (send(who,@GetEnchantedState,#what=self)*2);
+   % Stuff we handle to be an attack modifier
+   ModifyHitRoll(who=$,what=$,hit_roll=$)
+   {
+      return hit_roll + 100 + (Send(who,@GetEnchantedState,#what=self)*2);
    }
    
-   ModifyDamage(who = $,what = $,damage = $)
+   ModifyDamage(who=$,what=$,damage=$)
    {
-      return (damage + 1 + Random(0,send(who,@GetEnchantedState,#what=self)/20));
+      return (damage + 1 + Random(0,Send(who,@GetEnchantedState,#what=self)/20));
    }
 
    GetPotionClass()
    {
-      RETURN &KaraholsCursePotion;
+      return &KaraholsCursePotion;
    }
 
    EffectDesc(who=$)
@@ -147,8 +152,8 @@ messages:
       AppendTempString(" attack damage. When it expires, it will paralyze you for ");
       AppendTempString(((40+(Send(who,@GetEnchantedState,#what=self)/2)) * 1000)/6);
       AppendTempString(" milliseconds.");
-      
-      return;
+
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/mshield.kod
+++ b/kod/object/passive/spell/persench/mshield.kod
@@ -21,7 +21,7 @@ resources:
    magicshield_desc_rsc = \
       "Summons a shield of powerful magical energy that will "
       "deflect some of the blows aimed at you for several minutes.  "
-      "Requires mushrooms and red mushrooms to cast."
+      "Requires two mushrooms and one red mushroom to cast."
    
    magicshield_already_enchanted_rsc = "You already have magic shield."
    magicshield_on_rsc = \
@@ -66,11 +66,11 @@ messages:
 
       return;
    }
-	 
-   CastSpell(who = $,lTargets = $)
+
+   CastSpell(who=$,lTargets=$)
    {
       Send(first(lTargets),@AddDefenseModifier,#what=self);
-      
+
       propagate;
    }
 
@@ -78,7 +78,7 @@ messages:
    {
       local iDuration;
 
-      iDuration = 1 + ((iSpellPower + 5)/10); 
+      iDuration = 1 + ((iSpellPower + 5)/10);
 
       % Convert to ms.
       iDuration = iDuration * 60 * 1000;
@@ -91,35 +91,35 @@ messages:
       return iSpellpower;
    }
 
-   EndEnchantment(who = $, report = TRUE, state = 0)
+   EndEnchantment(who=$,report=TRUE,state=0)
    {
-      send(who,@RemoveDefenseModifier,#what=self);
-      
+      Send(who,@RemoveDefenseModifier,#what=self);
+
       propagate;
    }
 
    GetPotionClass()
    {
-      RETURN &MagicShieldPotion;
+      return &MagicShieldPotion;
    }
 
    % Stuff we handle to be a defense modifier.
 
-   ModifyDefensePower(who = $,what = $,defense_power = 0)
+   ModifyDefensePower(who=$,what=$,defense_power=0)
    {
       local iSpellpower;
 
-      iSpellpower = send(who,@GetEnchantedState,#what=self);
-      
+      iSpellpower = Send(who,@GetEnchantedState,#what=self);
+
       return (defense_power + 50 + (2 * iSpellpower));
    }
 
-   ModifyDefenseDamage(who = $,what = $,damage = $)
+   ModifyDefenseDamage(who=$,what=$,damage=$)
    {
       return damage;
    }
 
-   DefendingHit(who = $,what = $)
+   DefendingHit(who=$,what=$)
    {
       return;
    }
@@ -132,8 +132,8 @@ messages:
       AppendTempString(" enchantment adds ");
       AppendTempString(50 + (2 * Send(who,@GetEnchantedState,#what=self)));
       AppendTempString(" defense.");
-      
-      return;
+
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/nightv.kod
+++ b/kod/object/passive/spell/persench/nightv.kod
@@ -20,7 +20,7 @@ resources:
    nightvision_icon_rsc = nitvsico.bgf
    nightvision_desc_rsc = \
       "Magically enhances the vision of the target.  "
-	   "Requires elderberry to cast."
+      "Requires three elderberries to cast."
    
    nightvision_already_enchanted_rsc = "You already have night vision."
 
@@ -46,7 +46,7 @@ classvars:
 
    viChance_To_Increase = 35
    viMeditate_ratio = 10
-   
+
    viFlash = FLASH_GOOD_SELF
 
 properties:
@@ -61,31 +61,31 @@ messages:
       return;
    }
 
-   GetStateValue(who = $, iSpellPower = 0,target=$)
+   GetStateValue(who=$,iSpellPower=0,target=$)
    {
       local iState;
 
       iState = iSpellPower + 50;
       Send(target,@GainLight,#amount=iState);
-      
+
       return iState;
    }
-   
-   GetDuration(iSpellpower = 0)
+
+   GetDuration(iSpellpower=0)
    {
       local iDuration;
-      
+
       iDuration = 1500 + 10 * iSpellPower;
       iDuration = iDuration * 1000;
-      
+
       return iDuration;
    }
 
 
-   EndEnchantment(who = $, report = TRUE, state = 0)
+   EndEnchantment(who=$,report=TRUE,state=0)
    {
       Send(who,@LoseLight,#amount=state);
-      
+
       propagate;
    }
 
@@ -102,10 +102,9 @@ messages:
       AppendTempString(" enchantment adds ");
       AppendTempString(Send(who,@GetEnchantedState,#what=self));
       AppendTempString(" visual light.");
-      
-      return;
+
+      propagate;
    }
 
 end
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/persench/resist.kod
+++ b/kod/object/passive/spell/persench/resist.kod
@@ -33,14 +33,14 @@ properties:
 
 messages:
 
-   CanPayCosts(who = $, lTargets = $)
+   CanPayCosts(who=$,lTargets=$)
    {
-      
+
       lTargets = [who];
-         
-      if (vrAlreadyEnchanted = $) or (vrEnchantment_On = $) or (vrEnchantment_Off = $) or (vrSuccess = $)
+
+      if (vrAlreadyEnchanted = $) OR (vrEnchantment_On = $) OR (vrEnchantment_Off = $) OR (vrSuccess = $)
       {
-         DEBUG("Haven't set messages for this spell!  Aborting cast.");
+         Debug("Haven't set messages for this spell!  Aborting cast.");
          
          return FALSE;
       }
@@ -48,40 +48,45 @@ messages:
       propagate;
    }
 
-   GetStateValue(who = $, iSpellPower = 0, target = $)
+   GetStateValue(who=$,iSpellPower=0,target=$)
    {
       local iValue;
-      
-      iValue = send(self,@GetResistanceStrength,#iSpellPower=iSpellPower);
-      
+
+      iValue = Send(self,@GetResistanceStrength,#iSpellPower=iSpellPower);
+
       return iValue;
    }
 
-   GetResistanceStrength(iSpellpower = 0)
+   GetResistanceStrength(iSpellpower=0)
    {
-      %% strength varies from 1 to 50
+      %% Strength varies from 1 to 50
       return iSpellPower/2 + 1;
    }
 
    ModifyResistance(resistance_list=$,iState=0)
    {
-      resistance_list = Send(SYS,@AddResistance,#what=viResistanceType,#value=iState,#resistance_list=resistance_list);
+      resistance_list = Send(SYS,@AddResistance,#what=viResistanceType,
+                              #value=iState,#resistance_list=resistance_list);
       return resistance_list;
    }
 
-   GetDuration(iSpellPower = 0)
+   GetDuration(iSpellPower=0)
    {
-      local iDuration;	   %%% 5 to 10 minutes
-      
+      local iDuration;      %%% 5 to 10 minutes
+
       iDuration = 300 + iSpellPower * 3;
-      iDuration = iDuration * 1000;	  %% translate to milliseconds
-      
+      iDuration = iDuration * 1000;      %% translate to milliseconds
+
       return iDuration;
    }
 
-   EndEnchantment(who = $, report = TRUE, state = -1)
+   EndEnchantment(who=$,report=TRUE,state=-1)
    {
-      if state = -1  { DEBUG("Bad data!"); state = 0; }
+      if state = -1
+      {
+         Debug("Bad data!");
+         state = 0;
+      }
 
       propagate;
    }
@@ -90,7 +95,7 @@ messages:
    {
       return 0;
    }
-  
+
    EffectDesc(who=$)
    {
       AppendTempString("\n\n");
@@ -101,10 +106,9 @@ messages:
       AppendTempString("\% ");
       AppendTempString(Send(SYS,@GetResistanceName,#type=viResistanceType));
       AppendTempString(".");
-      
-      return;
-   }
-   
-end
 
+      propagate;
+   }
+
+end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/persench/respois.kod
+++ b/kod/object/passive/spell/persench/respois.kod
@@ -20,13 +20,16 @@ resources:
    ResistPoison_icon_rsc = irespois.bgf
    ResistPoison_desc_rsc = \
       "Stabilizes your immune system, protecting you from some poisons.  "
-      "Requires herbs and red mushrooms."
+      "Requires two herbs and a red mushroom."
    
-   ResistPoison_on_rsc = "Your body tingles for a moment, and you feel a little "
-                         "strange."
-   ResistPoison_off_rsc = "Your strange feeling of tolerance subsides."
-   ResistPoison_already_enchanted_rsc = "You're already resistant to poisons."
-   ResistPoison_success_rsc = "Your magic increases %s%s's resistance to poison."
+   ResistPoison_on_rsc = \
+      "Your body tingles for a moment, and you feel a little strange."
+   ResistPoison_off_rsc = \
+      "Your strange feeling of tolerance subsides."
+   ResistPoison_already_enchanted_rsc = \
+      "You're already resistant to poisons."
+   ResistPoison_success_rsc = \
+      "Your magic increases %s%s's resistance to poison."
 
    resistpoison_sound = kresistp.wav
 
@@ -65,14 +68,14 @@ messages:
 
    GetStateValue(iSpellPower=$)
    {
-      local ifactor;    
+      local iFactor;
 
       iFactor = bound(iSpellPower,10,99);
 
       return iFactor;
    }
-  
-   GetDuration(iSpellPower = 0)
+
+   GetDuration(iSpellPower=0)
    {
       local iDuration;
 
@@ -81,7 +84,7 @@ messages:
       % Convert to ms.
       iDuration = iDuration * 1000;
 
-      return iDuration;     
+      return iDuration;
    }
 
    OfferToNewCharacters()
@@ -92,7 +95,7 @@ messages:
 
    GetPotionClass()
    {
-      RETURN &ResistPoisonPotion;
+      return &ResistPoisonPotion;
    }
 
    EffectDesc(who=$)
@@ -103,8 +106,8 @@ messages:
       AppendTempString(" enchantment will protect you from poisoning attempts ");
       AppendTempString(Send(who,@GetEnchantedState,#what=self));
       AppendTempString("\% of the time.");
-      
-      return;
+
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/shadform.kod
+++ b/kod/object/passive/spell/persench/shadform.kod
@@ -17,14 +17,16 @@ constants:
 resources:
 
    shadowform_name_rsc = "shadow form"
-   shadowform_icon_rsc = ishadfrm.bgf   
+   shadowform_icon_rsc = ishadfrm.bgf
    shadowform_desc_rsc = \
      "Transforms the target into a silhouette of their former self, "
-	  "perfect for skulking in darker locales and making them more difficult to hit.  "
-	  "Requires a handful of rainbow fern."
+     "perfect for skulking in darker locales and making them more difficult "
+     "to hit.  Requires three rainbow ferns to cast."
 
-   shadowform_already_enchanted = "You already have shadow form."
-   shadowform_already_affected = "The shadows refuse to hide what you wish."
+   shadowform_already_enchanted = \
+      "You already have shadow form."
+   shadowform_already_affected = \
+      "The shadows refuse to hide what you wish."
 
    shadowform_on = "You melt into your shadow."
    shadowform_off = "You fade back to your own colors."
@@ -58,12 +60,12 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&RainbowFern,3],plReagents);      
+      plReagents = Cons([&RainbowFern,3],plReagents);
 
       return;
    }
 
-   CanPayCosts(who = $, lTargets = $)
+   CanPayCosts(who=$,lTargets=$)
    {
       local oTarget, iDrawFX;
 
@@ -74,7 +76,7 @@ messages:
          return FALSE;
       }
 
-      % check for lighting effect already applied
+      % Check for lighting effect already applied
       if oTarget <> who
       {
          iDrawfX = Send(oTarget,@GetPlayerDrawFX);
@@ -91,10 +93,10 @@ messages:
       propagate;
    }
 
-   GetDuration(who = $,iSpellPower = 0)
+   GetDuration(who=$,iSpellPower=0)
    {
       local iTime;
-      
+
       iTime = 60000 + (iSpellPower * 3000);
 
       return iTime;
@@ -103,54 +105,55 @@ messages:
    SetSpellPlayerFlag(who=$)
    {
       Send(who,@SetPlayerDrawFX,#drawfx=DRAWFX_BLACK,#SendSomethingChanged=TRUE);
-      
-      return;  
-   }
 
-   EndEnchantment(who = $, report = TRUE)
-   {
-      Send(who,@ResetPlayerDrawfx);
-      send(who,@RemoveDefenseModifier,#what=self);
-      
-      if report
-      {
-	      Send(who,@MsgSendUser,#message_rsc=shadowform_off);
-      }
-     
       return;
    }
 
-   GetStateValue(who = $, iSpellPower = 0,target=$)      
-   {      
-      Send(target,@AddDefenseModifier,#what=self);       
+   EndEnchantment(who=$,report=TRUE)
+   {
+      Send(who,@ResetPlayerDrawfx);
+      Send(who,@RemoveDefenseModifier,#what=self);
+
+      if report
+      {
+         Send(who,@MsgSendUser,#message_rsc=shadowform_off);
+      }
+
+      return;
+   }
+
+   GetStateValue(who=$,iSpellPower=0,target=$)
+   {
+      Send(target,@AddDefenseModifier,#what=self);
 
       return iSpellPower;
    }
 
    GetPotionClass()
    {
-      RETURN &ShadowFormPotion;
+      return &ShadowFormPotion;
    }
 
-   ModifyDefensePower(who = $, what = $,defense_power = $)
+   ModifyDefensePower(who=$,what=$,defense_power=$)
    {
       local iLight,iShadowbonus;
 
-      iLight = send(send(who,@GetOwner),@GetRoomLight);
+      iLight = Send(send(who,@GetOwner),@GetRoomLight);
 
       if what <> $
       {
-         % A player attacker's light determines how well they can see the enchanted, too.
-         if isClass(what,&Player)
+         % A player attacker's light determines how well they can see the
+         % enchanted, too.
+         if IsClass(what,&Player)
          {
-            iLight =  iLight + send(what,@GetPlayerLightLevel);
+            iLight =  iLight + Send(what,@GetPlayerLightLevel);
          }
       }
 
       % Give bonuses if we're in a darker room.
       iShadowBonus = 30 + (LIGHT_NICE - iLight);
 
-      iShadowBonus = bound(iShadowBonus,10,150); 
+      iShadowBonus = Bound(iShadowBonus,10,150);
 
       return defense_power + iShadowBonus;
    }
@@ -158,14 +161,14 @@ messages:
    EffectDesc(who=$)
    {
       local iShadowBonusMonster, iShadowBonusPlayer, iLight;
-      
+
       iLight = send(send(who,@GetOwner),@GetRoomLight);
       iShadowBonusMonster = 30 + (LIGHT_NICE - iLight);
       iShadowBonusMonster = bound(iShadowBonusMonster,10,150);
-      
+
       iShadowBonusPlayer = 30 + (LIGHT_NICE - (iLight + 5));
       iShadowBonusPlayer = bound(iShadowBonusPlayer,10,150);
-      
+
       AppendTempString("\n\n");
       AppendTempString("Your current ");
       AppendTempString(Send(self,@GetName));
@@ -174,8 +177,8 @@ messages:
       AppendTempString(" defense against monsters here. Against a player of average light level, it will add ");
       AppendTempString(iShadowBonusPlayer);
       AppendTempString(" defense.");
-      
-      return;
+
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/strength.kod
+++ b/kod/object/passive/spell/persench/strength.kod
@@ -16,18 +16,26 @@ constants:
 
 resources:
 
-   superstrength_on_rsc = "Your blood tingles with the force of Kraanan.  You are ready for battle!"
-   superstrength_off_rsc  = "The superhuman strength of Kraanan departs your body, leaving you a mortal once more."
-   superstrength_already_enchanted_rsc = "You already have superior strength."
-   superstrength_success_rsc = "%s%s reels under the impact of Kraanan's power."
+   superstrength_on_rsc = \
+      "Your blood tingles with the force of Kraanan.  You are ready for "
+      "battle!"
+   superstrength_off_rsc  = \
+      "The superhuman strength of Kraanan departs your body, leaving you a "
+      "mortal once more."
+   superstrength_already_enchanted_rsc = \
+      "You already have superior strength."
+   superstrength_success_rsc = \
+      "%s%s reels under the impact of Kraanan's power."
 
    superstrength_name_rsc = "super strength"
    superstrength_icon_rsc = istreng.bgf
    superstrength_desc_rsc = \
       "Infuses your body with superhuman strength.  "
-      "Requires mushrooms and orc teeth to cast."
+      "Requires two mushrooms and an orc tooth to cast."
 
-   superstrength_spell_intro = "Kraanan Lv. 2: Infuses your body with superhuman strength in preparation for battle."
+   superstrength_spell_intro = \
+      "Kraanan Lv. 2: Infuses your body with superhuman strength in "
+      "preparation for battle."
 
 classvars:
    viPersonal_ench = True
@@ -53,7 +61,7 @@ classvars:
 
    viOffensive = TRUE
 
-properties:  
+properties:
 
 messages:
 
@@ -67,35 +75,35 @@ messages:
    }
 
 
-   GetStateValue(who = $, iSpellPower = 0, Target = $)
+   GetStateValue(who=$,iSpellPower=0,Target=$)
    {
       local iMightChange;
       iMightChange = iSpellPower/5+1;
 
-      send(Target,@AddMight,#points=iMightChange);
+      Send(Target,@AddMight,#points=iMightChange);
 
       return iMightChange;
    }
 
-   GetDuration(iSpellPower = 0)
+   GetDuration(iSpellPower=0)
    {
       local iDuration;
       iDuration = 300 + (iSpellpower * 6);
       iDuration = iDuration * 1000;
-      
+
       return iDuration;
    }
 
-   EndEnchantment( who = $, state = 0, report = TRUE )
+   EndEnchantment(who=$,state=0,report=TRUE)
    {
-      send(who,@AddMight,#points=-state);
-     
+      Send(who,@AddMight,#points=-state);
+
       propagate;
    }
 
    GetPotionClass()
    {
-      RETURN &StrengthPotion;
+      return &StrengthPotion;
    }
 
    EffectDesc(who=$)
@@ -106,8 +114,8 @@ messages:
       AppendTempString(" enchantment adds ");
       AppendTempString(Send(who,@GetEnchantedState,#what=self));
       AppendTempString(" Might.");
-      
-      return;
+
+      propagate;
    }
 
 end

--- a/kod/object/passive/spell/persench/touchatk.kod
+++ b/kod/object/passive/spell/persench/touchatk.kod
@@ -458,8 +458,8 @@ messages:
       AppendTempString(" base ");
       AppendTempString(Send(SYS,@GetSpellDamageTypeName,#type=(viSpellType & ~ATCK_SPELL_ALL)));
       AppendTempString(" damage.");
-      
-      return;
+
+      propagate;
    }
 
 end


### PR DESCRIPTION
Expanded the EffectDesc() function in persench.kod to append the time remaining for each buff to the icon description. Changed all PEs to propagate so this timer is added after any text added by those files. Detect evil and detect good are modified in a separate pull due to possible conflicts (both pulls are mine).

I've also cleaned up all the files in the persench class (except touch attacks due to other pulls). I'm not too sure as to whether I should do this to room enchants, as there may be strategic value for the person who cast the spell in others not knowing the time remaining.

Note: anonymity, illusionary form and morph don't work yet; they are in Spell not PersonalEnchantments.
