### PR TITLE
RecreateAll/object references changes.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -632,6 +632,9 @@ messages:
          Send(poMaster,@RemoveControlledMinion,#what=self);
       }
 
+      % Clear reagent return list.
+      plSpellList = $;
+
       % If this monster is an 'Evil Twin', tell the original it was deleted.
       if poEvilTwinOriginal <> $
       {
@@ -5910,7 +5913,7 @@ messages:
       % that was cast on the monster.
       for i in plSpellList
       {
-         for j in send(i,@GetReagents)
+         for j in Send(Send(SYS,@FindSpellByNum,#num=i),@GetReagents)
          {
             oReagent = Create(First(j),#corpse=corpse,#number=Nth(j,2));
             lTreasureItems = Cons(oReagent,lTreasureItems);
@@ -6935,19 +6938,19 @@ messages:
       return;
    }
 
-   AddToSpellList(spellobject=$)
+   AddToSpellList(spellNum=$)
    {
       local i;
 
       for i in plSpellList
       {
-         if i = spellobject
+         if i = spellNum
          {
             return;
          }
       }
 
-      plSpellList = Cons(spellobject,plSpellList);
+      plSpellList = Cons(spellNum,plSpellList);
 
       return;
    }

--- a/kod/object/active/holder/room/monsroom/marcryp1.kod
+++ b/kod/object/active/holder/room/monsroom/marcryp1.kod
@@ -232,6 +232,12 @@ messages:
          return;
       }
 
+      % Don't cast it if no users present.
+      if NOT pbUser_in_room
+      {
+         return;
+      }
+
       oMartyr = send(SYS,@FindSpellByNum,#num=SID_MARTYRS_BATTLEGROUND);
       
       if Send(self,@IsEnchanted,#what=oMartyr)

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1518,9 +1518,12 @@ messages:
          oTarget = First(lTargets);
 
          % If the spell was cast on a monster, let the monster keep track of that for loot.
-         if IsClass(oTarget,&Monster) AND NOT bItemCast
+         if IsClass(oTarget,&Monster)
+            AND NOT bItemCast
+            AND who <> $
+            AND IsClass(who,&Player)
          {
-            Send(oTarget,@AddToSpellList,#spellobject=self);
+            Send(oTarget,@AddToSpellList,#spellNum=viSpell_num);
          }
       }
       else

--- a/kod/object/passive/spell/atakspel/illwound.kod
+++ b/kod/object/passive/spell/atakspel/illwound.kod
@@ -56,12 +56,20 @@ properties:
    pbAbsolute = TRUE
 
    % This is the spell we are simulating.
-   poRandomSpell = $
+   piRandomSpell = $
 
    % This is the list of spells we can choose from.
    plRandomSpells = $
 
 messages:
+
+   Constructor()
+   {
+      plRandomSpells = [ SID_BLAST_OF_FIRE, SID_SHOCKING_FURY,
+                         SID_EXPLOSIVE_FROST, SID_SPLASH_OF_ACID ];
+
+      propagate;
+   }
 
    ResetReagents()
    {
@@ -74,38 +82,36 @@ messages:
 
    CastSpell(who = $, lTargets = $, iSpellPower = 0, bItemCast = FALSE)
    {
-      local iDamage, iManaFocus, oRoom, oTarget, iDuration;
-
-      % Do this now when the spell is being cast.  If we do it in the Constructor,
-      %   these spells may not be available
-      if plRandomSpells = $
-      {
-         plRandomSpells = Cons(Send(SYS,@FindSpellByNum,#num=SID_BLAST_OF_FIRE),plRandomSpells);
-         plRandomSpells = Cons(Send(SYS,@FindSpellByNum,#num=SID_SHOCKING_FURY),plRandomSpells);
-         plRandomSpells = Cons(Send(SYS,@FindSpellByNum,#num=SID_EXPLOSIVE_FROST),plRandomSpells);
-         plRandomSpells = Cons(Send(SYS,@FindSpellByNum,#num=SID_SPLASH_OF_ACID),plRandomSpells);
-      }
+      local iDamage, iManaFocus, oRoom, oSpell, oTarget, iDuration;
 
       oTarget = First(lTargets);
 
       oRoom = Send(who,@GetOwner);
       Send(oRoom,@SpellCast,#who=who,#oSpell=self,#lItems=lTargets);
 
+      % Double check that we have a valid plRandomSpells list.
+      if plRandomSpells = $
+      {
+         plRandomSpells = [ SID_BLAST_OF_FIRE, SID_SHOCKING_FURY,
+                            SID_EXPLOSIVE_FROST, SID_SPLASH_OF_ACID ];
+      }
+
       % Only switch damage rarely so we get a clumpy effect
-      if random(1,100) < 50 OR poRandomSpell = $
+      if Random(1,100) < 50 OR piRandomSpell = $
       {
          % Okay, pick our damage type here.  Due to the miracles of single-threading,
          %  this will allow us to key the right damage type and spell name for
          %  illusionary wounds.
-         poRandomSpell = Nth(plRandomSpells,random(1,length(plRandomSpells)));
+         piRandomSpell = Nth(plRandomSpells,Random(1,Length(plRandomSpells)));
       }
 
-      Send(oRoom,@SomethingWaveRoom,#what=who,#wave_rsc=Send(poRandomSpell,@GetSpellSound));
+      oSpell = Send(SYS,@FindSpellByNum,#num=piRandomSpell);
+      Send(oRoom,@SomethingWaveRoom,#what=who,#wave_rsc=Send(oSpell,@GetSpellSound));
       Send(who,@MsgSendUser,#message_rsc=illusionarywounds_cast,
-           #parm1=Send(poRandomSpell,@GetName));
-      
+            #parm1=Send(oSpell,@GetName));
+
       iDuration = Send(self,@GetDuration,#iSpellPower=iSpellPower);
-      iDamage = Send(self,@GetHPLoss,#who=who,#victim=first(lTargets),#iSpellPower=iSpellPower);
+      iDamage = Send(self,@GetHPLoss,#who=who,#victim=First(lTargets),#iSpellPower=iSpellPower);
 
       if IsClass(who,&Player)
       {
@@ -135,8 +141,8 @@ messages:
       else
       {
          Send(oTarget,@StartEnchantment,#what=self,
-            #time=Send(self,@GetDuration,#iSpellPower=iSpellPower),
-            #lastcall=TRUE,#state=iDamage,#addicon=FALSE);
+               #time=Send(self,@GetDuration,#iSpellPower=iSpellPower),
+               #lastcall=TRUE,#state=iDamage,#addicon=FALSE);
       }
 
       Send(oRoom,@SomethingAttacked,#what=who,#victim=oTarget,#use_weapon=self);
@@ -150,7 +156,7 @@ messages:
          Send(oTarget,@AddToSpellList,#spellobject=self);
       }
 
-      if not bItemCast
+      if NOT bItemCast
       {
          Send(self,@ImproveAbility,#who=who,#target=oTarget);
       }
@@ -161,30 +167,30 @@ messages:
 
    GetAttackSpell()
    {
-      if poRandomSpell = $
+      if piRandomSpell = $
       {
          return $;
       }
-      
-      return Send(poRandomSpell,@GetAttackSpell);
+
+      return Send(Send(SYS,@FindSpellByNum,#num=piRandomSpell),@GetAttackSpell);
    }
 
    % This is for the attack message infrastructure.
    GetAttackName()
    {
-      if poRandomSpell = $
+      if piRandomSpell = $
       {
          return vrName;
       }
-      
-      return Send(poRandomSpell,@GetAttackName);
+
+      return Send(Send(SYS,@FindSpellByNum,#num=piRandomSpell),@GetAttackName);
    }
 
    % iFactor is the factor to divide damage by.
    GetHPLoss(who=$,victim=$,iSpellPower=0,iFactor=1)
    {
       local iBaseDamage, iHPLoss, iMaxHPs;
-   
+
       if IsClass(victim,&Player)
       {
          iBaseDamage = 17 + (50 - Send(victim,@GetIntellect))/10;
@@ -192,7 +198,7 @@ messages:
       }
       else
       {
-         iBaseDamage = 30 - bound(Send(victim,@GetDifficulty)*2,1,20);
+         iBaseDamage = 30 - Bound(Send(victim,@GetDifficulty)*2,1,20);
          iMaxHPs = Send(victim,@ReturnMaxHitPoints);
       }
 
@@ -206,8 +212,8 @@ messages:
       iHPLoss = iBaseDamage * iSpellPower / SPELLPOWER_MAXIMUM;
 
       % Always leaves 1 HP behind, no more than 1/3 damage.
-      iHPLoss = bound(iHPLoss,0,(iMaxHps*33));
-      iHPLoss = bound(iHPLoss,0,Send(victim,@GetExactHealth)-1);
+      iHPLoss = Bound(iHPLoss,0,(iMaxHps*33));
+      iHPLoss = Bound(iHPLoss,0,Send(victim,@GetExactHealth)-1);
 
       if iFactor > 1
       {
@@ -223,7 +229,7 @@ messages:
 
       % Get int damage bonus.
       iIntellect = Send(who,@GetIntellect);
-      iDamage = ((100+bound(iIntellect-25,0,40))*damage)/100;
+      iDamage = ((100+Bound(iIntellect-25,0,40))*damage)/100;
 
       return iDamage;
    }
@@ -231,16 +237,16 @@ messages:
    GetDuration(iSpellPower = 0)
    {
       local iDuration;
-      
+
       iDuration = 20000 + (iSpellPower * 750); 
-      iDuration = bound(iDuration,20000,80000);
-      
-      return iDuration;      
+      iDuration = Bound(iDuration,20000,80000);
+
+      return iDuration;
    }
 
    EndEnchantment(who = $, state=$, report = TRUE)
    {
-      post(self,@EndEnchantmentEffects,#who=who,#state=state,#report=report);
+      Post(self,@EndEnchantmentEffects,#who=who,#state=state,#report=report);
 
       return;
    }
@@ -256,10 +262,9 @@ messages:
             Send(who,@MsgSendUser,#message_rsc=illusionarywounds_off);
          }
       }
-      
-      return;
-   } 
 
+      return;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/atakspel/illwound.kod
+++ b/kod/object/passive/spell/atakspel/illwound.kod
@@ -153,7 +153,7 @@ messages:
       % for loot.
       if IsClass(oTarget,&Monster) AND NOT bItemCast
       {
-         Send(oTarget,@AddToSpellList,#spellobject=self);
+        Send(oTarget,@AddToSpellList,#spellnum=viSpell_num);
       }
 
       if NOT bItemCast

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -613,9 +613,18 @@ messages:
       Send(self,@RecreateRentableRoomMaintenance);
       Send(self,@RecreateSurvivalRoomMaintenance);
       Send(self,@RecreateWarEvent);
-      Send(self,@CreateAllSpellsIfNew);
-      Send(self,@CreateAllRoomsIfNew);
       Send(self,@RecreateEventEngine);
+
+      % These don't need to be done here.
+      % RecreateAllRooms calls CreateAllRoomsIfNew. Calling it again here
+      % duplicates every room (cleaned up on next system save).
+      % CreateAllSpellsIfNew is called by RecreateAllSpells in recreate phase 3,
+      % which was commented out. This was possibly because enchantments weren't
+      % being removed from players before deleting all the spells, though with
+      % so much change to the codebase since then it could have been some other
+      % bug we've since fixed.
+      %Send(self,@CreateAllSpellsIfNew);
+      %Send(self,@CreateAllRoomsIfNew);
 
       if plSavedFlagStates <> $
       {
@@ -679,7 +688,7 @@ messages:
       ptRecreateTimer = $;
       piRecreate_State = RECREATE_PHASE_THREE;
 
-      % Send(self,@RecreateAllSpells,#figure_totals=FALSE);
+      Send(self,@RecreateAllSpells,#figure_totals=FALSE);
 
       ptRecreateTimer = CreateTimer(self,@RecreateTimerPhaseFour,2000);
       piRecreate_state = RECREATE_WAITING;
@@ -3634,9 +3643,15 @@ messages:
    "Admin supported\n"
    "Deletes all spells and then calls CreateAllSpellsIfNew."
    "Figure_totals decides whether or not to recount the number of spells for "
-   "the advacnement object.  If in doubt, call it."
+   "the advancement object.  If in doubt, call it."
    {
       local i;
+
+      for i in plUsers
+      {
+         Send(i,@RemoveAllEnchantments,#report=FALSE);
+         Send(i,@RemoveAllRadiusEnchantments,#report=FALSE);
+      }
 
       for i in plSpells
       {


### PR DESCRIPTION
RecreateAllSpells should be called in Recreate phase 3 but was commented out. CreateAllSpellsIfNew and CreateAllRoomsIfNew were added to Recreate phase 1 but new rooms are already handled in RecreateAllRooms, and spells (should be) handled in RecreateAllSpells.

Possible reasons for commenting out RecreateAllSpells:
- Dangling spell object references from WA_SPELLCASTER weapon attributes (see #1017)
- Ditto for Illusionary Wounds spell imitation list (fixed here).
- Ditto for Marion Crypt 1 Martyr's Battleground, which would cast when the room is recreated (but before the spells are, fixed here).
- Enchantments on players referencing the old spell objects, keeping them alive (fixed here).
- Statistics for spell casts are stored in the spell object, these will get cleared.

Reasons to run RecreateAllSpells:
- Some changes we make require the spells to be rebuilt, I've been doing this manually.
- Anyone else using the codebase needs to watch my patch notes to check if I specify to run the command manually.
- Statistics for spell casts are sometimes no longer valid after we change a spell and probably should be reset.
- Spell list in system.kod is in a specific order (heavily referenced spells added at the end, so appear first in the list). Only creating new spells rather than all can change this order.
