### PR TITLE
Fix Meditate not returning mana in some cases.

### DIFF
--- a/kod/object/passive/spell/utility/meditate.kod
+++ b/kod/object/passive/spell/utility/meditate.kod
@@ -248,9 +248,12 @@ messages:
 
       iMana = Send(who,@GetMaxMana);
       iPercent = Send(self,@GetAbility,#who=who);
-      
-      Send(who,@GainMana,#amount=iMana*iPercent/100,
-            #bCapped=TRUE,#bRespectMax=TRUE);
+
+      if NOT Send(who,@IsCrystalizeManaSurging)
+      {
+         Send(who,@GainMana,#amount=iMana*iPercent/100,
+               #bCapped=TRUE);
+      }
       Send(who,@MsgSendUser,#message_rsc=Meditate_cast_finished);
 
       return;


### PR DESCRIPTION
Meditate wasn't returning mana if it put the player over their cap. Meditate now checks for CM active before giving mana, and works as before.
