### PR TITLE
Settings updates, permanent spawn rate increase, logoff temp disable timer fix.

### DIFF
--- a/kod/object/active/holder/room/monsroom.kod
+++ b/kod/object/active/holder/room/monsroom.kod
@@ -91,17 +91,17 @@ messages:
    {
       local iWaitTime, iNumberOfPlayers, iMaxPlayers;
       % GetSpawnRate =  100
-	  % iWaitTime = (20000 * (100 / 100));
-	  % iWaitTime = 20000
-	  
-	  % GetSpawnRate =  300
-	  % iWaitTime = (20000 * (300 / 100));
-	  % iWaitTime = 60000
-	  
-	  % GetSpawnRate =  1
-	  % iWaitTime = (20000 * (300 / 100));
-	  % iWaitTime = 200
-      iWaitTime = (piGen_Time * Send(Send(SYS, @GetSettings), @GetSpawnRate)) / 100;
+      % iWaitTime = (20000 * (100 / 100));
+      % iWaitTime = 20000
+
+      % GetSpawnRate =  300
+      % iWaitTime = (20000 * (300 / 100));
+      % iWaitTime = 60000
+     
+      % GetSpawnRate =  1
+      % iWaitTime = (20000 * (300 / 100));
+      % iWaitTime = 200
+      iWaitTime = (piGen_Time * Send(Send(SYS, @GetSettings), @GetSpawnRate)) / 200;
 
       % Reduce spawn time for up to 5 people.
       iNumberOfPlayers = Send(self,@CountHoldingHowMany,#class=&Player);

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -85,7 +85,7 @@ properties:
 
    % Can't cast a teleport spell until this long after attacking someone.  Prevents
    % hit-and-run.  If 0, there's no restriction on when the spell can be cast.
-   piTeleportAttackDelaySec = 10 * 60
+   piTeleportAttackDelaySec = 2 * 60
 
    % Rescue always takes at least this long to cast
    piRescueBaseDelaySec = 15
@@ -122,16 +122,16 @@ properties:
    %
    
    % Worst lagspike
-   piMoveMaxLag = 2000
+   piMoveMaxLag = 1500
    
    % Limit for processing simultaneous move requests (due to TCP)
-   piMoveMaxSimulReq = 8
+   piMoveMaxSimulReq = 6
    
    % The default interval the server expects from the client
    piMoveDefaultInterval = 250
    
    % A tolerance that is given on each move step
-   piMoveStepTolerance = 100
+   piMoveStepTolerance = 70
    
    %
    % Miscellaneous

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -6037,9 +6037,8 @@ messages:
       }
 
       iDisableDuration = (Send(Send(self,@GetSettings),@GetLogoffPenaltyGhostTime)*150)/100;
-      iDisableDuration = iDisableDuration * 1000;   % convert to ms
 
-      ptLogoffPenaltyTempDisable = createTimer(self,@LogoffPenaltyTempDisableTrigger,iDisableDuration);
+      ptLogoffPenaltyTempDisable = CreateTimer(self,@LogoffPenaltyTempDisableTrigger,iDisableDuration);
 
       return;
    }


### PR DESCRIPTION
Updated the default settings values for: rescue/elusion teleport timer (2 minutes, down from 10) and various speedhack detection settings.

Decreased the default amount of time before a monster is spawned in monsroom.kod, so that the 100% setting in settings.kod will give a 50% increased spawn rate.

Fixed a calculation for the temporary suspension of logoff penalties enacted when the population drops (e.g. server crash, update) which was returning a very large number and causing overflow and a negative number to be returned.
