### PR TITLE
Multiple Spell Items Combining at once

### DIFF
--- a/kod/object/item/passitem/spelitem.kod
+++ b/kod/object/item/passitem/spelitem.kod
@@ -490,7 +490,7 @@ messages:
       {
          Send(poOwner,@MsgSendUser,#message_rsc=combine_spell_item_rsc,#parm1=Send(sacrificed_item,@GetName),#parm2=piHits,#parm3=piSpellPower);
       }
-      Send(sacrificed_item,@Delete);
+      Post(sacrificed_item,@Delete);
       
       return;
    }


### PR DESCRIPTION
These were deleting too early. Now they'll wait till after all
combinations. You'll be able to grab multiple potions at once
without any getting accidentally lost in the shuffle.
