### PR TITLE
Increase initial allocated list nodes to 10 million.

### DIFF
--- a/blakserv/list.h
+++ b/blakserv/list.h
@@ -13,7 +13,7 @@
 #ifndef _LIST_H
 #define _LIST_H
 
-#define INIT_LIST_NODES (500000)
+#define INIT_LIST_NODES (10000000)
 
 typedef struct
 {


### PR DESCRIPTION
In an attempt to stop repeated resizes of the allocated list nodes, the initial value is increased from 500k to 10 mil. This should hopefully prevent the recent crashes from occurring again.
