### PR TITLE
Corpses as Holders

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/temples/shalprst.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/temples/shalprst.kod
@@ -36,6 +36,9 @@ resources:
                                   "that is said to be able to hinder the spells that come from the darkness.  I am "
                                   "willing to teach it to those that are able to learn it."
    shalillepriestess_teach = "The benevolence of Shal'ille offers "
+   
+   shalillepriestess_summon = "I shall aid you in your time of weakness."
+   shalillepriestess_summoned = "A benevolent light gently sets your corpse at your feet!"
 
 classvars:
 
@@ -234,6 +237,25 @@ messages:
          send(self,@SetMood,#new_mood=piMood - 1 );
       }
       
+      propagate;
+   }
+   
+   SomeoneSaid(what=$,type=$,string=$)
+   {
+      local oCorpse;
+
+      if StringContain(string,"summon")
+         AND what <> $
+         AND IsClass(what,&User)
+         AND Send(what,@GetCorpse) <> $
+      {
+         Send(poOwner,@SomeoneSaid,#what=self,#type=SAY_RESOURCE,
+		        #string=shalillepriestess_summon);
+         oCorpse = Send(what,@GetCorpse);
+         Send(poOwner,@NewHold,#what=oCorpse,#new_row=Send(what,@GetRow),#new_col=Send(what,@GetCol));
+         Send(what,@MsgSendUser,#message_rsc=shalillepriestess_summoned);
+      }
+
       propagate;
    }
 

--- a/kod/object/active/holder/nomoveon/battler/monster/temples/shalprst.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/temples/shalprst.kod
@@ -244,6 +244,11 @@ messages:
    {
       local oCorpse;
 
+      if type = SAY_YELL OR NOT IsClass(what,&User)
+      {
+          propagate;
+      }
+
       if StringContain(string,"summon")
          AND what <> $
          AND IsClass(what,&User)

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1036,6 +1036,9 @@ properties:
 
    % Put new reagents in your bag
    pbReagentBagAuto = TRUE
+   
+   % Track your last corpse
+   poCorpse = $
 
 messages:
 
@@ -13805,6 +13808,17 @@ messages:
    {
       pbReagentBagAuto = value;
       return;
+   }
+   
+   SetCorpse(corpse=$)
+   {
+      poCorpse = corpse;
+      return;
+   }
+   
+   GetCorpse()
+   {
+      return poCorpse;
    }
 
 end

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8584,7 +8584,15 @@ messages:
       }
 
       % Create the corpse.
-      oBody = Send(self,@CreateCorpse);
+      if IsClass(what,&User)
+      {
+         oBody = Send(self,@CreateCorpse,#oPlayerKiller=what);
+      }
+      else
+      {
+         oBody = Send(self,@CreateCorpse);
+      }
+
       Send(oRoom,@NewHold,#what=oBody,#new_row=iRow,#new_col=iCol,#fine_row=16,#fine_col=16, #new_angle=iAngle);
 
       % Start losing stuff if applicable.
@@ -8620,20 +8628,15 @@ messages:
          {
             for i in lItems
             {
-               if Send(oRoom,@ReqNewHold,#what=i,#new_row=iRow,#new_col=iCol) 
-                  AND Send(oRoom,@ReqSomethingMoved,#what=i,#new_row=iRow,#new_col=iCol)
-                  AND Send(i,@DropOnDeath)
+               if oItemAtt <> $    
                {
-                  if oItemAtt <> $    
-                  {
-                     % We know this was a pk.  Only let PKillables pick up the loot.
-                     %  Put the appropriate item attribute on it.
-                     Send(oItemAtt,@AddToItem,#oItem=i,#timer_duration=PKPOINTER_TIME,
+                  % We know this was a pk.  Only let PKillables pick up the loot.
+                  %  Put the appropriate item attribute on it.
+                  Send(oItemAtt,@AddToItem,#oItem=i,#timer_duration=PKPOINTER_TIME,
                           #state1=self);
-                  }
+               }
                   
-                  Send(oRoom,@NewHold,#what=i,#new_row=iRow,#new_col=iCol,#merge=FALSE);
-               } 
+               Send(oBody,@NewHold,#what=i);
             }
          }
 
@@ -8909,7 +8912,7 @@ messages:
       return piDeathCost;
    }
 
-   CreateCorpse(Assassinated=FALSE)
+   CreateCorpse(Assassinated=FALSE, oPlayerKiller=$)
    {
       local inKocatan;
 
@@ -8945,6 +8948,7 @@ messages:
                           #PlayerBodyOverlay=player_dead_male_iconb_rsc,
                           #BodyTranslation=Send(self,@GetBodyTranslation),
                           #LegsTranslation=Send(self,@GetLegsTranslation),
+                          #oPlayerKiller=oPlayerKiller,
                           #inKocatan = inKocatan,#DearlyDeparted=self);
          }
          else
@@ -8958,6 +8962,7 @@ messages:
                           #PlayerBodyOverlay=player_dead_female_iconb_rsc,
                           #BodyTranslation=Send(self,@GetBodyTranslation),
                           #LegsTranslation=Send(self,@GetLegsTranslation),
+                          #oPlayerKiller=oPlayerKiller,
                           #inKocatan = inKocatan,#DearlyDeparted=self);
          }
       }
@@ -8970,6 +8975,7 @@ messages:
                        #good=(piKarma>0),#PlayerBodyOverlay=player_dead_male_iconb_rsc,
                        #BodyTranslation=Send(self,@GetDefaultShirtTranslation),
                        #LegsTranslation=Send(self,@GetDefaultPantsTranslation),
+                       #oPlayerKiller=oPlayerKiller,
                        #inKocatan = inKocatan,#DearlyDeparted=self);
       }
       % female, default colors
@@ -8978,6 +8984,7 @@ messages:
                     #good=(piKarma>0),#PlayerBodyOverlay=player_dead_female_iconb_rsc,
                     #BodyTranslation=Send(self,@GetDefaultShirtTranslation),
                     #LegsTranslation=Send(self,@GetDefaultPantsTranslation),
+                    #oPlayerKiller=oPlayerKiller,
                     #inKocatan = inKocatan,#DearlyDeparted=self);
    }
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -4335,6 +4335,7 @@ messages:
       {
          if IsClass(what,&ReagentBag)
             AND Send(what,@GetReagentBagContents) <> $
+            AND Send(what,@GetOwner) = self
          {
             Send(self,@UserObjectContents,#what=what);
             return;
@@ -4342,6 +4343,8 @@ messages:
 
          if IsClass(what,&DeadBody)
             AND Send(what,@GetCorpseContents) <> $
+            AND Send(self,@SquaredDistanceTo,#what=what) <> $
+            AND Send(self,@SquaredDistanceTo,#what=what) <= 6
          {
             Send(self,@UserObjectContents,#what=what);
             return;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3962,6 +3962,7 @@ messages:
 
       if NOT IsClass(what,&Holder)
          AND NOT IsClass(what,&ReagentBag)
+         AND NOT IsClass(what,&DeadBody)
          OR (IsClass(what,&Player)
              AND NOT (what = self OR IsClass(self,&Admin)))
       {
@@ -3992,8 +3993,16 @@ messages:
          }
          else
          {
-            lHolding1 = Send(what,@GetHolderActive);
-            lHolding2 = Send(what,@GetHolderPassive);
+            if IsClass(what,&DeadBody)
+            {
+               lHolding1 = Send(what,@GetCorpseContents);
+               lHolding2 = $;
+            }
+            else
+            {
+               lHolding1 = Send(what,@GetHolderActive);
+               lHolding2 = Send(what,@GetHolderPassive);
+            }
          }
       }
 
@@ -4330,6 +4339,14 @@ messages:
             Send(self,@UserObjectContents,#what=what);
             return;
          }
+
+         if IsClass(what,&DeadBody)
+            AND Send(what,@GetCorpseContents) <> $
+         {
+            Send(self,@UserObjectContents,#what=what);
+            return;
+         }
+
 
          AddPacket(1,BP_LOOK);
          Send(self,@ToCliObject,#what=what,#show_type=SHOW_LOOK,

--- a/kod/object/passive/body.kod
+++ b/kod/object/passive/body.kod
@@ -241,6 +241,11 @@ messages:
       
       propagate;
    }
+   
+   GetPlayerKiller()
+   {
+      return poPlayerKiller;
+   }
 
    GetDearlyDeparted()
    {

--- a/kod/object/passive/body.kod
+++ b/kod/object/passive/body.kod
@@ -84,7 +84,11 @@ messages:
       poDearlyDeparted = DearlyDeparted;
       piTimeOfDeath = GetTime();
       poPlayerKiller = oPlayerKiller;
-      Send(Send(self,@GetDearlyDeparted),@SetCorpse,#corpse=self);
+      
+      if poDearlyDeparted <> $
+      {
+         Send(poDearlyDeparted,@SetCorpse,#corpse=self);
+      }
 
       if decomposes
       {
@@ -137,7 +141,10 @@ messages:
    {
       local i;
       
-      Send(Send(self,@GetDearlyDeparted),@SetCorpse);
+      if poDearlyDeparted <> $
+      {
+         Send(poDearlyDeparted,@SetCorpse);
+      }
 
       if ptDelete <> $
       {

--- a/kod/object/passive/body.kod
+++ b/kod/object/passive/body.kod
@@ -59,6 +59,9 @@ properties:
    piTimeOfDeath = $
 
    pbResurrected = FALSE
+   
+   plCorpseContents = $
+   poPlayerKiller = $
 
 messages:
 
@@ -66,7 +69,7 @@ messages:
    Constructor(name = $,icon = $,playername = $,good = FALSE, mob=FALSE ,monstername = $,
                inKocatan = FALSE, assassinated = FALSE,drawfx = 0, BodyTranslation = 0,
                LegsTranslation = 0, PlayerBodyOverlay = $, Decomposes=TRUE,
-               DearlyDeparted = $)
+               DearlyDeparted = $, oPlayerKiller = $)
    {
       vrName = name;
       vrIcon = icon;
@@ -80,6 +83,7 @@ messages:
       piLegsTrans = LegsTranslation;      
       poDearlyDeparted = DearlyDeparted;
       piTimeOfDeath = GetTime();
+      poPlayerKiller = oPlayerKiller;
 
       if decomposes
       {
@@ -260,6 +264,137 @@ messages:
    GetResurrected()
    {
       return pbResurrected;
+   }
+   
+   GetCorpseContents()
+   {
+      return plCorpseContents;
+   }
+
+   HolderExtractObject(data = $)
+   {
+      return data;
+   }
+
+   IsHolding(what = $)
+   {
+      local i,each_obj;
+
+      for i in plCorpseContents
+      {
+         if what = i
+         {
+            return TRUE;
+         }
+      }
+
+      return FALSE;
+   }
+
+   GetBulk()
+   {
+      local i, iSum;
+
+      iSum = 0;
+      
+      for i in plCorpseContents
+      {
+         iSum = iSum + Send(i,@GetBulk);
+      }
+
+      return iSum;
+   }
+
+   GetWeight()
+   {
+      local i, iSum;
+
+      iSum = 0;
+
+      for i in plCorpseContents
+      {
+         iSum = iSum + Send(i,@GetWeight);
+      }
+
+      return iSum;
+   }
+
+   ReqTaker(what=$,taker=$)
+   {
+      if taker = poDearlyDeparted
+      {
+         return TRUE;
+      }
+
+      if poPlayerKiller <> $
+         AND taker <> poPlayerKiller
+      {
+         return FALSE;
+      }
+
+      return TRUE;
+   }
+
+   ReqNewHold(what = $, who = $)
+   {
+      return FALSE;
+   }
+
+   NewHold(what = $)
+   {
+      local i;
+
+      if IsClass(what,&NumberItem)
+      {
+         for i in plCorpseContents
+         {
+            if i <> what
+            {
+               if GetClass(what) = GetClass(i)
+               {
+                  % should only be one of these, so can quit loop if found
+                  Send(i,@AddNumber,#number=Send(what,@GetNumber));
+                  Send(what,@Delete);
+                  return;
+               }
+            }
+         }
+      }
+
+      Send(what,@NewOwner,#what=self);
+      plCorpseContents = Cons(what,plCorpseContents);
+      
+      return;
+   }
+   
+   ReqNewOwner(what=$)
+   {
+      propagate;
+   }
+
+   ReqLeaveHold(what = $)
+   {
+      return TRUE;
+   }
+
+   LeaveHold(what = $)
+   {
+      local i;
+      
+      for i in plCorpseContents
+      {
+         if i = what
+         {
+            plCorpseContents = DelListElem(plCorpseContents,i);
+         }
+      }
+
+      return;
+   }
+   
+   ChangeBulkAndWeight()
+   {
+      return;
    }
 
 

--- a/kod/object/passive/body.kod
+++ b/kod/object/passive/body.kod
@@ -84,6 +84,7 @@ messages:
       poDearlyDeparted = DearlyDeparted;
       piTimeOfDeath = GetTime();
       poPlayerKiller = oPlayerKiller;
+      Send(Send(self,@GetDearlyDeparted),@SetCorpse,#corpse=self);
 
       if decomposes
       {
@@ -95,7 +96,7 @@ messages:
          else
          {
             % Make player corpses hang around longer.
-            ptDelete = CreateTimer(self,@DeleteTimerMessage,600000);	    
+            ptDelete = CreateTimer(self,@DeleteTimerMessage,600000*6);	    
             Send(Send(SYS,@Findroombynum,#num=RID_UNDERWORLD),@Newdeath,#what=self,#inKocatan=inKocatan);
          }
       }
@@ -135,6 +136,8 @@ messages:
    Delete()
    {
       local i;
+      
+      Send(Send(self,@GetDearlyDeparted),@SetCorpse);
 
       if ptDelete <> $
       {

--- a/kod/object/passive/body.kod
+++ b/kod/object/passive/body.kod
@@ -134,6 +134,8 @@ messages:
 
    Delete()
    {
+      local i;
+
       if ptDelete <> $
       {
          Send(Send(SYS,@FindRoomByNum,#num=RID_UNDERWORLD),@CorpseDecomposed,#what=self);
@@ -151,6 +153,12 @@ messages:
       {
          send(poOwner,@CorpseFading,#corpse=self);
       }
+      
+      for i in plCorpseContents
+      {
+         Send(i,@Delete);
+      }
+      plCorpseContents = $;
       
       propagate;
    }


### PR DESCRIPTION
Player corpses now no longer drop their loot on the ground. Instead, loot is held within the body. Viewing the corpse from beyond range 6 shows you the name of the victim and the corpse description. Viewing the corpse from within range 6 shows you their loot instead.
* This is a permanent fix to 'loot piles' crashing players and rooms, most notably from event chars.

The victim and the player killer may full loot any item.
If the death was to a mob, any player may loot.
* This is a permanent fix to loot grabbers during PvP, especially in towns.

Saying "summon" to the Shal Priestess will summon your corpse to your feet in cases where corpses cannot be otherwise retrieved.
* This is a permanent fix for loot getting lost in walls.

* Player corpses now last 1 hour rather than 10 minutes for convenience.