### PR TITLE
Fix vigor drain not working on new characters/some very old characters.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -707,6 +707,9 @@ messages:
       % Give user the logon delay
       Send(self,@LogonDelay);
 
+      % Update vigor drain time as 'now' so we drain vigor correctly
+      piLastVigorDrainTime = GetTickCount();
+
       return;
    }
 
@@ -2878,130 +2881,149 @@ messages:
    GetMoveStepTolerance()
    {
       % Explanation:
-	  % This tolerance is added to the maximum allowed stepsize	  
-	  % TODO: measure and estimate RTT and adjust dynamically
-	  	 	  
+      % This tolerance is added to the maximum allowed stepsize	  
+      % TODO: measure and estimate RTT and adjust dynamically
+
       return Send(Send(SYS, @GetSettings), @GetMoveStepTolerance);
    }
-   
+
    GetMoveAmountTolerance()
    {
       % Explanation:
       % This is the amount of move requests that are allowed 
-	  % when processing several ones in one tick.	  
-	  % This is required because of TCP retransmits,
-	  % which can cause this to happen.
-	  % But this is also exploitable by a speedhacker!	  
-	  
-	  % Example:
-	  % At an update interval of 250ms you probably want to 
-	  % keep this in between 2 and 12.
-	  % At 8 the server will still accept a buffered-up movement
-	  % processed at once, but legally created in steps within a 2s "lagspike".
-	  
-	  % TODO: use estimated RTT to adjust dynamically.
-	  
+      % when processing several ones in one tick.
+      % This is required because of TCP retransmits,
+      % which can cause this to happen.
+      % But this is also exploitable by a speedhacker!
+
+      % Example:
+      % At an update interval of 250ms you probably want to
+      % keep this in between 2 and 12.
+      % At 8 the server will still accept a buffered-up movement
+      % processed at once, but legally created in steps within a 2s "lagspike".
+
+      % TODO: use estimated RTT to adjust dynamically.
+
       return Send(Send(SYS, @GetSettings), @GetMoveMaxSimulReq);
    }
