### PR TITLE
No training point unless player lands killing blow on HP-appropriate monster.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8315,7 +8315,9 @@ messages:
          }
          else
          {
-            if piTraining_points mod 100 = 0 AND piInform
+            if piTraining_points mod 100 = 0
+               AND piTraining_points <> 0
+               AND piInform
             {
                Send(self,@MsgSendUser,#message_rsc=player_training_inform,#parm1=piTraining_points);
             }


### PR DESCRIPTION
Training points were being acquired far too quickly via grouping, as they were being applied every time the player gained an 'experience' point. This also occurred any time a player killed _any_ monster, provided they were not in a group, due to an error in how the solo builder bonus gain point is applied. This experience point is now only given if the player kills a HP-appropriate monster (does not spit on) thus the training point is only applied then also. Players will also need to land the killing blow to gain a training point, so that monsters aren't giving out multiple training points for a single kill (theory is that you need to kill it to train yourself and be rewarded the point).
