### PR TITLE
Nerudite Armor Rebalance idea 2

### DIFF
--- a/kod/object/item/passitem/defmod/armor/neruarmr.kod
+++ b/kod/object/item/passitem/defmod/armor/neruarmr.kod
@@ -60,11 +60,8 @@ messages:
 
    GetResistanceModifiers()
    {
-      return [ [-ATCK_SPELL_FIRE,20],
-               [-ATCK_SPELL_SHOCK,20],
-               [-ATCK_SPELL_COLD,20],
-               [-ATCK_SPELL_ACID,20],
-               [-ATCK_SPELL_QUAKE,-20]
+      return [ [-ATCK_SPELL_ALL,10],
+               [-ATCK_SPELL_QUAKE,-30]
              ];
    }
 


### PR DESCRIPTION
There's been much discussion of Nerudite Armor lately. This system is of
course complex, involving nerudite armor, resist rings, and buffs.
Here is one idea for changing how the armor works that may be elegant.
- Changed nerudite resistances from individual to ATCK_SPELL_ALL. This
  means it will no longer stack with rings, and it will also help against
  holy and unholy. The only thing this new nerudite armor will stack with
  is Resist Magic. The new value for this "all spell" resistance is 10%.
  The armor is still vulnerable to quake damage by a sum of -20%.

No changes were made to any other spell or item, but the effects here
are wide-reaching.

Together, Nerudite Armor and Resist Magic will add up to 35% "all spell"
resistance. This will cut damage of spell attacks by roughly a third.
The majority of this resistance (25%) is from Resist Magic, which can be
purged, weapon proc purged, or timed out (max duration 4 minutes).
Compare to elemental resists which last up to 8 minutes.

Elemental resists + rings will add up to 45% resist to their respective
element, still remaining superior to Nerudite + Resist Magic's 35%.

This should take much of the emphasis off of nerudite armor and resist
ring switching during combat. Without Nerudite Armor's individual
resists, Resist Magic trumps rings now (25% > 20%), so wearing rings is
pointless if you have Resist Magic. Rings will likely be relegated to
builder protection or stacking with elemental resists for Faren mages.
Rings can still, however, help make up for elemental weaknesses.
You can wear a robe and a resist fire ring to make up for the robe's
weakness, even if Resist Magic would otherwise trump a ring's effect.
Instead of -20% fire, you will have -0% fire weakness. You will have
-0% + 25% (25% total) instead of -20% + 25% (5% total).

Robe's +15% shock resistance will also stack to 35% with a shock ring,
trumping Resist Magic's 25%, but not Neru + Resist Magic's 35%.

One final thing I like about this is that Nerudite Armor will now offer
some protection against holy and unholy damage. Currently, there exists
no reliable way to protect against holy damage, since Unholy Resolve
and Resist Magic can simply be purged by a Shal opponent wielding
holy enchanted weapons. Nerudite's 10% "all spell" resist will now help
in that situation.

Nerudite Armor, even with this change, may still be the best armor
for many situations due to having 5 damage reduction and spell resists
rather than weaknesses (like plate's weakness to fire and shock).
Other armors should probably be upgraded.
