### PR TITLE
Fix hitroll bug caused by all weapon enchantments/attributes.

### DIFF
--- a/kod/object/item/passitem/weapon.kod
+++ b/kod/object/item/passitem/weapon.kod
@@ -290,7 +290,7 @@ messages:
          oWeapAtt = Send(SYS,@FindItemAttByNum,#num=Send(self,@GetNumFromCompound,#compound=First(i)));
          if IsClass(oWeapAtt,&WeaponAttribute)
          {
-            iBaseHit = Send(oWeapAtt,@ModifyHitRoll,#hitroll=hit_roll,#wielder=poOwner,
+            iBaseHit = Send(oWeapAtt,@ModifyHitRoll,#hitroll=iBaseHit,#wielder=poOwner,
                               #target=target,#lData=i);
          }
       }


### PR DESCRIPTION
This involves a line of code in weapon.kod, where any hitroll modification from weapon enchantments or attributes are added to any innate bonuses that the weapon has, eg. scimitar has 50, mystic sword 175. However instead of adding the weapon bonus to base player hitroll, then having the weapon attribute modify the new hitroll, the original hitroll is sent to that function so any weapon with an enchantment or attribute just loses the innate weapon bonuses.

Now fixed.
