### PR TITLE
Death Link won't drop mana over max

### DIFF
--- a/kod/object/passive/spell/persench/dethlink.kod
+++ b/kod/object/passive/spell/persench/dethlink.kod
@@ -110,14 +110,8 @@ messages:
       }
 
       Send(caster,@GainHealthNormal,#Amount=iAmountHpInc);
-      Send(caster,@GainMana,#Amount=iAmountManaInc);
-      
-      % Don't let caster go over max mana
-      if Send(caster,@GetMana) > Send(caster,@GetMaxMana)
-      {
-         Send(caster,@LoseMana,#amount=(Send(caster,@GetMana)-Send(caster,@GetMaxMana)));
-      }
-      
+      Send(caster,@GainMana,#Amount=iAmountManaInc,#bRespectMax=TRUE);
+
       Send(caster,@MsgSendUser,#message_rsc=deathlink_feed_rsc);
 
       return;


### PR DESCRIPTION
Uses bRespectMax added previously to fix mana gains over max
