### PR TITLE
Spell Item Splitter owner checks

### DIFF
--- a/kod/object/item/passitem/spelitemsplit.kod
+++ b/kod/object/item/passitem/spelitemsplit.kod
@@ -98,7 +98,23 @@ messages:
       
       oNewItem = Create(cSacrificeClass,#iSpellpower=iSacrificeSpellPower);
       Send(oNewItem,@SetHits,#number=iNewHits);
-      Send(what,@NewHold,#what=oNewItem,#check_combine=FALSE); 
+      
+      If Send(sacrificed_item,@GetOwner) = what
+      {
+         Send(what,@NewHold,#what=oNewItem,#check_combine=FALSE);
+      }
+      else
+      {
+         If Send(sacrificed_item,@GetOwner) <> $
+            AND IsClass(Send(sacrificed_item,@GetOwner),&Room)
+         {
+            Send(Send(sacrificed_item,@GetOwner),@NewHold,#what=oNewItem,#new_row=Send(sacrificed_item,@GetRow),#new_col=Send(sacrificed_item,@GetCol));
+         }
+         else
+         {
+            Send(oNewItem,@Delete);
+         }
+      }
 
       If IsClass(what,&User)
       {


### PR DESCRIPTION
If the player is holding a spell item, it will split into his inventory.

If the spell item is on the floor in a room, it will split onto the
floor.

If it's not owned by a player or by a room, the new potion will delete
rather than go anywhere.

This solves a potential issue where players could hold limitless potions
by splitting a potion on the ground (which would then go to their inventory
with no weight checks)
