### PR TITLE
Log spells cast by DMs/admins to godlog, show DMs spellpower for spells cast (for testing).

### DIFF
--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1401,6 +1401,23 @@ messages:
    {
       local oTarget, oRoom;
 
+      if IsClass(who,&DM)
+      {
+         ClearTempString();
+         AppendTempString("DM ");
+         AppendTempString(Send(who,@GetTrueName));
+         AppendTempString(" cast the spell ");
+         AppendTempString(Send(self,@GetName));
+         
+         if lTargets <> $
+         {
+            AppendTempString(" on target ");
+            AppendTempString(Send(First(lTargets),@GetTrueName));
+         }
+
+         GodLog();
+      }
+
       if NOT bItemCast
       {         
          piAverage_spellpower = ((piAverage_spellpower * piCast_successes)
@@ -1440,7 +1457,8 @@ messages:
                   Send(oTarget,@BadSpellFlashEffect);
                }
                
-               if Send(Send(SYS,@GetSettings),@DisplaySpellData)
+               if (Send(Send(SYS,@GetSettings),@DisplaySpellData)
+                     OR IsClass(oTarget,&DM))
                   AND oTarget <> who
                {
                   Send(oTarget,@MsgSendUser,#message_rsc=spell_display_spellpower,
@@ -1451,6 +1469,7 @@ messages:
       }
 
       if Send(Send(SYS,@GetSettings),@DisplaySpellData)
+         OR IsClass(who,&DM)
       {
          Send(who,@MsgSendUser,#message_rsc=spell_display_spellpower,
                #parm1=Send(self,@GetName),#parm2=iSpellPower);


### PR DESCRIPTION
The publicly available godlog will now log any spell cast by a DM or admin character (including DM spells). In addition, spellpower for any spell cast will be shown to DMs for testing purposes. For instance, if a player is unsure that a spell is having the intended effect, or a spellpower item is giving the correct spellpower, this can be tested much faster and with the spell/item in question on 103.
