### PR TITLE
Login delay added to phase, default time 2.5 sec for phase and normal login.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -407,7 +407,6 @@ properties:
    pbAutoCombine = TRUE
    pbAutoloot = TRUE
 
-   piLogonDelay = 1500
    ptLogonDelayTimer = $
 
 messages:
@@ -643,7 +642,7 @@ messages:
 
    UserLogon(session_id = $)
    {
-      local i, oSpell;
+      local i;
       
       poSession = session_id;
       pbLogged_on = TRUE;
@@ -705,15 +704,30 @@ messages:
       Send(self,@ToCliSpellSchools);
       Send(self,@UserLogonHook);
 
+      % Give user the logon delay
+      Send(self,@LogonDelay);
+
+      return;
+   }
+
+   LogonDelay()
+   {
+      local iLogonDelay, oSpell;
+
       oSpell = Send(SYS,@FindSpellByNum,#num=SID_HOLD);
+
       if NOT Send(self,@IsEnchanted,#what=oSpell)
          AND NOT Send(poOwner,@CheckDefaultRoomFlag,#flag=ROOM_SAFELOGOFF)
          AND NOT (IsClass(self,&DM) AND Send(self,@PlayerIsImmortal))
-         AND ptLogonDelayTimer = $
       {
+         if ptLogonDelayTimer <> $
+         {
+            DeleteTimer(ptLogonDelayTimer);
+         }
          Send(self,@EffectSendUser,#what=self,#effect=EFFECT_PARALYZE_ON);
          Send(self,@SysMsgSendUser,#message_rsc=user_logon_delay);
-         ptLogonDelayTimer = CreateTimer(self,@LogonHoldOff,piLogonDelay);
+         iLogonDelay = Send(Send(SYS,@GetSettings),@GetLogonDelay);
+         ptLogonDelayTimer = CreateTimer(self,@LogonHoldOff,iLogonDelay);
       }
 
       return;

--- a/kod/object/passive/spell/utility/phase.kod
+++ b/kod/object/passive/spell/utility/phase.kod
@@ -169,13 +169,13 @@ messages:
       return;
    }
 
-   CastSpell(who = $, lTargets = $)
+   CastSpell(who=$,lTargets=$)
    {
-   
       if Send(who,@IsPhasedOut)
       {
          Send(self,@NotifyRoomPhaseIn,#who=who);
          Send(who,@RemoveEnchantment,#what=self);
+         Send(who,@LogonDelay);
       }
       else
       {

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -179,7 +179,10 @@ properties:
 
    % If enabled, logoff penalties do not rise exponentially, and instead remain flat
    pbFlatPenalties = TRUE
-   
+
+   % Length of hold effect players experience when logging or phasing in
+   piLogonDelay = 2500
+
    % Revenant speed setting
    piRevSpeed = 18
 
@@ -446,17 +449,22 @@ messages:
    {
       return piWeaponcraftImprovementMinimumSwings;
    }
-   
+
    GetFlatPenaltiesEnable()
    {
       return pbFlatPenalties;
    }
-   
+
+   GetLogonDelay()
+   {
+      return piLogonDelay;
+   }
+
    GetOutlawMurdererLogoffPenaltyGhostTime()
    {
       return piOutlawMurdererLogoffPenaltyGhostTime;
    }
-   
+
    GetResistRingLoseDurability()
    {
       return piResistRingLoseDurability;


### PR DESCRIPTION
Upped the time that a user is paralyzed on login to 2.5 sec; this can be changed via system setting now.

Phasing in will also trigger this. Users can still phase back out after 1.5 sec but can't avoid the hold effect using any combination of phase/login.
