### PR TITLE
Object flag expansion - new bit field for player name colors and minimap dot info.

### DIFF
--- a/clientd3d/color.c
+++ b/clientd3d/color.c
@@ -437,28 +437,25 @@ WORD GetItemListColor(HWND hwnd, int type, int flags)
 */
 COLORREF GetPlayerNameColor(int flags,char*name)
 {
-	switch (flags)
-	{
-		case PF_SHADOW:
-			return NAME_COLOR_BLACK_FG;
-		case PF_DM:
-			return NAME_COLOR_DM_FG;
-		case PF_KILLER:
-			return NAME_COLOR_KILLER_FG;
-		case PF_OUTLAW:
-			return NAME_COLOR_OUTLAW_FG;
-		case PF_CREATOR:
-			return NAME_COLOR_DAENKS_FG;
-		case PF_SUPER:
-			return NAME_COLOR_SUPER_FG;
-		case PF_MODERATOR:
-			return NAME_COLOR_MOD_FG;
-		case PF_EVENTCHAR:
-			return NAME_COLOR_EVENT_FG;
-            
-    default:
-			return NAME_COLOR_NORMAL_FG;
-	}
+	// Arranged in order of precedence
+	if (flags & PF_SHADOW)
+		return NAME_COLOR_BLACK_FG;
+	if (flags & PF_EVENTCHAR)
+		return NAME_COLOR_EVENT_FG;
+	if (flags & PF_CREATOR)
+		return NAME_COLOR_DAENKS_FG;
+	if (flags & PF_SUPER)
+		return NAME_COLOR_SUPER_FG;
+	if (flags & PF_DM)
+		return NAME_COLOR_DM_FG;
+	if (flags & PF_MODERATOR)
+		return NAME_COLOR_MOD_FG;
+	if (flags & PF_KILLER)
+		return NAME_COLOR_KILLER_FG;
+	if (flags & PF_OUTLAW)
+		return NAME_COLOR_OUTLAW_FG;
+
+	return NAME_COLOR_NORMAL_FG;
 }
 
 /****************************************************************************/
@@ -468,24 +465,10 @@ COLORREF GetPlayerNameColor(int flags,char*name)
 */
 COLORREF GetPlayerWhoNameColor(int flags,char*name)
 {
-    switch (flags)
-    {
-        case PF_DM:
-            return NAME_COLOR_DM_FG;
-        case PF_CREATOR:
-            return NAME_COLOR_DAENKS_FG;
-        case PF_SUPER:
-            return NAME_COLOR_SUPER_FG;
-        case PF_EVENTCHAR:
-            return NAME_COLOR_EVENT_FG;
-        case PF_KILLER:
-            return NAME_COLOR_KILLER_FG;
-        case PF_OUTLAW:
-            return NAME_COLOR_OUTLAW_FG;
-        case PF_MODERATOR:
-            return NAME_COLOR_MOD_FG;
+   // Remove the shadow flag if applicable, then call GetPlayerNameColor
+   // to determine the color to use.
+	if (flags & PF_SHADOW)
+		flags = (flags & ~PF_SHADOW);
 
-        default:
-            return NAME_COLOR_NORMAL_FG;
-    }
+	return GetPlayerNameColor(flags,name);
 }

