### PR TITLE
Room item dispose fix/improvements.

### DIFF
--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -1578,18 +1578,32 @@ messages:
 
             iLengthDispose = Length(lDisposeItems);
 
-            % If we have more than 5 items on the ground, dispose 20%
-            if iLengthDispose > 5
+            % If we have more than 11 items on the ground, dispose 25%
+            if iLengthDispose > 11
             {
-               delete_index = 4*iLengthDispose/5;
+               delete_index = iLengthDispose/4;
+
+               % In rare cases we can end up with items piling up far too
+               % fast, so we should do a one-off dispose of a larger number
+               % to prevent the screen from crashing
+               if iLengthDispose > 75
+               {
+                  delete_index = iLengthDispose/2;
+               }
+
                count = 0;
 
                for j in lDisposeItems
                {
                   count = count + 1;
-                  if count > delete_index
+                  if count <= delete_index
                   {
                      Send(j,@DestroyDisposable);
+                  }
+                  else
+                  {
+                     % Deleted all the appropriate items
+                     break;
                   }
                }
             }


### PR DESCRIPTION
The last fix to the room item disposal caused newer items to be disposed first since the list was copied and the older/newer items were back to front from the plPassive list.

This fix swaps that around, and it now deletes the first items in the new list (the oldest items).

Item disposal will now also only happen if there is 12 or more items on the ground, and 25% are disposed instead of 20%. In addition if there is more than 75 items on the ground, the room will dispose of the oldest half at once to prevent graphical errors and possible screen crashes due to transmission error.

This should solve all 'loot pile' problems (which occur at ~80 items) while leaving smaller piles of loot around for longer.
