### PR TITLE
Set item durability to full when Extra Durability mod is added

### DIFF
--- a/kod/object/passive/itematt/iadurabl.kod
+++ b/kod/object/passive/itematt/iadurabl.kod
@@ -72,6 +72,7 @@ messages:
       iHits = (iHits * state1)/100;
       iHits = bound(iHits,1,$);
       Send(oItem,@setMaxHits,#number=iHits);
+      Send(oItem,@SetHits,#number=Send(oItem,@GetMaxHits));
 
       return;
    }


### PR DESCRIPTION
Items with Extra Durability currently come damaged (because they have
normal hits, but triple max hits). This fixes that.