--- a/clientd3d/color.c
+++ b/clientd3d/color.c
@@ -437,11 +437,10 @@ WORD GetItemListColor(HWND hwnd, int type, int flags)
 */
 COLORREF GetPlayerNameColor(int flags,char*name)
 {
-	if (GetDrawingEffect(flags) == OF_BLACK)
-		return NAME_COLOR_BLACK_FG;
-
-	switch (GetPlayerFlags(flags))
+	switch (flags)
 	{
+		case PF_SHADOW:
+			return NAME_COLOR_BLACK_FG;
 		case PF_DM:
 			return NAME_COLOR_DM_FG;
 		case PF_KILLER:
@@ -469,7 +468,7 @@ COLORREF GetPlayerNameColor(int flags,char*name)
 */
 COLORREF GetPlayerWhoNameColor(int flags,char*name)
 {
-    switch (GetPlayerFlags(flags))
+    switch (flags)
     {
         case PF_DM:
             return NAME_COLOR_DM_FG;

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -3524,7 +3524,7 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
 			((float)pRNode->boundingHeightAdjust * 4.0f), (float)pRNode->motion.y);
 		MatrixMultiply(&xForm, &rot, &mat);
 
-		fg_color = GetPlayerNameColor(pRNode->obj.flags, pName);
+		fg_color = GetPlayerNameColor(pRNode->obj.identityflags, pName);
 
 		// Some names never grow darker, they use PALETTEINDEX().
 		if (HIBYTE(HIWORD(fg_color)) == HIBYTE(HIWORD(PALETTEINDEX(0))))

--- a/clientd3d/dialog.c
+++ b/clientd3d/dialog.c
@@ -229,7 +229,7 @@ BOOL CALLBACK DescDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lParam)
 			(int)FONT_TITLES, info->name);
 		SetDlgItemText(hDlg, IDC_DESCNAME, info->name);
 		hdc = GetDC(hDlg);
-		SetTextColor(hdc,GetPlayerNameColor(info->obj->flags,info->name));
+		SetTextColor(hdc,GetPlayerNameColor(info->obj->identityflags,info->name));
 		ReleaseDC(hDlg,hdc);
 		
 		// Item Description.
@@ -404,7 +404,7 @@ BOOL CALLBACK DescDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lParam)
 		   SetTextColor(lpdis->hDC, NAME_COLOR_NORMAL_BG);
 		   DrawText(lpdis->hDC, str, strlen(str), &lpdis->rcItem, DT_LEFT | DT_VCENTER | DT_NOPREFIX);
 		   OffsetRect(&lpdis->rcItem, -1, -1);
-		   SetTextColor(lpdis->hDC, GetPlayerNameColor(info->obj->flags,info->name));
+		   SetTextColor(lpdis->hDC, GetPlayerNameColor(info->obj->identityflags,info->name));
 		   DrawText(lpdis->hDC, str, strlen(str), &lpdis->rcItem, DT_LEFT | DT_VCENTER | DT_NOPREFIX);
 		   
 		   break;

