### PR TITLE
Revamp Hold for CC changes, reduce length of Kara'hol's hold, lower Gaze cast time by 1 second. Gaze duration now equal to 'spellpower' seconds.

### DIFF
--- a/kod/object/passive/spell/persench/karahol.kod
+++ b/kod/object/passive/spell/persench/karahol.kod
@@ -110,8 +110,8 @@ messages:
          Send(who,@RemoveEnchantment,#what=oHoldSpell,#report=FALSE);
       }
 
-      % Lasts 1/6 the time of the bonus.
-      iDuration = (Send(self,@GetDuration,#iSpellPower=state)) / 6;
+      % Hold effect lasts 8 sec at low spellpower, 2 sec at high sp.
+      iDuration = Bound(((100-state) * 100 + 2000),2000,8000);
       Send(oHoldSpell,@DoSpell,#what=self,#oTarget=who,#iDuration=iDuration,
             #report=TRUE,#bAllowFreeAction=FALSE);
 
@@ -144,7 +144,7 @@ messages:
       AppendTempString(" offense and 1-");
       AppendTempString(1 + (Send(who,@GetEnchantedState,#what=self) / 20));
       AppendTempString(" attack damage. When it expires, it will paralyze you for ");
-      AppendTempString((40 + (Send(who,@GetEnchantedState,#what=self) / 2)) / 6);
+      AppendTempString(Bound(((100-(Send(who,@GetEnchantedState,#what=self))) + 20) / 10,2,8));
       AppendTempString(" seconds.");
 
       propagate;


### PR DESCRIPTION
Forum thread: http://openmeridian.org/forums/index.php/topic,103.0.html

Currently hold lasts 2-6 seconds, 50% random duration, no cast time, 2 second post-cast. This pull request reduces the randomness to 10%, lowers the post cast to 1 second, but adds a 400ms cast time. This will prevent or hinder chain-holding but still allow the spell to be used much the same in other cases. The forum thread states 2-5 second duration for hold, we'll start the testing at 6 seconds max (modifiable in game for testing purposes).

Also changed are Gaze, which will cast in 4 seconds instead of 5, and Kara'hols, which has a different mechanism for the hold effect when it wears off. Instead of penalising the player for spellpower, the hold effect will last from 2 sec to 8 sec, but inversely related to spellpower (99 sp = 2 sec, below 40sp = 8 sec).

All other changes here are file cleanups, or modifications to make things that use hold (lupogg king, disarm, Riija temple, flash, sporeburst) function correctly. Any other submitters for 1.0.1.4 might want to not edit any of those files if possible.