-   
+
    UserMove(new_row = 1, new_col = 1,
             fine_row = FINENESS/2, fine_col = FINENESS/2, speed = 0)
    {
-      local iCurrentTime, iDelta, iDeltaVigor, iExertion, iHasteLevel, 
-			iAngle, iRow, iCol, iFineRow, iFineCol,
-			iDx, iDy, iMoveLength, iMaxMoveRun;
-    		  
-	  % 1. Get current position values
-	  iRow = Send(self,@GetRow);
+      local iCurrentTime, iDelta, iDeltaVigor, iExertion, iHasteLevel,
+         iAngle, iRow, iCol, iFineRow, iFineCol,
+         iDx, iDy, iMoveLength, iMaxMoveRun;
+
+      %
+      % 1. Get current position values
+      %
+
+      iRow = Send(self,@GetRow);
       iCol = Send(self,@GetCol);
       iFineRow = Send(self,@GetFineRow);
       iFineCol = Send(self,@GetFineCol);
-	  iAngle = Send(self,@GetAngle);
-	  
-	  % 2. Do not allow any moves if player is marked as not allowed to move
+      iAngle = Send(self,@GetAngle);
+
+      %
+      % 2. Do not allow any moves if player is marked as not allowed to move
+      %
+
       if Send(self,@CheckPlayerflag,#flag=PFLAG_NO_MOVE)
       {
-		 % reset position
+         % Reset position
          Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
-              #new_row=iRow,
-			  #new_col=iCol,
-              #fine_row=iFineRow,
-              #fine_col=iFineCol,
-              #new_angle=iAngle);
+               #new_row=iRow,
+               #new_col=iCol,
+               #fine_row=iFineRow,
+               #fine_col=iFineCol,
+               #new_angle=iAngle);
 
          return;
       }
-	  
-	  % 3.1 Get current tick (ms resolution)    
-	  iCurrentTime = GetTickCount();
-      
-	  % 3.2 Get time-deltas
-	  iDelta = iCurrentTime - piLastMoveUpdateTime;
+
+      %
+      % 3.1 Get current tick (ms resolution)
+      %
+      iCurrentTime = GetTickCount();
+
+      %
+      % 3.2 Get time-deltas
+      %
+      iDelta = iCurrentTime - piLastMoveUpdateTime;
       iDeltaVigor = iCurrentTime - piLastVigorDrainTime;
-	  
-	  % 3.3 Bound time-deltas
-	  % Prevents long teleports after stops and negative numbers
-	  iDelta = bound(iDelta,0,Send(Send(SYS, @GetSettings), @GetMoveMaxLag));
-	  iDeltaVigor = bound(iDeltaVigor,0,3000);
-	  
-	  % 3.4 TCP workaround
-	  % iDelta can be 0 (~16 within ms resolution for +- 1 tick) in case
+
+      %
+      % 3.3 Bound time-deltas
+      % Prevents long teleports after stops and negative numbers
+      %
+      iDelta = bound(iDelta,0,Send(Send(SYS, @GetSettings), @GetMoveMaxLag));
+      iDeltaVigor = bound(iDeltaVigor,0,3000);
+
+      %
+      % 3.4 TCP workaround
+      % iDelta can be 0 (~16 within ms resolution for +- 1 tick) in case
       % we're processing buffered up TCP segments with several requests at once.
-	  % This can either happen because of IP packetloss and retransmits (legal)
-	  % or because someone is sending multiple positions at once by purpose (illegal).
-	  % So we must allow up to a certain amount of such buffered up requests,
-	  % but limit it so no one can exploit it too much.
-	  if iDelta <= 16
-	  {
-	    % if within the limits of allowed multiple requests
-		if piMovesInTick < Send(self,@GetMoveAmountTolerance)
-		{
-		  % fallback to default dt expected from client
-		  iDelta = Send(Send(SYS, @GetSettings), @GetMoveDefaultInterval);
-		  
-	      piMovesInTick = piMovesInTick + 1;
-		}
-		else
-		{
-		  % this is too many buffered up requests
-		  % reset position for this and any following in this tick
-          Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
-              #new_row=iRow,
-			  #new_col=iCol,
-              #fine_row=iFineRow,
-              #fine_col=iFineCol,
-              #new_angle=iAngle);
+      % This can either happen because of IP packetloss and retransmits (legal)
+      % or because someone is sending multiple positions at once by purpose (illegal).
+      % So we must allow up to a certain amount of such buffered up requests,
+      % but limit it so no one can exploit it too much.
+      %
+      if iDelta <= 16
+      {
+         % If within the limits of allowed multiple requests
+         if piMovesInTick < Send(self,@GetMoveAmountTolerance)
+         {
+            % Fallback to default dt expected from client
+            iDelta = Send(Send(SYS, @GetSettings), @GetMoveDefaultInterval);
 
-		  % make a logentry
-          if piCheaterLogs < MAX_LOGGED_THRESHOLD
-          {
-            piCheaterLogs = piCheaterLogs + 1;
-            Debug("ALERT!",Send(self,@GetTrueName),self,"exceeded multiple reqmove limit");
-          }
-		 
-          return;
-		}
-	  }
-	  else
-	  {
-	    % reset moves in tick counter
-	    piMovesInTick = 1;
-	  }
+            piMovesInTick = piMovesInTick + 1;
+         }
+         else
+         {
+            % This is too many buffered up requests
+            % Reset position for this and any following in this tick
+            Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
+                  #new_row=iRow,
+                  #new_col=iCol,
+                  #fine_row=iFineRow,
+                  #fine_col=iFineCol,
+                  #new_angle=iAngle);
 
-	  % 4.1 Get move-deltas	  
-	  iDy = ((new_row * FINENESS) + fine_row) - ((iRow * FINENESS) + iFineRow);
-	  iDx = ((new_col * FINENESS) + fine_col) - ((iCol * FINENESS) + iFineCol);
-	  	 	  
-	  % 4.2 Get move-vector length.
-	  % This is the squared move-vector length
-	  iMoveLength = (iDy * iDy) + (iDx * iDx);
-	  
-	  % 4.3 Calculate maximum allowed
-	  % squared movesize for running in this dt
-	  iMaxMoveRun = ((8 * USER_RUNNING_SPEED * iDelta) / 1000) + Send(self,@GetMoveStepTolerance);
-	  iMaxMoveRun = (iMaxMoveRun * iMaxMoveRun);
-	  
-      % DEBUG output		
+            % Make a log entry
+            if piCheaterLogs < MAX_LOGGED_THRESHOLD
+            {
+               piCheaterLogs = piCheaterLogs + 1;
+               Debug("ALERT!",Send(self,@GetTrueName),self,
+                  "exceeded multiple reqmove limit");
+            }
+
+            return;
+         }
+      }
+      else
+      {
+         % Reset moves in tick counter
+         piMovesInTick = 1;
+      }
+
+      %
+      % 4.1 Get move-deltas
+      %
+      iDy = ((new_row * FINENESS) + fine_row) - ((iRow * FINENESS) + iFineRow);
+      iDx = ((new_col * FINENESS) + fine_col) - ((iCol * FINENESS) + iFineCol);
+
+      %
+      % 4.2 Get move-vector length. This is the squared move-vector length.
+      %
+      iMoveLength = (iDy * iDy) + (iDx * iDx);
+
+      %
+      % 4.3 Calculate maximum allowed squared movesize for running in this dt.
+      %
+      iMaxMoveRun = ((8 * USER_RUNNING_SPEED * iDelta) / 1000) + Send(self,@GetMoveStepTolerance);
+      iMaxMoveRun = (iMaxMoveRun * iMaxMoveRun);
+
+      % DEBUG output
       %Debug(
       %  "iDelta:",iDelta,
       %  "iMaxMoveRun:",iMaxMoveRun,
@@ -3014,98 +3036,107 @@ messages:
       %  "new_col:",new_col,
       %  "fine_row:",fine_row,
       %  "fine_col:",fine_col);
-	  
-	  % 5.1 This move is bigger than running allows (speedhack).
-	  if (iMoveLength > iMaxMoveRun)
-	  {
-		 % reset position
+
+      %
+      % 5.1 This move is bigger than running allows (speedhack).
+      %
+      if (iMoveLength > iMaxMoveRun)
+      {
+         % Reset position
          Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
-              #new_row=iRow,
-			  #new_col=iCol,
-              #fine_row=iFineRow,
-              #fine_col=iFineCol,
-              #new_angle=iAngle);
-	
-		 % make a logentry
+               #new_row=iRow,
+               #new_col=iCol,
+               #fine_row=iFineRow,
+               #fine_col=iFineCol,
+               #new_angle=iAngle);
+
+         % Make a log entry
          if piCheaterLogs < MAX_LOGGED_THRESHOLD
          {
             piCheaterLogs = piCheaterLogs + 1;
             Debug("ALERT!",Send(self,@GetTrueName),self,"was moving too fast");
          }
-		  
-		 return;
-	  }
-	  
-	  % 5.2 This move is bigger than walking allows.
-	  % Right now: Still use the transmitted speed
+
+         return;
+      }
+
+      %
+      % 5.2 This move is bigger than walking allows.
+      % Right now: Still use the transmitted speed
+      %
       if (speed > USER_WALKING_SPEED)
       {
-		 % disallow run with low vigor
+         % Disallow run with low vigor
          if Send(self,@GetVigor) < VIGOR_RUN_THRESHOLD
          {
-            % reset position
-			Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
-				 #new_row=iRow,
-				 #new_col=iCol,
-				 #fine_row=iFineRow,
-				 #fine_col=iFineCol,
-				 #new_angle=iAngle);
-				 
-			% make a logentry		    
+            % Reset position
+            Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
+                  #new_row=iRow,
+                  #new_col=iCol,
+                  #fine_row=iFineRow,
+                  #fine_col=iFineCol,
+                  #new_angle=iAngle);
+
+            % Make a log entry
             if piCheaterLogs < MAX_LOGGED_THRESHOLD
             {
                piCheaterLogs = piCheaterLogs + 1;
                Debug("ALERT!",Send(self,@GetTrueName),self,"was running with "
                      "no vigor.");
             }
-			
-			return;
+
+            return;
          }
 
-		 % break trance
+         % Break trance
          if (piFlags & PFLAG_TRANCE)
-         { 
-            Send(self,@BreakTrance,#event=EVENT_RUN); 
+         {
+            Send(self,@BreakTrance,#event=EVENT_RUN);
          }
 
-		 % stop dance
+         % Stop dance
          if Send(self,@CheckPlayerFlag,#flag=PFLAG2_DANCING,#flagset=2)
-         { 
+         {
             Send(self,@StopDancing);
          }
       }
-	  
-	  % 5.3 Manual move checks in some rooms
-	  if Send(poOwner,@GetRoomNum) = RID_CAVE2
-	  {
-		if NOT Send(poOwner,@IsMoveOK,
-					#old_row=iRow,#old_col=iCol,#old_fine_row=iFineRow,#old_fine_col=iFineCol,
-					#new_row=new_row,#new_col=new_col,#new_fine_row=fine_row,#new_fine_col=fine_col)
-		{
-			% log
-			Debug("ALERT!",Send(self,@GetTrueName),self,"tried to move through closed cave entrance.");
-		
-			% reset position
-			Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
-				 #new_row=iRow,
-				 #new_col=iCol,
-				 #fine_row=iFineRow,
-				 #fine_col=iFineCol,
-				 #new_angle=iAngle);
-				 
-			return;
-		}
-	  }
-	  
+
+      %
+      % 5.3 Manual move checks in some rooms
+      %
+      if Send(poOwner,@GetRoomNum) = RID_CAVE2
+      {
+         if NOT Send(poOwner,@IsMoveOK,
+                  #old_row=iRow,#old_col=iCol,#old_fine_row=iFineRow,#old_fine_col=iFineCol,
+                  #new_row=new_row,#new_col=new_col,#new_fine_row=fine_row,#new_fine_col=fine_col)
+         {
+            % Log it
+            Debug("ALERT!",Send(self,@GetTrueName),self,
+               "tried to move through closed cave entrance.");
+
+            % Reset position
+            Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
+                  #new_row=iRow,
+                  #new_col=iCol,
+                  #fine_row=iFineRow,
+                  #fine_col=iFineCol,
+                  #new_angle=iAngle);
+
+            return;
+         }
+      }
+
+      %
       % 6. Drain vigor once per 1000 ms.
+      %
       if iDeltaVigor >= 1000
       {
          % Reduce speed value to old value, 5/6ths current value, then
-         %  square it.
+         % square it.
          iExertion = (speed * 5)/6;
          iExertion = iExertion * iExertion;
          iExertion = EXERTION_PER_MOVE * iExertion;
-         
+
          if Send(self,@CheckPlayerFlag,#flag=PFLAG2_HASTED,#flagset=2)
          {
             iHasteLevel = Send(self,@GetEnchantedState,
@@ -3115,27 +3146,33 @@ messages:
          }
 
          Send(self,@AddExertion,#amount=iExertion);
-		 
-		 % save vigor drain tick
-		 piLastVigorDrainTime = iCurrentTime;
+
+         % Save vigor drain tick
+         piLastVigorDrainTime = iCurrentTime;
+
       }
 
+      %
       % 7. Notify monsters about presence (bitflag check instead of function)
+      %
       if NOT (piFlags & PFLAG_MOVED_SINCE_ENTRY)
       {
          Send(self,@NotifyMonstersOfPresence);
       }
-  
+
+      %
       % 8. Save this move tick for next execution
+      %
       piLastMoveUpdateTime = iCurrentTime;
 
-	  % 9. Process the move
-
+      %
+      % 9. Process the move
+      %
       Send(poOwner,@SomethingMoved,#what=self,
-           #new_row=new_row,#new_col=new_col,
-           #fine_row=fine_row,#fine_col=fine_col,
-           #cause=CAUSE_USER_INPUT,#speed=speed);
-		   
+            #new_row=new_row,#new_col=new_col,
+            #fine_row=fine_row,#fine_col=fine_col,
+            #cause=CAUSE_USER_INPUT,#speed=speed);
+
       return;
    }
 


### PR DESCRIPTION
Vigor drain is only calculated if iDeltaVigor is > 1000 (i.e. every one second) but there are cases where iDeltaVigor will return a negative number and prevent the character from losing vigor from running at all. 

piLastVigorDrainTime will now be updated when the character logs in so iDeltaVigor will always be positive.

Also cleaned up some of the code in UserMove.