--- a/clientd3d/draw3d.h
+++ b/clientd3d/draw3d.h
@@ -87,6 +87,7 @@ typedef struct {
    list_type overlays;         /* Bitmaps to draw over object */
    BYTE light;                 /* Strength of sector light at object */
    int  flags;                 /* Object flags, including moveon type */
+   int  identityflags;         /* Object identity flags */
    int  height;                /* Height to draw object (FINENESS units) */   
    int  center;                /* Screen column of center of object */
    int  depth;                 /* Depth under ground to draw object (FINENESS units) */

--- a/clientd3d/map.c
+++ b/clientd3d/map.c
@@ -401,7 +401,8 @@ void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
 
          if (r->obj.flags & OF_FRIEND)
          {
-            if ((r->obj.flags & OF_ENEMY) || (r->obj.flags & OF_GUILDMATE))
+            if ((r->obj.identityflags & OF_ENEMY)
+                  || (r->obj.identityflags & OF_GUILDMATE))
                ring_radius = 2.4f * radius;
 
             SelectObject(hdc, hFriendPen);
@@ -413,7 +414,7 @@ void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
          }
 
          // Enemy?
-         if (r->obj.flags & OF_ENEMY)
+         if (r->obj.identityflags & OF_ENEMY)
          {
             SelectObject(hdc, hEnemyPen);
             Ellipse(hdc, (int) (new_x - ring_radius),
@@ -423,7 +424,7 @@ void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
          }
 
          // Guildmate?
-         if (r->obj.flags & OF_GUILDMATE)
+         if (r->obj.identityflags & OF_GUILDMATE)
          {
              SelectObject(hdc, hGuildmatePen);
              Ellipse(hdc, (int) (new_x - ring_radius),
@@ -441,12 +442,12 @@ void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
           SelectObject(hdc, hPlayerPen);
           SelectObject(hdc, hPlayerBrush);
       }
-      else if ((r->obj.flags & OF_MINION_SELF) == OF_MINION_SELF)
+      else if ((r->obj.identityflags & OF_MINION_SELF) == OF_MINION_SELF)
       {
           SelectObject(hdc, hMinionPen);
           SelectObject(hdc, hMinionBrush);
       }
-      else if ((r->obj.flags & OF_MINION_OTHER) == OF_MINION_OTHER)
+      else if ((r->obj.identityflags & OF_MINION_OTHER) == OF_MINION_OTHER)
       {
           SelectObject(hdc, hMinionOtherPen);
           SelectObject(hdc, hMinionOtherBrush);
@@ -458,8 +459,8 @@ void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
       }
 
       // Draw a circle at the object's position
-      Ellipse(hdc, (int) (new_x - radius), (int) (new_y - radius), 
-	      (int) (new_x + radius), (int) (new_y + radius));
+      Ellipse(hdc, (int) (new_x - radius), (int) (new_y - radius),
+         (int) (new_x + radius), (int) (new_y + radius));
 
    }
 }

--- a/clientd3d/objdraw.h
+++ b/clientd3d/objdraw.h
@@ -15,6 +15,7 @@
 // Structure passed to inner loops
 typedef struct {
    int   flags;             // Object flags
+   int   identityflags;     // Object identity flags
    BYTE  translation;       // Palette translation to use
    BYTE  secondtranslation; // Another palette translation to use
    BYTE *start_ptr;         // Points to start of row to draw in

--- a/clientd3d/object.c
+++ b/clientd3d/object.c
@@ -90,6 +90,7 @@ object_node *ObjectCopy(object_node *obj)
    temp->name_res = obj->name_res;
    temp->icon_res = obj->icon_res;
    temp->flags  = obj->flags;
+   temp->identityflags = obj->identityflags;
    temp->amount = obj->amount;
    temp->temp_amount = obj->temp_amount;
    temp->translation = obj->translation;

--- a/clientd3d/object.h
+++ b/clientd3d/object.h
@@ -79,6 +79,7 @@ typedef struct {
 		                     this field gives amount of object */
    DWORD     temp_amount;         /* Scratch field used when user is selecting amount of object */
    int       flags;               /* Flags describing various properties of objects */
+   int       identityflags;       // Flags used for obj props such as name and minimap coloring
    BYTE      translation;         // Palette translation information
    Animate   *animate;            /* Pointer to current animation (normal or motion animation) */
    list_type *overlays;           /* Pointer to current overlays (normal or motion animation) */

--- a/clientd3d/object3d.c
+++ b/clientd3d/object3d.c
@@ -879,7 +879,7 @@ void DrawObjectDecorations(DrawnObject *object)
    y = range->top_row - s.cy - 2;
 
    // Give a shadowed look to be visible on all color backgrounds
-   fg_color = GetPlayerNameColor(r->obj.flags,name);
+   fg_color = GetPlayerNameColor(r->obj.identityflags,name);
    bg_color = NAME_COLOR_NORMAL_BG;
 
    // Some names never grow darker, they use PALETTEINDEX().

--- a/clientd3d/object3d.h
+++ b/clientd3d/object3d.h
@@ -39,17 +39,18 @@ typedef struct {
 
 // Options to DrawObjectBitmap
 typedef struct {
-   PDIB      pdib;       // Object bitmap
-   int       distance;   // Distance to object in FINENESS units
-   BYTE      light;      // Light level to draw object
-   Bool      draw;       // True if object should actually be drawn (False = just compute location)
-   ViewCone *cone;       // Cone in which to draw object
-   int       flags;      // Object flags for special options (invisibility, etc.)
-   int       cutoff;     // Last screen row in which to draw object (to cut off at ground level)
-   BYTE      translation;// Color translation type, 0 = none
-   BYTE      secondtranslation; // Overriding second translation for all overlays.
-   BYTE	     effect;
-   room_contents_node *obj;    // Pointer to room_contents_node for object
+   PDIB      pdib;          // Object bitmap
+   int       distance;      // Distance to object in FINENESS units
+   BYTE      light;         // Light level to draw object
+   Bool      draw;          // True if object should actually be drawn (False = just compute location)
+   ViewCone *cone;          // Cone in which to draw object
+   int       flags;         // Object flags for special options (invisibility, etc.)
+   int       identityflags; // Object identity flags.
+   int       cutoff;        // Last screen row in which to draw object (to cut off at ground level)
+   BYTE      translation;   // Color translation type, 0 = none
+   BYTE      secondtranslation;  // Overriding second translation for all overlays.
+   BYTE      effect;
+   room_contents_node *obj;      // Pointer to room_contents_node for object
 } DrawObjectInfo;
 
 #define NAME_COLOR_NORMAL_BG   PALETTERGB(0, 0, 0)

--- a/clientd3d/ownerdrw.c
+++ b/clientd3d/ownerdrw.c
@@ -438,7 +438,7 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
    {
    	// get the color we'd prefer for this particular obj
    	crColorText = GetPlayerWhoNameColor(obj->identityflags,NULL);
-   	
+
 	// draw a black halo around the text just to ensure it is visible
 	SetTextColor(lpdis->hDC, RGB(0, 0, 0));
         OffsetRect(&r, 1, 0);

--- a/clientd3d/ownerdrw.c
+++ b/clientd3d/ownerdrw.c
@@ -437,7 +437,7 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
    if (style & OD_COLORTEXT)
    {
    	// get the color we'd prefer for this particular obj
-   	crColorText = GetPlayerWhoNameColor(obj->flags,NULL);
+   	crColorText = GetPlayerWhoNameColor(obj->identityflags,NULL);
    	
 	// draw a black halo around the text just to ensure it is visible
 	SetTextColor(lpdis->hDC, RGB(0, 0, 0));

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -328,6 +328,7 @@ void ExtractObject(char **ptr, object_node *item)
       item->amount = 0;
    Extract(ptr, &item->icon_res, SIZE_ID);
    Extract(ptr, &item->name_res, SIZE_ID);
+   Extract(ptr, &item->identityflags, 4);
    Extract(ptr, &item->flags, 4); // includes drawfx_mask bits
 
    ExtractDLighting(ptr, &item->dLighting);
@@ -361,6 +362,7 @@ void ExtractObjectNoLight(char **ptr, object_node *item)
       item->amount = 0;
    Extract(ptr, &item->icon_res, SIZE_ID);
    Extract(ptr, &item->name_res, SIZE_ID);
+   Extract(ptr, &item->identityflags, 4);
    Extract(ptr, &item->flags, 4); // includes drawfx_mask bits
 
    ExtractPaletteTranslation(ptr,&item->translation,&item->effect);
@@ -1142,6 +1144,7 @@ Bool HandlePlayers(char *ptr,long len)
       ChangeResource(obj->name_res, name);
 
       Extract(&ptr, &obj->flags, SIZE_VALUE);
+      Extract(&ptr, &obj->identityflags, SIZE_VALUE);
       len -= SIZE_VALUE;
 
       list = list_add_item(list, obj);
@@ -1172,6 +1175,7 @@ Bool HandleAddPlayer(char *ptr,long len)
    ChangeResource(obj->name_res, name);
    
    Extract(&ptr, &obj->flags, SIZE_VALUE);
+   Extract(&ptr, &obj->identityflags, SIZE_VALUE);
    len -= SIZE_VALUE;
 
    if (len != 0)

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -328,8 +328,8 @@ void ExtractObject(char **ptr, object_node *item)
       item->amount = 0;
    Extract(ptr, &item->icon_res, SIZE_ID);
    Extract(ptr, &item->name_res, SIZE_ID);
-   Extract(ptr, &item->identityflags, 4);
    Extract(ptr, &item->flags, 4); // includes drawfx_mask bits
+   Extract(ptr, &item->identityflags, 4);
 
    ExtractDLighting(ptr, &item->dLighting);
 
@@ -362,7 +362,6 @@ void ExtractObjectNoLight(char **ptr, object_node *item)
       item->amount = 0;
    Extract(ptr, &item->icon_res, SIZE_ID);
    Extract(ptr, &item->name_res, SIZE_ID);
-   Extract(ptr, &item->identityflags, 4);
    Extract(ptr, &item->flags, 4); // includes drawfx_mask bits
 
    ExtractPaletteTranslation(ptr,&item->translation,&item->effect);
@@ -575,6 +574,7 @@ Bool HandleMessage(char *message, int len)
    }
 
    handled =  LookupMessage(message, len, table);
+   
    if (!handled)
       debug(("Got unknown message type %d from server\n", (int) (unsigned char) message[0]));
    return handled;
@@ -597,14 +597,14 @@ Bool LookupMessage(char *message, int len, HandlerTable table)
 
    ptr = message + SIZE_TYPE;
 
-   /* Look for message handler in table */
-   index = 0;
+	/* Look for message handler in table */
+	index = 0;
 	while (table[index].msg_type != 0)
 	{
 		if (table[index].msg_type == type)
 		{
 			if (table[index].handler != NULL)
-			{                           
+			{
 				/* Don't count type byte in length for handler */
 				success = (*table[index].handler)(ptr, len - SIZE_TYPE);
 				if (!success)
@@ -1145,7 +1145,7 @@ Bool HandlePlayers(char *ptr,long len)
 
       Extract(&ptr, &obj->flags, SIZE_VALUE);
       Extract(&ptr, &obj->identityflags, SIZE_VALUE);
-      len -= SIZE_VALUE;
+      len -= 2* SIZE_VALUE;
 
       list = list_add_item(list, obj);
    }
@@ -1176,7 +1176,7 @@ Bool HandleAddPlayer(char *ptr,long len)
    
    Extract(&ptr, &obj->flags, SIZE_VALUE);
    Extract(&ptr, &obj->identityflags, SIZE_VALUE);
-   len -= SIZE_VALUE;
+   len -= 2* SIZE_VALUE;
 
    if (len != 0)
    {

--- a/include/proto.h
+++ b/include/proto.h
@@ -366,16 +366,6 @@ enum {
 #define OF_APPLYABLE     0x00001000    // Set if object can be applied to another object
 #define OF_SAFETY        0x00002000    // Set if player has safety on (self only)
 
-// Player name colors
-#define PF_KILLER        0x00004000    // Set if object is a killer (must also have OF_PLAYER)
-#define PF_OUTLAW        0x00008000    // Set if object is an outlaw (must also have OF_PLAYER)
-#define PF_DM            0x0000C000    // Set if object is a DM player
-#define PF_CREATOR       0x00010000    // Set if object is a creator player
-#define PF_SUPER         0x00014000    // Set if object is a "super DM"
-#define PF_MODERATOR     0x00018000    // Set if object is a "moderator"
-#define PF_EVENTCHAR     0x0001C000    // Set if object is an event character
-#define OF_PLAYER_MASK   0x0001C000    // Mask to get player flag bits
-
 #define OF_FLICKERING    0x00020000    // For players or objects if holding a flickering light.
 #define OF_FLASHING      0x00040000    // For players or objects if flashing with light.
 #define OF_BOUNCING      0x00060000    // If both flags on then object is bouncing
@@ -393,20 +383,27 @@ enum {
 #define OF_DITHERTRANS   0x00800000    // Dither (with two translates) 50% of pixels
 #define OF_DOUBLETRANS   0x00900000    // Translate twice each pixel, plus lighting
 #define OF_SECONDTRANS   0x00A00000    // Ignore per-overlay xlat and use only secondary xlat
-#define OF_EFFECT_MASK   0x00F00000    // Mask to get object drawing effect bits
-#define NUM_DRAW_EFFECTS 16            // # of possible object drawing effects
+#define OF_EFFECT_MASK   0x01F00000    // Mask to get object drawing effect bits
+#define NUM_DRAW_EFFECTS 32            // # of possible object drawing effects
 
-// Minimap dot colors
-#define OF_ENEMY         0x01000000    // Enemy player
-#define OF_FRIEND        0x02000000    // Friendly player
-#define OF_GUILDMATE     0x04000000    // Guildmate player
-#define OF_MINION        0x08000000    // Monster is a minion owned by a player
-#define OF_MINION_OTHER  0x09000000    // Set if monster is other's minion
-#define OF_MINION_SELF   0x0A000000    // Set if a monster is our minion
-#define OF_MINIMAP_MASK  0x0F000000    // Mask to get minimap drawing effects
+/* Object identity flags. These are a separate bit field (obj->identityflags) and
+ * are used for name drawing effects and minimap dot coloring */
+#define PF_SHADOW        0x00000001    // Set if object has a shadow form effect (black name)
+#define PF_KILLER        0x00000002    // Set if object is a killer
+#define PF_OUTLAW        0x00000004    // Set if object is an outlaw
+#define PF_DM            0x00000008    // Set if object is a DM player
+#define PF_CREATOR       0x00000010    // Set if object is a creator player
+#define PF_SUPER         0x00000020    // Set if object is a "super DM"
+#define PF_MODERATOR     0x00000040    // Set if object is a "moderator"
+#define PF_EVENTCHAR     0x00000080    // Set if object is an event character
 
-#define GetMinimapFlags(flags)  ((flags) & OF_MINIMAP_MASK)
-#define GetPlayerFlags(flags)   ((flags) & OF_PLAYER_MASK)
+#define OF_MINION_SELF   0x00010000    // Set if a monster is our minion
+#define OF_MINION_OTHER  0x00020000    // Set if monster is other's minion
+
+#define OF_ENEMY         0x00100000    // Enemy player
+#define OF_FRIEND        0x00200000    // Friendly player
+#define OF_GUILDMATE     0x00400000    // Guildmate player
+
 #define GetDrawingEffect(flags) ((flags) & OF_EFFECT_MASK)
 #define GetDrawingEffectIndex(flags) (((flags) & OF_EFFECT_MASK) >> 20)
 #define GetItemFlags(flags)   ((flags))

--- a/include/proto.h
+++ b/include/proto.h
@@ -228,7 +228,7 @@ enum {
    UC_STAND = 6,
    UC_SAFETY = 7,
    UC_SUICIDE = 8,
-
+   UC_TEMPSAFE = 9,
    UC_REQ_GUILDINFO = 10,
    UC_GUILDINFO = 11,
    UC_INVITE = 12,
@@ -365,6 +365,7 @@ enum {
 #define OF_ACTIVATABLE   0x00000800    // Set if object can be activated
 #define OF_APPLYABLE     0x00001000    // Set if object can be applied to another object
 #define OF_SAFETY        0x00002000    // Set if player has safety on (self only)
+#define OF_TEMPSAFE      0x00004000    // Set if player has temp safety on death on (self only)
 
 #define OF_FLICKERING    0x00020000    // For players or objects if holding a flickering light.
 #define OF_FLASHING      0x00040000    // For players or objects if flashing with light.

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -94,24 +94,29 @@
    DRAWFX_SECONDTRANS    = 0xA00000
    DRAWFX_MASK           = 0xF00000
 
-   % Bits 0x4000, 0x8000, 0x10000 in total describe the player type
-   PLAYER_NO         = 0
-   PLAYER_PK         = 0x4000
-   PLAYER_OUTLAW     = 0x8000
-   PLAYER_DM         = 0xC000
-   PLAYER_CREATOR    = 0x10000
-   PLAYER_SUPER      = 0x14000
-   PLAYER_MODERATOR  = 0x18000
-   PLAYER_EVENT      = 0x1C000
+   % The following are 'identityflags', used by the client to determine
+   % how to draw the player's name, and also minimap dots. This is a
+   % separate bit field to the normal object flags and uses
+   % viObjectIdentity_flags as opposed to viObject_flags.
 
-   % What is the target, according to the viewer?  Used for special flagging.
-   PLAYER_IS_ENEMY      = 0x01000000
-   PLAYER_IS_FRIEND     = 0x02000000
-   PLAYER_IS_GUILDMATE  = 0x04000000
-   MINION_YES           = 0x08000000
-   MINION_OTHER         = 0x09000000
-   MINION_SELF          = 0x0A000000
-   MINIMAP_MASK         = 0x0F000000
+   % Player name drawing, 0x0001 to 0x8000 (room for 8 more)
+   PLAYER_NO         = 0
+   PLAYER_SHADOW     = 0x0001
+   PLAYER_PK         = 0x0002
+   PLAYER_OUTLAW     = 0x0004
+   PLAYER_DM         = 0x0008
+   PLAYER_CREATOR    = 0x0010
+   PLAYER_SUPER      = 0x0020
+   PLAYER_MODERATOR  = 0x0040
+   PLAYER_EVENT      = 0x0080
+
+   % Monsters - 0x10000 to 0x80000 (room for 2 more)
+   MINION_SELF          = 0x10000
+   MINION_OTHER         = 0x20000
+   % Players - 0x0100000 to 0x4000000 (room for 4 more)
+   PLAYER_IS_ENEMY      = 0x0100000
+   PLAYER_IS_FRIEND     = 0x0200000
+   PLAYER_IS_GUILDMATE  = 0x0400000
 
    %%% Projectile and Light flags
 

--- a/kod/object.kod
+++ b/kod/object.kod
@@ -77,6 +77,7 @@ classvars:
 
    viGender = GENDER_NEUTER
    viObject_flags = 0
+   viObjectIdentity_flags = 0
 
 properties:
 
@@ -735,6 +736,11 @@ messages:
    GetObjectFlags()
    {
       return viObject_flags;
+   }
+
+   GetObjectIdentityFlags()
+   {
+      return viObjectIdentity_flags;
    }
 
    GetGender()

--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -305,6 +305,15 @@ messages:
       return iFlags;
    }
 
+   GetObjectIdentityFlags()
+   {
+      local iFlags;
+
+      iFlags = Send(poOriginal,@GetObjectIdentityFlags);
+
+      return iFlags;
+   }
+
    GetAttackRange()
    {
       local iWeapon;

--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -322,6 +322,20 @@ messages:
       return iFlags;
    }
 
+   GetObjectIdentityFlags()
+   {
+      local iFlags;
+
+      if poOriginal = $
+      {
+         post(self,@Delete);
+      }
+
+      iFlags = Send(poOriginal,@GetObjectIdentityFlags);
+
+      return iFlags;
+   }
+
    GetAttackRange()
    {
       local iWeapon;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -922,6 +922,7 @@ messages:
          AddPacket(4,what,4,rName);
          AddPacket(STRING_RESOURCE,rName);
          AddPacket(4,Send(what,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
+         AddPacket(4,Send(what,@GetObjectIdentityFlags));
          SendPacket(poSession);
 
          if IsClass(self,&Admin) AND IsClass(what,&Admin)
@@ -2330,7 +2331,7 @@ messages:
    "show_type is used to get the look or inventory animation and overlays "
    "instead of the normal animation and overlays."
    {
-      local iFlags, iEnemyKarma, iSelfKarma, oIllusion, oOtherGuild, oRoom;
+      local iFlags, iIdentityFlags, iEnemyKarma, iSelfKarma, oIllusion, oOtherGuild, oRoom;
 
       % Send given object's id number, name, icon, and animation info
 
@@ -2357,6 +2358,7 @@ messages:
       }
 
       iFlags = Send(what,@GetObjectFlags);
+      iIdentityFlags = Send(what,@GetObjectIdentityFlags);
 
       if Send(self,@CheckPlayerFlag,#flag=PFLAG2_DETECT_INVIS,#flagset=2)
          AND (iFlags & DRAWFX_MASK) = DRAWFX_INVISIBLE
@@ -2404,18 +2406,18 @@ messages:
                {
                   if poGuild = oOtherGuild
                   {
-                     iFlags = (iFlags | PLAYER_IS_GUILDMATE);
+                     iIdentityFlags = (iIdentityFlags | PLAYER_IS_GUILDMATE);
                   }
 
                   if Send(poGuild,@IsAlly,#otherguild=oOtherGuild)
                      AND Send(oOtherGuild,@IsAlly,#otherguild=poGuild)
                   {
-                     iFlags = (iFlags | PLAYER_IS_FRIEND);
+                     iIdentityFlags = (iIdentityFlags | PLAYER_IS_FRIEND);
                   }
 
                   if Send(poGuild,@IsMutualEnemy,#otherguild=oOtherGuild)
                   {
-                     iFlags = (iFlags | PLAYER_IS_ENEMY);
+                     iIdentityFlags = (iIdentityFlags | PLAYER_IS_ENEMY);
                   }
                }
             }
@@ -2424,7 +2426,7 @@ messages:
                AND NOT IsClass(self,&DM)
                AND Send(self,@AllowPlayerAttack,#victim=what,#report=FALSE,#actual=FALSE)
             {
-               iFlags = (iFlags | PLAYER_IS_ENEMY);
+               iIdentityFlags = (iIdentityFlags | PLAYER_IS_ENEMY);
             }
          }
 
@@ -2435,11 +2437,11 @@ messages:
          {
             if (Send(what,@GetMaster) = self)
             {
-               iFlags = (iFlags | MINION_SELF);
+               iIdentityFlags = (iIdentityFlags | MINION_SELF);
             }
             else
             {
-               iFlags = (iFlags | MINION_OTHER);
+               iIdentityFlags = (iIdentityFlags | MINION_OTHER);
             }
          }
       }
@@ -2449,11 +2451,12 @@ messages:
       {
          if Send(oRoom,@AreGroupedHere,#who=self,#what=what)
          {
-            iFlags = (iFlags | PLAYER_IS_FRIEND);
+            iIdentityFlags = (iIdentityFlags | PLAYER_IS_FRIEND);
          }
       }
 
       AddPacket(4,iFlags);
+      AddPacket(4,iIdentityFlags);
 
       % Send the lighting information.
       Send(what,@SendLightingInformation);
@@ -2565,6 +2568,7 @@ messages:
 
          AddPacket(4,i, 4,rName, STRING_RESOURCE,rName);
          AddPacket(4,Send(i,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
+         AddPacket(4,Send(i,@GetObjectIdentityFlags));
       }
       
       SendPacket(poSession);
@@ -8160,12 +8164,21 @@ messages:
       return ret_val;
    }
 
-   GetObjectFlags()
+   GetObjectIdentityFlags()
    {
-      local iFlags, oIllusion;
+      local iFlags, iDrawFX;
 
-      iFlags = MOVEON_NO | BATTLER_YES | USER_YES | OFFER_YES;
+      % This is where the flags for drawing the player name color and
+      % any minimap colors or modifications are sent.
 
+      % Check for any shadow form effects.
+      iDrawfX = Send(self,@GetPlayerDrawFX);
+      if (iDrawFX & DRAWFX_BLACK) = DRAWFX_BLACK
+      {
+         iFlags = iFlags | PLAYER_SHADOW;
+      }
+
+      % Send the appropriate flag to draw the name.
       if IsClass(self,&Creator)
       {
          iFlags = iFlags | PLAYER_CREATOR;
@@ -8213,13 +8226,22 @@ messages:
          }
       }
 
+      return iFlags;
+   }
+
+   GetObjectFlags()
+   {
+      local iFlags, oIllusion;
+
+      iFlags = MOVEON_NO | BATTLER_YES | USER_YES | OFFER_YES;
+
       if (piFlags & PFLAG_INVISIBLE)
       {
          % invisibility overrides any other drawfx
          iFlags = iFlags & (~DRAWFX_MASK);
          iFlags = iFlags | DRAWFX_INVISIBLE;
       }
-      
+
       if (piFlags & PFLAG_SAFETY)
       {
          iFlags = iFlags | SAFETY_YES;
@@ -8237,13 +8259,13 @@ messages:
       {
          iFlags = (iFlags & ~USER_YES & ~OFFER_YES);
       }
-      
+
       if Send(self,@IsPhasedOut)
       {
          iFlags = iFlags | LOOK_NO;
          iFlags = (iFlags & ~MOVEON_NO & ~BATTLER_YES & ~OFFER_YES & ~USER_YES);
       }
-      
+
       % Angeled characters cannot block other players
       if NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
       {

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -8168,6 +8168,8 @@ messages:
    {
       local iFlags, iDrawFX;
 
+      iFlags = viObjectIdentity_flags;
+
       % This is where the flags for drawing the player name color and
       % any minimap colors or modifications are sent.
 


### PR DESCRIPTION
Forum thread: http://openmeridian.org/forums/index.php/topic,234.0.html

This pull request creates a new bit field, referred to in the kod code as viObjectIdentity_flags and in the client as obj->identityflags. This bit field handles the coloring of player names and any extra drawing effects for minimap dots (plan red/blue dots are still determined using the original flags).

The moved bit flags have been given new values and no longer overlap, although if space becomes an issue again we could use overlapping for the player name colors again. Players who have the black draw FX (shadow form, some illusionary forms) will send a new bit flag, PLAYER_SHADOW/PF_SHADOW for simplicity in the C code.

Refactored the code for drawing player name colors in color.c.

Note that this pull request is coded to go in simultaneously with #358.