### PR TITLE
Fix errors caused by prism spells casting with no prism.

### DIFF
--- a/kod/object/passive/spell/multicst.kod
+++ b/kod/object/passive/spell/multicst.kod
@@ -207,6 +207,12 @@ messages:
       local oRoom, oPrism;
 
       oPrism = Send(Self,@FindPrism,#who=who);
+      if oPrism = $
+      {
+         Send(who,@MsgSendUser,#message_rsc=multicast_no_prism);
+
+         return;
+      }
 
       Send(who,@StartEnchantment,#what=self,#state=[oPrism],#time=viDrainTime,
            #iSpellPower=iSpellPower,#lastcall=FALSE);

--- a/kod/object/passive/spell/multicst/hunt.kod
+++ b/kod/object/passive/spell/multicst/hunt.kod
@@ -29,7 +29,7 @@ resources:
       "periodic notification of the hunted player's whereabouts.  "
       "Requires all of the claws from one kriipa paw, and the casters' "
       "mystical energies must be focused through a prism."
-   
+
    Hunt_sound = khunt.wav
 
    hunt_cold_trail = "Your trail for %s%s seems to have gone cold."
@@ -43,8 +43,9 @@ resources:
 
    hunt_lost_trackers = "You seem to have managed to lose your trackers!"
    hunt_gain_trackers = "You sense that someone knows where you are..."
-   
-   hunt_must_be_murderer = "Sensing that the target's soul is unmarred, the spell fails."
+
+   hunt_must_be_murderer = \
+      "Sensing that the target's soul is unmarred, the spell fails."
 
 classvars:
 
@@ -61,35 +62,32 @@ classvars:
    viSpell_level = 5
 
    viSpellExertion = 50
-   viCast_time = 20000
+   viCast_time = 10000
    viChance_To_Increase = 50
 
    % Drain is amount used every viDrainTime milliseconds
    viManaDrain = 1
    % Drain some mana every viDrainTime milliseconds
-   viDrainTime = 1000    
+   viDrainTime = 1000
 
-   % in milliseconds
-   viCast_time = 10000    
-
-properties:                     
+properties:
 
    viMultiCast_Spellpower = 5000 
 
    % Spell is harmful to the player it's cast upon.
    viHarmful = TRUE
 
-messages:      
+messages:
 
-   Constructed()  
+   Constructed()
    {
       % Allow the spell on Sacred Haven.
-      if NOT Send(SYS,@IsPKAllowed) 
-      {        
-         viHarmful = FALSE;  
-      }  
-        
-      propagate;  
+      if NOT Send(SYS,@IsPKAllowed)
+      {
+         viHarmful = FALSE;
+      }
+
+      propagate;
    }
 
    ResetReagents()
@@ -99,8 +97,8 @@ messages:
 
       return;
    }
-  
-   PrismCast(spellpower = 0, lCasters=$, lTargets=$, oPrism = $) 
+
+   PrismCast(spellpower = 0, lCasters=$, lTargets=$, oPrism = $)
    {
       local i, oTarget;
 
@@ -114,7 +112,7 @@ messages:
          }
          return;
       }
-      
+
       for i in Send(oPrism,@GetCasters)
       {
          if i = oTarget
@@ -125,8 +123,8 @@ messages:
 
       Send(oTarget,@MsgSendUser,#message_rsc=hunt_gain_trackers);
       Send(oTarget,@StartEnchantment,#what=self,
-           #state=lCasters, #time=HUNT_TIME,
-           #iSpellPower=SpellPower,#lastcall=TRUE,#addicon=FALSE);
+            #state=lCasters,#time=HUNT_TIME,
+            #iSpellPower=SpellPower,#lastcall=TRUE,#addicon=FALSE);
 
       for i in lCasters
       {
@@ -134,7 +132,7 @@ messages:
       }
 
       Send(oTarget,@InformHunters);
-      
+
       return;
    }
 
@@ -146,10 +144,17 @@ messages:
       local oPrism;
 
       oPrism = Send(self,@FindPrism,#who=who);
+      if oPrism = $
+      {
+         Send(who,@MsgSendUser,#message_rsc=multicast_no_prism);
+
+         return;
+      }
 
       if Send(oPrism,@GetSpell) = $ AND lTargets = $
       {
          Send(who,@MsgSendUser,#message_rsc=hunt_no_target);
+
          return;
       }
 
@@ -174,8 +179,8 @@ messages:
       if oPrey <> $
       {
          % Use EVENT_STEER so we don't print message
-         Send(who,@breaktrance,#event=EVENT_STEER);  
-         lTargets = cons(oPrey,lTargets);
+         Send(who,@BreakTrance,#event=EVENT_STEER);
+         lTargets = Cons(oPrey,lTargets);
          Send(self,@CastSpell,#who=who,#lTargets=lTargets,
               #ispellpower=Send(self,@GetSpellPower,#who=who));
       }
@@ -198,7 +203,7 @@ messages:
          for i in state
          {
             Send(i,@MsgSendUser,#message_rsc=hunt_cold_trail,
-                 #parm1=Send(who,@GetDef),#parm2=Send(who,@GetUserName));
+                  #parm1=Send(who,@GetDef),#parm2=Send(who,@GetUserName));
          }
       }
 
@@ -210,7 +215,8 @@ messages:
       local state;
 
       state = Send(who,@GetEnchantedState,#what=self);
-      if isclass(first(state),&prism)
+
+      if IsClass(first(state),&prism)
       {
          Send(who,@SetTranceFlag);
       }
@@ -228,7 +234,6 @@ messages:
       % You cannot remove this spell by spells.
       return FALSE;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/multicst/shttrlck.kod
+++ b/kod/object/passive/spell/multicst/shttrlck.kod
@@ -22,26 +22,26 @@ resources:
    ShatterLock_name_rsc = "shatterlock"
    ShatterLock_icon_rsc = ishatlok.bgf
    ShatterLock_desc_rsc = \
-      "Penetrates the locks of a guild hall (note that it won't open other kinds "
-      "of doors elsewhere).  Requires Kriipa Claws to cast, and the casters' "
-      "energies must be focused through a prism."
+      "Penetrates the locks of a guild hall (note that it won't open other "
+      "kinds of doors elsewhere).  Requires four Kriipa Claws to cast, and "
+      "the casters' energies must be focused through a prism."
 
    Shatterlock_safety = \
-      "You must not have a guardian angel and must turn your safety OFF before "
-      "you cast this spell.  Note that you will marked as an outlaw as the result "
-      "of casting this spell."
+      "You must not have a guardian angel and must turn your safety OFF "
+      "before you cast this spell.  Note that you will marked as an outlaw "
+      "as the result of casting this spell."
 
    Shatterlock_outlaw = \
-      "NOTE: Casting this spell will mark you as an outlaw, even if you are not "
-      "successful in breaking into the hall.  Therefore, you must turn your "
-      "safety OFF before casting the spell."
+      "NOTE: Casting this spell will mark you as an outlaw, even if you are "
+      "not successful in breaking into the hall.  Therefore, you must turn "
+      "your safety OFF before casting the spell."
 
    ShatterLock_cast_complete = \
       "As you finish your incantation, the door to the guild hall opens!"
 
    ShatterLock_guildwarning = \
-      "You have a strange feeling that your guild hall's defenses are being "
-      "tampered with."
+      "You have a strange feeling that your guild hall's defenses are "
+      "being tampered with."
 
    ShatterLock_sound = kraanan.wav
 
@@ -53,20 +53,18 @@ classvars:
 
    vrSucceed_wav = ShatterLock_sound
 
-   viMana = 50         % Mana is amount used upon inititiation
+   viMana = 50         % Mana is amount used upon initiation
 
    viSpell_num = SID_SHATTERLOCK
    viSchool = SS_KRAANAN
    viSpell_level = 6
 
    viSpellExertion = 50
-   viCast_time = 20000
+   viCast_time = 2000
    viChance_To_Increase = 50
 
    viManaDrain = 1       % Drain is amount used every viDrainTime milliseconds
    viDrainTime = 1000    % Drain some mana every viDrainTime milliseconds
-
-   viCast_time = 2000    % in milliseconds
 
    viOutlaw = TRUE
    vbCastable_in_HappyLand = FALSE
@@ -101,6 +99,13 @@ messages:
       }
 
       oPrism = Send(self,@FindPrism,#who=who);
+      if oPrism = $
+      {
+         Send(who,@MsgSendUser,#message_rsc=multicast_no_prism);
+
+         return;
+      }
+
       if NOT IsClass(Send(oPrism,@GetOwner),&GuildHall)
       {
          return FALSE;
@@ -111,7 +116,8 @@ messages:
 
    GetTotalSpellPower(oPrism=$)
    {
-      local lMembers, iMembers, oGuild, oGuildHall, iMembersNotOnline, i, iReqSpellPower;
+      local lMembers, iMembers, oGuild, oGuildHall, iMembersNotOnline,
+            i, iReqSpellPower;
 
       oGuildHall = Send(oPrism,@GetOwner);
 


### PR DESCRIPTION
Hunt and Shatterlock can be cast without a prism on the ground if the spell is started with one present and the prism picked up before the focus time completes, causing errors due to no prism found.

Any call to FindPrism is now followed by a check for null return.

Also cleaned up the files a little.
