### PR TITLE
Dazzle revamp, part of CC changes.

### DIFF
--- a/kod/object/passive/spell/debuff/dazzle.kod
+++ b/kod/object/passive/spell/debuff/dazzle.kod
@@ -36,6 +36,11 @@ classvars:
    vrIcon = Dazzle_icon_rsc
    vrDesc = Dazzle_desc_rsc
 
+   vrAlreadyEnchanted = Dazzle_already_enchanted
+   vrEnchantment_On = Dazzle_on
+   vrEnchantment_Off = Dazzle_off
+   vrSuccess = Dazzle_caster
+
    viSpell_num = SID_DAZZLE
    viSchool = SS_SHALILLE
    viSpell_level = 4
@@ -45,13 +50,14 @@ classvars:
 
    viSpellExertion = 6
 
-   viOutlaw = TRUE
-   viHarmful = TRUE
-   viNoNewbieOffense = TRUE
-
    vrSucceed_wav = Dazzle_sound
 
 properties:
+
+   piSpellPowerMultiplier = 40
+   piKarmaPowerMultiplier = 10
+   piBaseDuration = 3000
+   piDeviation = 10
 
 messages:
 
@@ -64,55 +70,6 @@ messages:
       return;
    }
 
-   CanPayCosts(who=$,lTargets=$,bItemCast=FALSE)
-   {
-      local target, i;
-
-      % Can cast spell if the 1 target item is a user
-      if Length(lTargets) <> 1
-      {
-         return FALSE;
-      }
-
-      target = First(lTargets);
-      if NOT IsClass(target,&Battler) OR IsClass(target,&Revenant)
-      {
-         if not bItemCast
-         {
-            Send(who,@MsgSendUser,#message_rsc=spell_bad_target, 
-                 #parm1=vrName,#parm2=Send(target,@GetDef),
-                 #parm3=Send(target,@GetName));
-         }
-
-         return FALSE;
-      }
-
-      if target = who
-      {
-         if NOT bItemCast
-         {
-            Send(who,@MsgSendUser,#message_rsc=spell_no_self_target,
-                 #parm1=vrName);
-         }
-
-         return FALSE;
-      }
-
-      % Check for enchantment already applied
-      if Send(target,@IsEnchanted,#what=self)
-      {
-         if not bItemCast
-         {
-            Send(who,@MsgSendUser,#message_rsc=Dazzle_already_enchanted,
-                 #parm1=Send(target,@GetCapDef),#parm2=Send(target,@GetName));
-         }
-
-         return FALSE;
-      }
-
-      propagate;
-   }
-
    CastSpell(who=$,lTargets=$,iSpellPower=0)
    {
       local oTarget, iDuration;
@@ -121,16 +78,14 @@ messages:
       iDuration = Send(self,@GetDuration,#iSpellPower=iSpellPower,
                         #caster=who,#target=oTarget);
 
-      Send(self,@DoDazzle,#what=who,#oTarget=oTarget,#iDurationSecs=iDuration);
+      Send(self,@DoSpell,#what=who,#oTarget=oTarget,#iDuration=iDuration);
 
       propagate;
    }
 
-   DoDazzle(what=$,oTarget=$,iDurationSecs=0)
+   DoSpell(what=$,oTarget=$,iDuration=0)
    {
-      local oSpell, iDuration;
-
-      iDuration = iDurationSecs;
+      local oSpell;
 
       oSpell = Send(SYS,@FindSpellByNum,#NUM=SID_EAGLE_EYES);
       if Send(oTarget,@IsEnchanted,#what=oSpell)
@@ -144,15 +99,13 @@ messages:
          }
       }
 
-      % Convert duration to milliseconds
-      iDuration = bound(iDuration,3,15);
-      iDuration = iDuration * 1000;
+      iDuration = Bound(iDuration,3000,8000);
 
       if IsClass(oTarget,&Player)
       {
-         Send(oTarget,@MsgSendUser,#message_rsc=Dazzle_on);
+         Send(oTarget,@MsgSendUser,#message_rsc=vrEnchantment_On);
          Send(oTarget,@EffectSendUserDuration,#effect=EFFECT_WHITEOUT,
-              #duration=iDuration);
+               #duration=iDuration);
       }
       else
       {
@@ -160,19 +113,20 @@ messages:
          Post(oTarget,@ResetBehaviorFlags);
       }
 
-      Send(what,@MsgSendUser,#message_rsc=Dazzle_caster,
+      Send(what,@MsgSendUser,#message_rsc=vrSuccess,
             #parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
+
       Send(oTarget,@StartEnchantment,#what=self,#time=iDuration);
 
-      return;
+      propagate;
    }
 
    GetDuration(iSpellPower=0,caster=$,target=$)
    {
-      local iDuration,iKarmaDif,iKarma;
+      local iDuration,iKarma;
 
-      % 1-8 seconds based on spellpower.
-      iDuration = (iSpellPower/12);
+      % 3-7 seconds based on spellpower.
+      iDuration = piBaseDuration + iSpellPower * piSpellPowerMultiplier;
       if IsClass(caster,&Battler)
       {
          iKarma = Send(caster,@GetKarma);
@@ -183,9 +137,9 @@ messages:
          iKarma = random(30,90);
       }
 
-       % 1-10 seconds based on Karma difference.
-      iKarmaDif = (iKarma - Send(target,@GetKarma,#detect=TRUE))/20;
-      iDuration = bound(iDuration + iKarmaDif,3,15);  
+       % Add up to an extra second based on karma (in practice, 400-1000ms)
+      iDuration = Bound(iDuration + (iKarma * piKarmaPowerMultiplier) ,3000,8000);
+      iDuration = Random(iDuration*(100-piDeviation)/100,iDuration);
 
       return iDuration;
    }
@@ -196,17 +150,17 @@ messages:
       {
          if report
          {
-            Send(who,@MsgSendUser,#message_rsc=Dazzle_off);
+            Send(who,@MsgSendUser,#message_rsc=vrEnchantment_Off);
          }
 
-         Send(who,@EffectSendUserDuration,#effect=EFFECT_PAIN,#duration=8000);
+         Send(who,@EffectSendUserDuration,#effect=EFFECT_PAIN,#duration=1000);
          Send(who,@EffectSendUserXLat,#xlat=0);
       }
       else
       {
          % Class is monster
          % Post this so it's done AFTER the enchantment is gone from the
-         %  monster's ench list
+         % monster's ench list
          Post(who,@ResetBehaviorFlags);
       }
 
@@ -221,14 +175,24 @@ messages:
       return;
    }
 
-   SendEffectData()
-   {
-      return;
-   }
-
    RestartEnchantmentEffect(who=$,state=$)
    {
-      Send(who,@MsgSendUser,#message_rsc=Dazzle_on);
+      local i, iDuration, oList;
+
+      Send(who,@MsgSendUser,#message_rsc=vrEnchantment_On);
+
+      oList = Send(who,@GetEnchantmentList);
+
+      for i in oList
+      {
+         if Nth(i,2) = self
+         {
+            iDuration = GetTimeRemaining(Nth(i,1));
+         }
+      }
+
+      Send(who,@EffectSendUserDuration,#effect=EFFECT_WHITEOUT,
+            #duration=iDuration);
 
       return;
    }


### PR DESCRIPTION
Forum thread: http://openmeridian.org/forums/index.php/topic,103.0.html

This pull request looks at balancing Dazzle, which currently lasts up to 15 seconds and is not reduced by the same random calculation as the other CC spells. Currently, 1-8 seconds of duration come from spellpower, and 1-10 from karma difference between attacker and victim, and the result is bound between 3-15 seconds.

My version has the total bound between 3-8 seconds, with 0.4-1.0 seconds coming from the attacker's karma, 3 seconds base time and up to 4 seconds from spellpower. The final duration is subject to a 10% randomness, so with 99 spellpower and 100 karma, the attacker could count on a dazzle between 7.2 and 8 seconds (before mitigating factors such as EE, dement, AmA). The pain effect after dazzle wears off is reduced from 8 seconds to 1 second.

As with the blind pull request, I've started the duration off slightly higher than stated in the forum thread, and we can balance down from there if necessary.