### PR TITLE
Rejuvenate won't reset mana if mana is over max

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -6582,7 +6582,7 @@ messages:
       return iManaLost;
    }
 
-   GainMana(amount=0, bCapped=FALSE)
+   GainMana(amount=0, bCapped=FALSE, bRespectMax=FALSE)
    {
       local iManaGained;
 
@@ -6590,6 +6590,12 @@ messages:
       
       if NOT Send(self,@IsPhasedOut)
       {
+         if bRespectMax
+            AND piMana + amount > piMax_mana
+         {
+            return 0;
+         }
+
          piMana = piMana + amount;
 
          if bCapped AND piMana > piMax_Mana

--- a/kod/object/passive/spell/radiusench/jala/rejuven.kod
+++ b/kod/object/passive/spell/radiusench/jala/rejuven.kod
@@ -95,7 +95,7 @@ messages:
             if Nth(lState,3) = source
                AND Nth(lState,2) = iPower
             {
-               Send(oUser,@GainMana,#amount=1,#bCapped=TRUE);
+               Send(oUser,@GainMana,#amount=1,#bRespectMax=TRUE);
             }
          }
       }


### PR DESCRIPTION
GainMana now has a new bRespectMax parameter that will make no change to mana
if the new mana would be over max mana.
