### PR TITLE
Mark of Dishonor & Max Vigor Bug fix

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1399,8 +1399,8 @@ messages:
       {
          piVigor_rest_threshold = 10;
       }
-      
-      piVigor_rest_threshold = Bound(piVigor_rest_threshold,10,100);
+
+      piVigor_rest_threshold = Bound(piVigor_rest_threshold,10,80 + ((Send(self,@GetSkillAbility,#skill_num=SKID_SECOND_WIND)+1)/5));
 
       Send(self,@DrawVigor);
 

--- a/kod/object/passive/spell/debuff/dishonor.kod
+++ b/kod/object/passive/spell/debuff/dishonor.kod
@@ -100,6 +100,7 @@ messages:
       if IsClass(oTarget,&Player)
       {
          iKarma = Send(oTarget,@GetKarma);
+         iVigorRestThresholdChange = 0;
 
          % Shal'ille only takes vigor from evil people.
          if iKarma < 0


### PR DESCRIPTION
Players have been using Mark of Dishonor cast on positive karma characters
to set their max vigor to 100 without having second wind. This fixes
Mark of Dishonor (which sent an undefined value for VigorThresholdChange
if the target is positive karma) and it also bounds max vigor based on
80 + second wind skill / 5 so no future bugs will ever break max vigor.
