### PR TITLE
Plate Armor Upgrade

### DIFF
--- a/kod/object/item/passitem/defmod/armor/plate.kod
+++ b/kod/object/item/passitem/defmod/armor/plate.kod
@@ -59,7 +59,11 @@ messages:
    GetResistanceModifiers()
    {
       return [ [-ATCK_SPELL_FIRE,-10],
-               [-ATCK_SPELL_SHOCK,-15]
+               [-ATCK_SPELL_SHOCK,-15],
+               [ATCK_WEAP_SLASH,10],
+               [ATCK_WEAP_THRUST,10],
+               [ATCK_WEAP_BLUDGEON,10],
+               [ATCK_WEAP_PIERCE,10]
              ];
    }
 


### PR DESCRIPTION
Plate Armor has fallen behind other armors in many ways. It's only got 1
point of direct damage reduction over nerudite, and none of the other
spell-resistance benefits. If plate armor is going to be a boss at what
it does, it needs to be stronger.

Therefore, I propose this change:
- Added 10% slash, thrust, bludgeon, and pierce resistance to plate
  armor.

I chose individual resistances rather than ATCK_WEAP_ALL so that the
values can stack with shields such as Gold Shields (10% slash, 10%
bludgeon, 10% thrust), Knight's Shield (10% pierce), Small Round Shield
(10% slash), and Herald Shields (10% pierce). Shields should probably also
be upgraded for variety at some point.

These new resistances will help plate armor's damage reduction scale
with our new higher damages, without dramatically affecting low damage
values (usually due to gort + lots of direct armor). So these new
resists will, for example, take 3 damage off of a 30 damage scimitar
hit, but only reduce a 10 damage Hammer hit by 1.

This will also improve plate armor's performance against partially magical
attacks. A holy or unholy weapon can cut through direct armor, but not
resistances. That means the 10% reduction will always work, which isn't
the case with 6 direct damage reduction, which can hit as low as 1 point with
a bad roll against a holy or unholy weapon. (33% effectiveness roll on 6
bringing it to 2, then reduced another third by the partially magic attack).

Hopefully, this will help plate armor become a powerful option again,
especially if combined with nerudite armor rebalancing.
