### PR TITLE
Increase INIT_OBJECTS from 100k to 1mil

### DIFF
--- a/blakserv/object.h
+++ b/blakserv/object.h
@@ -13,7 +13,7 @@
 #ifndef _OBJECT_H
 #define _OBJECT_H
 
-#define INIT_OBJECTS 100000
+#define INIT_OBJECTS 1000000
 
 typedef struct
 {


### PR DESCRIPTION
Same idea as with the listnodes:
Prevent more possible memory resizes by increasing the initial INIT_OBJECTS value in object.h from 100k to 1mil.
