### PR TITLE
Discord won't remove AEs in safe zones

### DIFF
--- a/kod/object/passive/spell/discord.kod
+++ b/kod/object/passive/spell/discord.kod
@@ -136,6 +136,7 @@ messages:
       local iNumEnchantments, lEnchantments, iModifiedChance, oEnchantment, oSpell, bRemovedSomething;
 
       if oRoom = $
+         OR Send(oRoom,@CheckRoomFlag,#flag=ROOM_NO_COMBAT)
       {
          return FALSE;
       }


### PR DESCRIPTION
It can still be cast, giving a chance to improve, but it can no longer be used to grief.

Remember, negative AEs such as AMA can't be used to grief in inns anymore, either.

This will also greatly aid imping AND cut down on 'discord spam'.

On a personal note, discord spam is one of the most enraging things this game has
ever created. I'll be glad to see it go.