### PR TITLE
Delete unnecessary monster template in QuestNode.

### DIFF
--- a/kod/object/passive/questnode.kod
+++ b/kod/object/passive/questnode.kod
@@ -1706,6 +1706,10 @@ messages:
       plIndefDescs = $;
       plDefDescs = $;
       pCargo = $;
+      if poMonster <> $
+      {
+         Send(poMonster,@Delete);
+      }
       poMonster = $;
       poQuestActivated = $;
       piStatus = QN_STATUS_UNINITIALIZED;


### PR DESCRIPTION
Quest nodes weren't deleting the 'template' monsters they were creating for reference during the quests. This was causing some errors on the server after the quest was finished when those unreferenced monsters were cleaned up during GC.

This will delete the monster when the quest node no longer needs them.
