### PR TITLE
Gort Message

### DIFF
--- a/kod/object/passive/spell/persench/gort.kod
+++ b/kod/object/passive/spell/persench/gort.kod
@@ -34,6 +34,10 @@ resources:
    ArmorOfGort_spell_intro = \
       "Kraanan Level 5: Magical armor that protects the caster."
 
+   gort_reduction_physical_rsc = "%s%s's armor of Gort hardens, protecting %s from much of the force of your attack."
+   gort_reduction_partial_magic_rsc = "%s%s's armor of Gort tightens, mitigating some of your partially magical attack."
+   gort_reduction_fully_magic_rsc = "%s%s's armor of Gort glimmers, offering a slight protection against your magical attack."
+
 classvars:
 
    vrName = ArmorOfGort_name_rsc
@@ -92,7 +96,7 @@ messages:
 
    PriorityModifyDefenseDamage(who=$,what=$,damage=$,atype=0,aspell =0)
    {
-      local iSpellPower, iAbsorbed, iMax;
+      local iSpellPower, iAbsorbed, iMax, iFinalDamage, iFinalAbsorbed;
 
       iSpellPower = Send(who,@GetEnchantedState,#what=self);
       iMax = 15;
@@ -116,8 +120,34 @@ messages:
             iMax = 25;
          }
       }
+      
+      iFinalDamage = Bound(damage-iAbsorbed,1,iMax);
+      iFinalAbsorbed = damage - iFinalDamage;
+      
+      If IsClass(what,&User)
+         AND iFinalAbsorbed > 0
+      {
+         if aspell <> 0
+         {
+            if atype <> 0
+            {
+               Send(what,@MsgSendUser,#message_rsc=gort_reduction_partial_magic_rsc,#parm1=Send(who,@GetDef),
+                                      #parm2=Send(who,@GetName));
+            }
+            else
+            {
+               Send(what,@MsgSendUser,#message_rsc=gort_reduction_fully_magic_rsc,#parm1=Send(who,@GetDef),
+                                      #parm2=Send(who,@GetName),#parm3=Send(who,@GetHimHer));
+            }
+         }
+         else
+         {
+            Send(what,@MsgSendUser,#message_rsc=gort_reduction_physical_rsc,#parm1=Send(who,@GetDef),
+                                   #parm2=Send(who,@GetName),#parm3=Send(who,@GetHimHer));
+         }
+      }
 
-      return Bound(damage-iAbsorbed,1,iMax);
+      return iFinalDamage;
    }
 
    ModifyDefenseDamage(who=$,what=$,damage=$,atype=0,aspell=0)


### PR DESCRIPTION
Armor of Gort now gives attackers a message about what it is doing. I've noticed that
Gort is incredibly important in PvP, yet nobody is ever anything but frustrated because
they don't understand why they are doing very little damage. These messages should
help clue in players as to what is happening, and, as a bonus, they also introduce
the educational concept of damage types and partially magical attacks. Anyone
who runs into this effect and loses a fight will probably try out a few attacks to see
what works better or worse against Gort.

These messages only appear if Gort actually reduces damage.

**Gar's armor of Gort hardens, protecting him from much of the force of your attack.**

**Gar's armor of Gort tightens, mitigating some of your partially magical attack.**

**Gar's armor of Gort glimmers, offering a slight protection against your magical attack.**

For reference, Gort caps physical attacks at 15, partially magic at 20, and fully magic
at 25. This has a dramatic effect when combined with armor. Capping a physical attack
at 15 will allow plate armor and a full power Jonas shield to reduce attacks to extremely
small amounts. Players need to adapt by using weapons with an elemental damage
type, touch spells, or magical attacks, or they need to use a purge weapon to get rid
of that Gort.
