### PR TITLE
Create Weapon/attribute timer error fixes, replace battle/long bow with practice bow.

### DIFF
--- a/kod/object/passive/spell/creaweap.kod
+++ b/kod/object/passive/spell/creaweap.kod
@@ -16,8 +16,9 @@ constants:
 resources:
 
    createweapon_cast_rsc = "%s%s appears."
-   createweapon_inv_full_rsc = "%s%s appears in the air before you, "
-   "but before you can drop something and grab it, it vanishes."
+   createweapon_inv_full_rsc = \
+      "%s%s appears in the air before you but since you are unable "
+      "to carry it, it falls on the floor with a loud clang."
    createweapon_name_rsc = "create weapon"
    createweapon_icon_rsc = icremace.bgf
    createweapon_desc_rsc = \


### PR DESCRIPTION
If a player creates a weapon but cannot hold it, when the game is saved the weapon is deleted before the IA_MADE attribute timer is renumbered which causes it to point to an invalid object. This fix will cause weapons that cannot be carried to drop onto the floor.

Also, I've removed battle and long bows from create weapon, replaced with practice bow.
