### PR TITLE
Arena Catch for REs

### DIFF
--- a/kod/object/active/holder/nomoveon.kod
+++ b/kod/object/active/holder/nomoveon.kod
@@ -147,6 +147,7 @@ messages:
          if Nth(i,1) = what
             AND Nth(i,2) = iPower
             AND Nth(i,3) = source
+            AND NOT Send(Nth(i,1),@IsActiveRoomRadiusEnchantment,#oRoom=Send(who,@GetOwner),#iPower=iPower,#source=source)
          {
             If IsClass(self,&User)
             {

--- a/kod/object/active/holder/nomoveon.kod
+++ b/kod/object/active/holder/nomoveon.kod
@@ -147,7 +147,7 @@ messages:
          if Nth(i,1) = what
             AND Nth(i,2) = iPower
             AND Nth(i,3) = source
-            AND NOT Send(Nth(i,1),@IsActiveRoomRadiusEnchantment,#oRoom=Send(who,@GetOwner),#iPower=iPower,#source=source)
+            AND NOT Send(Nth(i,1),@IsActiveRoomRadiusEnchantment,#oRoom=Send(self,@GetOwner),#iPower=iPower,#source=source)
          {
             If IsClass(self,&User)
             {

--- a/kod/object/active/holder/nomoveon.kod
+++ b/kod/object/active/holder/nomoveon.kod
@@ -147,7 +147,6 @@ messages:
          if Nth(i,1) = what
             AND Nth(i,2) = iPower
             AND Nth(i,3) = source
-            AND NOT Send(Nth(i,1),@IsActiveRoomRadiusEnchantment,#oRoom=Send(self,@GetOwner),#iPower=iPower,#source=source)
          {
             If IsClass(self,&User)
             {

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3244,7 +3244,7 @@ messages:
    "Used for Arenas to see if something is a valid target.  Non-arenas just "
    "return FALSE."
    {
-      return FALSE;
+      return TRUE;
    }
 
    GetWatcher()

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -267,7 +267,7 @@ messages:
    RecalculateActiveEnchantments()
    {
       local i, source, iDrain, iPeriodic, lEnchanted, iPower, iRange, iDuration,
-      iDistance, oObject, oRoom, oActive, oPassive, oCrystalizeMana, iCrystalizeManaAbility;
+      iDistance, oObject, oRoom, oActive, oPassive, oCrystalizeMana, iCrystalizeManaAbility, lPeriodicTargets, oPeriodicTarget;
 
       if ptRecalculationTimer <> $
       {
@@ -357,10 +357,38 @@ messages:
          }
 
          % Perform periodic effects
+         % This is especially complicated because we want players to see active spells in the arena while watching
+         % But the spells should not do periodic effects on them (damage, healing, etc).
+         % Non-periodic effects don't generally matter because watchers cannot cast, fight, or use items
          if viPeriodicEffect
             AND iPeriodic > Send(self,@CalculatePeriodicEffectTime,#iPower=iPower)
          {
-            Send(self,@PeriodicEffect,#lEnchanted=lEnchanted,#iPower=iPower,#iRange=iRange,#source=source);
+            if Send(source,@GetOwner) <> $
+               AND IsClass(Send(source,@GetOwner),&Room)
+               AND Send(Send(source,@GetOwner),@IsArena)
+            {
+               if IsClass(source,&User)
+                  AND Send(Send(source,@GetOwner),@IsValidTarget,#who=source)
+               {
+                  lPeriodicTargets = $;
+                  for oPeriodicTarget in lEnchanted
+                  {
+                     if Send(oPeriodicTarget,@GetOwner) <> $
+                        AND IsClass(Send(oPeriodicTarget,@GetOwner),&Room)
+                        AND Send(Send(oPeriodicTarget,@GetOwner),@IsArena)
+                        AND Send(Send(oPeriodicTarget,@GetOwner),@IsValidTarget,#who=oPeriodicTarget)
+                     {
+                        lPeriodicTargets = Cons(oPeriodicTarget,lPeriodicTargets);
+                     }
+                  }
+                  Send(self,@PeriodicEffect,#lEnchanted=lPeriodicTargets,#iPower=iPower,#iRange=iRange,#source=source);
+               }
+            }
+            else
+            {
+               Send(self,@PeriodicEffect,#lEnchanted=lEnchanted,#iPower=iPower,#iRange=iRange,#source=source);
+            }
+
             iPeriodic = iPeriodic - Send(self,@CalculatePeriodicEffectTime,#iPower=iPower);
          }
 
@@ -442,18 +470,18 @@ messages:
          return FALSE;
       }
       
-      if Send(target,@GetOwner) <> $
-         AND Send(Send(target,@GetOwner),@IsArena)
-         AND NOT Send(Send(target,@GetOwner),@IsValidTarget,#who=target)
-      {
-         return FALSE;
-      }
-
-      if Send(source,@GetOwner) <> $
+      if target <> source
+         AND Send(source,@GetOwner) <> $
          AND Send(Send(source,@GetOwner),@IsArena)
          AND NOT Send(Send(source,@GetOwner),@IsValidTarget,#who=source)
       {
          return FALSE;
+      }
+      
+      if Send(target,@GetOwner) <> $
+         AND Send(Send(target,@GetOwner),@IsArena)
+      {
+         return TRUE;
       }
 
       If IsClass(target,&Player)

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -149,9 +149,9 @@ messages:
          for i in plCurrentEnchantments
          {
             if Nth(i,8) = oRoom
+               AND Send(who,@IsAffectedByRadiusEnchantment,#what=self)
             {
                if IsClass(who,&User)
-                  AND Send(who,@IsAffectedByRadiusEnchantment,#what=self)
                {
                   Send(who,@MsgSendUser,#message_rsc=radius_ench_old_style_aleady_cast);
                }

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -442,6 +442,20 @@ messages:
          return FALSE;
       }
       
+      if Send(target,@GetOwner) <> $
+         AND Send(Send(target,@GetOwner),@IsArena)
+         AND NOT Send(Send(target,@GetOwner),@IsValidTarget,#who=target)
+      {
+         return FALSE;
+      }
+
+      if Send(source,@GetOwner) <> $
+         AND Send(Send(source,@GetOwner),@IsArena)
+         AND NOT Send(Send(source,@GetOwner),@IsValidTarget,#who=source)
+      {
+         return FALSE;
+      }
+
       If IsClass(target,&Player)
          AND Send(target,@IsPhasedOut)
       {

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -267,7 +267,7 @@ messages:
    RecalculateActiveEnchantments()
    {
       local i, source, iDrain, iPeriodic, lEnchanted, iPower, iRange, iDuration,
-      iDistance, oObject, oRoom, oActive, oPassive, oCrystalizeMana, iCrystalizeManaAbility, lPeriodicTargets, oPeriodicTarget;
+      iDistance, oObject, oRoom, oActive, oPassive, oCrystalizeMana, iCrystalizeManaAbility, oPeriodicTarget;
 
       if ptRecalculationTimer <> $
       {
@@ -363,30 +363,14 @@ messages:
          if viPeriodicEffect
             AND iPeriodic > Send(self,@CalculatePeriodicEffectTime,#iPower=iPower)
          {
-            if Send(source,@GetOwner) <> $
-               AND IsClass(Send(source,@GetOwner),&Room)
-               AND Send(Send(source,@GetOwner),@IsArena)
+            for oPeriodicTarget in lEnchanted
             {
-               if IsClass(source,&User)
-                  AND Send(Send(source,@GetOwner),@IsValidTarget,#who=source)
+               if Send(oPeriodicTarget,@GetOwner) <> $
+                  AND IsClass(Send(oPeriodicTarget,@GetOwner),&Room)
+                  AND Send(Send(oPeriodicTarget,@GetOwner),@IsValidTarget,#who=oPeriodicTarget)
                {
-                  lPeriodicTargets = $;
-                  for oPeriodicTarget in lEnchanted
-                  {
-                     if Send(oPeriodicTarget,@GetOwner) <> $
-                        AND IsClass(Send(oPeriodicTarget,@GetOwner),&Room)
-                        AND Send(Send(oPeriodicTarget,@GetOwner),@IsArena)
-                        AND Send(Send(oPeriodicTarget,@GetOwner),@IsValidTarget,#who=oPeriodicTarget)
-                     {
-                        lPeriodicTargets = Cons(oPeriodicTarget,lPeriodicTargets);
-                     }
-                  }
-                  Send(self,@PeriodicEffect,#lEnchanted=lPeriodicTargets,#iPower=iPower,#iRange=iRange,#source=source);
+                  Send(self,@PeriodicEffect,#oBattler=oPeriodicTarget,#iPower=iPower,#iRange=iRange,#source=source);
                }
-            }
-            else
-            {
-               Send(self,@PeriodicEffect,#lEnchanted=lEnchanted,#iPower=iPower,#iRange=iRange,#source=source);
             }
 
             iPeriodic = iPeriodic - Send(self,@CalculatePeriodicEffectTime,#iPower=iPower);
@@ -469,15 +453,7 @@ messages:
       {
          return FALSE;
       }
-      
-      if target <> source
-         AND Send(source,@GetOwner) <> $
-         AND Send(Send(source,@GetOwner),@IsArena)
-         AND NOT Send(Send(source,@GetOwner),@IsValidTarget,#who=source)
-      {
-         return FALSE;
-      }
-      
+
       if Send(target,@GetOwner) <> $
          AND Send(Send(target,@GetOwner),@IsArena)
       {
@@ -619,7 +595,7 @@ messages:
       return;
    }
    
-   PeriodicEffect(lEnchanted=$,iPower=0,iRange=0,source=$)
+   PeriodicEffect(oBattler=$,iPower=0,iRange=0,source=$)
    {
       return;
    }

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -151,6 +151,7 @@ messages:
             if Nth(i,8) = oRoom
             {
                if IsClass(who,&User)
+                  AND Send(who,@IsAffectedByRadiusEnchantment,#what=self)
                {
                   Send(who,@MsgSendUser,#message_rsc=radius_ench_old_style_aleady_cast);
                }

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -630,7 +630,7 @@ messages:
 
       oRoom = Send(who,@GetOwner);
 
-      % Only cancel Persist spells if they are offensive & caster is entering a non-combat room
+      % Cancel Persist spells if they are offensive & caster is entering a non-combat room
       if viCasterPersist
          AND (event = EVENT_NEWOWNER
              OR event = EVENT_REQNEWOWNER)
@@ -638,6 +638,17 @@ messages:
          if oRoom <> $
             AND NOT (viAffectsEnemies
                      AND Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT))
+         {
+            return FALSE;
+         }
+      }
+
+      % Cancel Persist spells if the caster is entering the arena
+      if viCasterPersist
+         AND event = EVENT_NEWOWNER
+      {
+         if oRoom <> $
+            AND Send(oRoom,@IsArena)
          {
             return FALSE;
          }
@@ -716,6 +727,33 @@ messages:
       }
 
       return;
+   }
+   
+   IsActiveRoomRadiusEnchantment(oRoom=$,iPower=0,source=$)
+   "Differentiates between enchants in the case of a user changing between rooms that both have old style REs with the same caster and spellpower."
+   {
+      local i, oActiveSource, oActivePower, oActiveRoom;
+
+      if oRoom <> $
+         AND IsClass(oRoom,&Room)
+         AND piOldAreaEnchStyle
+      {
+         for i in plCurrentEnchantments
+         {
+            oActiveSource = Nth(i,1);
+            oActivePower = Nth(i,5);
+            oActiveRoom = Nth(i,8);
+            
+            if oActiveRoom = oRoom
+               AND oActivePower = iPower
+               AND oActiveSource = source
+            {
+               return TRUE;
+            }
+         }
+      }
+
+      return FALSE;
    }
    
    RemoveEnchantmentEffects()

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -357,6 +357,12 @@ messages:
             }
          }
 
+         % Refresh information for targets
+         for oObject in lEnchanted
+         {
+            Send(oObject,@AddRadiusEnchantment,#what=self,#iPower=iPower,#source=source);
+         }
+
          % Perform periodic effects
          % This is especially complicated because we want players to see active spells in the arena while watching
          % But the spells should not do periodic effects on them (damage, healing, etc).
@@ -729,34 +735,7 @@ messages:
 
       return;
    }
-   
-   IsActiveRoomRadiusEnchantment(oRoom=$,iPower=0,source=$)
-   "Differentiates between enchants in the case of a user changing between rooms that both have old style REs with the same caster and spellpower."
-   {
-      local i, oActiveSource, oActivePower, oActiveRoom;
 
-      if oRoom <> $
-         AND IsClass(oRoom,&Room)
-         AND piOldAreaEnchStyle
-      {
-         for i in plCurrentEnchantments
-         {
-            oActiveSource = Nth(i,1);
-            oActivePower = Nth(i,5);
-            oActiveRoom = Nth(i,8);
-            
-            if oActiveRoom = oRoom
-               AND oActivePower = iPower
-               AND oActiveSource = source
-            {
-               return TRUE;
-            }
-         }
-      }
-
-      return FALSE;
-   }
-   
    RemoveEnchantmentEffects()
    "Need to override spell.kod's thing, since we do this ourselves specially."
    {

--- a/kod/object/passive/spell/radiusench/jala/invigor.kod
+++ b/kod/object/passive/spell/radiusench/jala/invigor.kod
@@ -83,21 +83,18 @@ messages:
       return 100000 / (iPower+1);
    }
 
-   PeriodicEffect(lEnchanted=$,iPower=0,iRange=0,source=$)
+   PeriodicEffect(oBattler=$,iPower=0,iRange=0,source=$)
    {
-      local oUser, lState;
+      local lState;
       
-      for oUser in lEnchanted
+      if IsClass(oBattler,&User)
       {
-         if IsClass(oUser,&User)
+         lState = Send(oBattler,@GetMostPowerfulRadiusEnchantmentState,#byClass=&Invigorate);
+
+         if Nth(lState,3) = source
+            AND Nth(lState,2) = iPower
          {
-            lState = Send(oUser,@GetMostPowerfulRadiusEnchantmentState,#byClass=&Invigorate);
-            
-            if Nth(lState,3) = source
-               AND Nth(lState,2) = iPower
-            {
-               Send(oUser,@RestAddExertion,#amount=-1000);
-            }
+            Send(oBattler,@RestAddExertion,#amount=-1000);
          }
       }
       

--- a/kod/object/passive/spell/radiusench/jala/rejuven.kod
+++ b/kod/object/passive/spell/radiusench/jala/rejuven.kod
@@ -82,21 +82,18 @@ messages:
       return 100000 / (iPower+1);
    }
 
-   PeriodicEffect(lEnchanted=$,iPower=0,iRange=0,source=$)
+   PeriodicEffect(oBattler=$,iPower=0,iRange=0,source=$)
    {
-      local oUser, lState;
+      local lState;
 
-      for oUser in lEnchanted
+      if IsClass(oBattler,&User)
       {
-         if IsClass(oUser,&User)
-         {
-            lState = Send(oUser,@GetMostPowerfulRadiusEnchantmentState,#byClass=&Rejuvenate);
+         lState = Send(oBattler,@GetMostPowerfulRadiusEnchantmentState,#byClass=&Rejuvenate);
             
-            if Nth(lState,3) = source
-               AND Nth(lState,2) = iPower
-            {
-               Send(oUser,@GainMana,#amount=1,#bRespectMax=TRUE);
-            }
+         if Nth(lState,3) = source
+            AND Nth(lState,2) = iPower
+         {
+            Send(oBattler,@GainMana,#amount=1,#bRespectMax=TRUE);
          }
       }
       

--- a/kod/object/passive/spell/radiusench/jala/restorat.kod
+++ b/kod/object/passive/spell/radiusench/jala/restorat.kod
@@ -83,21 +83,18 @@ messages:
       return 100000 / (iPower+1);
    }
 
-   PeriodicEffect(lEnchanted=$,iPower=0,iRange=0,source=$)
+   PeriodicEffect(oBattler=$,iPower=0,iRange=0,source=$)
    {
-      local oUser, lState;
+      local lState;
       
-      for oUser in lEnchanted
+      if IsClass(oBattler,&User)
       {
-         if IsClass(oUser,&User)
+         lState = Send(oBattler,@GetMostPowerfulRadiusEnchantmentState,#byClass=&Restorate);
+
+         if Nth(lState,3) = source
+            AND Nth(lState,2) = iPower
          {
-            lState = Send(oUser,@GetMostPowerfulRadiusEnchantmentState,#byClass=&Restorate);
-            
-            if Nth(lState,3) = source
-               AND Nth(lState,2) = iPower
-            {
-               Send(oUser,@GainHealthNormal,#amount=1);
-            }
+            Send(oBattler,@GainHealthNormal,#amount=1);
          }
       }
       

--- a/kod/object/passive/spell/radiusench/sandstor.kod
+++ b/kod/object/passive/spell/radiusench/sandstor.kod
@@ -145,7 +145,7 @@ messages:
       if IsClass(Send(oBattler,@GetOwner),&GuildHall)
          AND NOT Send(Send(oBattler,@GetOwner),@InFoyer,#who=oBattler)
       {
-         continue;
+         return;
       }
 
       if IsClass(oBattler,&User)

--- a/kod/object/passive/spell/radiusench/sandstor.kod
+++ b/kod/object/passive/spell/radiusench/sandstor.kod
@@ -131,9 +131,9 @@ messages:
       return 3000;
    }
    
-   PeriodicEffect(lEnchanted=$,iPower=0,iRange=0,source=$)
+   PeriodicEffect(oBattler=$,iPower=0,iRange=0,source=$)
    {
-      local oBattler, bExhaustedMultiple;
+      local bExhaustedMultiple;
       
       % Sandstorm applies 1-4 slashing damage from the source of the spell.
       % It also drains 1-4 vigor. Both values are based on spellpower, and are not random.
@@ -142,38 +142,33 @@ messages:
 
       bExhaustedMultiple = 1;
       
-      for oBattler in lEnchanted
+      if IsClass(Send(oBattler,@GetOwner),&GuildHall)
+         AND NOT Send(Send(oBattler,@GetOwner),@InFoyer,#who=oBattler)
       {
-         if IsClass(Send(oBattler,@GetOwner),&GuildHall)
-            AND NOT Send(Send(oBattler,@GetOwner),@InFoyer,#who=oBattler)
-         {
-            continue;
-         }
-         
-         if IsClass(oBattler,&User)
-         {
-            if Send(oBattler,@GetVigor) > 9
-            {
-               Send(oBattler,@AddExertion,#amount=((iPower+1)/25)*10000);
-            }
-            else
-            {
-               bExhaustedMultiple = 3;
-            }
-
-            if Send(oBattler,@AssessDamage,#what=source,#report=FALSE,#damage=(((iPower+1)/25)*bExhaustedMultiple),#atype=ATCK_WEAP_SLASH) = $
-            {
-               If IsClass(source,&Battler)
-               {
-                  Send(source,@KilledSomething,#what=oBattler);
-               }
-               Send(oBattler,@Killed,#what=source);
-            }
-         }
-         
-         bExhaustedMultiple = 1;
+         continue;
       }
-      
+
+      if IsClass(oBattler,&User)
+      {
+         if Send(oBattler,@GetVigor) > 9
+         {
+            Send(oBattler,@AddExertion,#amount=((iPower+1)/25)*10000);
+         }
+         else
+         {
+            bExhaustedMultiple = 3;
+         }
+
+         if Send(oBattler,@AssessDamage,#what=source,#report=FALSE,#damage=(((iPower+1)/25)*bExhaustedMultiple),#atype=ATCK_WEAP_SLASH) = $
+         {
+            If IsClass(source,&Battler)
+            {
+               Send(source,@KilledSomething,#what=oBattler);
+            }
+  %          Send(oBattler,@Killed,#what=source);
+         }
+      }
+
       return;
    }
 


### PR DESCRIPTION
All users in the arena will see icons for valid REs, but will not be affected by
periodic effects. For example, you will see sandstorm, but you will
not be hit by it. Same with Rejuvenate type spells.

Constant effects still apply, but they're irrelevant, as watchers
can't cast, fight, or use items in the arena.

Entering the arena will cancel any Persist songs (of which we currently
have none - Persist songs stay with the caster even if he changes rooms).

This implementation allows for better understanding of the fight,
and for admins to discord lingering spells after combat. It would be extremely
confusing to watch arena fights without seeing AMA, winds, etc.

In addition, I've fixed a rare bug where switching between two rooms
that both have old-style REs of the exact same power and caster would
cause icon issues.

Also, safety code for old-style REs has been updated. You can now cast
an old-style RE if you are not affected by that type of spell already, even
if one is in the room. For example, currently if I cast AMA from a mule, it
won't affect others, but you still can't cast AMA yourself. Now, you can.
Under rare conditions, this will stick more than one old-style RE on the
same person due to overlapping complex safety situations, but old-style
REs have already been coded to only take the most powerful version into
consideration.

For example, if you are red, two whites who are NOT guildmates can both
cast Anti-Magic Aura and you will see two Anti-Magic Aura icons. Rest
assured that only the strongest is affecting you, and a single Discordance
can potentially remove both of them.

This eliminates a potentially super annoying form of muling.