### PR TITLE
Fix a spell.kod Arena check to only check Battlers.

### DIFF
--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1100,7 +1100,8 @@ messages:
          for oObject in lTargets
          {
             % If we're in the arena, we can cast it.
-            if Send(Send(oObject,@GetOwner),@IsArena)
+            if IsClass(oObject,&Battler)
+               AND Send(Send(oObject,@GetOwner),@IsArena)
             {
                return TRUE;
             }


### PR DESCRIPTION
Currently it's checking casts on items as well, this causes errors to be logged.
