### PR TITLE
Keep target through map toggle.

### DIFF
--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -100,8 +100,6 @@ void GraphicsAreaDestroy(void)
 void GraphicsToggleMap(void)
 {
    map = !map;
-   if (map)
-      SetUserTargetID(INVALID_ID);
 
    RedrawAll();
 }


### PR DESCRIPTION
Currently if you toggle map mode you lose your selected target, even if that target is yourself. I can't find a good reason to keep it this way; some players may choose to fight a target in map mode with this change in but I don't see a problem with that.
