### PR TITLE
Fix roomedit compile

### DIFF
--- a/roomedit/makefile
+++ b/roomedit/makefile
@@ -79,7 +79,7 @@ LIBS = \
 	owlwf.lib \
 	import32.lib \
 	cw32.lib \
-	$(TOPDIR)\lib\wrap.lib
+	$(TOPDIR)\lib\zdll_omf.lib
 
 windeu32.exe : makedirs $(OBJS) OBJ\windeapp.res
   $(LINK) /v $(IDE_LFLAGS32) @<<


### PR DESCRIPTION
When the game was ported from using crusher compression to zlib it seems one of the required commits got lost. The roomedit makefile must be adjusted to link ZLIB instead of crusher (wrap). Otherwise it will fail...

This is the initial port containing the change to zlib:
https://github.com/Meridian59/Meridian59/pull/195
