### PR TITLE
Mana Bomb upgrades

### DIFF
--- a/kod/object/passive/spell/manabomb.kod
+++ b/kod/object/passive/spell/manabomb.kod
@@ -15,7 +15,7 @@ constants:
    include blakston.khd
 
    MANABOMB_RANGE = 6           %  max distance to enchantees 
-   MONSTER_EFFECT_TIME = 10000
+   MONSTER_BASE_EFFECT_TIME = 1000
 
 resources:
 
@@ -32,6 +32,9 @@ resources:
       "You feel mana being ripped from your body, burning "
       "itself out in a magical chain reaction."
    manabomb_hit_all = "All of your mana burns away in a magical chain reaction!"
+   
+   manabomb_took_enemy_mana = "%s cries out as your mana bomb burns %s spirit, leaving %s with ~b~B%i~B~n mana!"
+   manabomb_took_enemy_mana_all = "%s cries out as your mana bomb sears their spirit, leaving them bereft of mana!"
 
    manabomb_sound = kmbomb.wav
 
@@ -80,7 +83,7 @@ messages:
 
       oRoom = send(who,@GetOwner);
       lFinalTargets = Send(oRoom,@EnchantAllInRange,#what=self,
-                           #range=(6+iSpellpower/20),#center=who,#monsters=TRUE);
+                           #range=(MANABOMB_RANGE+(iSpellpower+1)/20),#center=who,#monsters=TRUE);
 
       return lFinalTargets;
    }
@@ -101,7 +104,7 @@ messages:
 
    CastSpell(who = $, lTargets = $, iSpellpower = 0)
    {
-      local oRoom, lEnchanted, iMana, i ;
+      local oRoom, lEnchanted, iMana, i, iManaLost;
       
       if isClass(who,&User)
       {
@@ -111,6 +114,12 @@ messages:
       else
       {
          iMana = iSpellPower/3;
+         
+         if who <> $
+            AND IsClass(who,&Monster)
+         {
+            iMana = iMana + (Send(who,@GetLevel)/4);
+         }
       }
       
       oRoom = Send(who,@GetOwner);
@@ -118,14 +127,27 @@ messages:
            #what=who,#parm1=send(who,@GetCapDef),#parm2=Send(who,@GetName));
 
       iMana = iMana / 2 ;
-      iMana = iMana + (iMana * iSpellPower)/100;
+      iMana = iMana + (iMana * (iSpellPower+1))/100;
 
       for i in lTargets
       {
-         if IsClass(i,&Player)
+         if IsClass(i,&User)
          {
-            Send(i,@LoseMana,#amount=iMana);
-            send(i,@BadSpellFlashEffect);
+            iManaLost = Send(i,@LoseMana,#amount=iMana);
+            If IsClass(who,&User)
+            {
+               if Send(i,@GetMana) = 0
+               {
+                  Send(who,@MsgSendUser,#message_rsc=manabomb_took_enemy_mana_all,#parm1=Send(i,@GetName));
+               }
+               else
+               {
+                  Send(who,@MsgSendUser,#message_rsc=manabomb_took_enemy_mana,#parm1=Send(i,@GetName),#parm2=Send(i,@GetHisHer),#parm3=Send(i,@GetHimHer),#parm4=Send(i,@GetMana));
+               }
+            }
+
+            Send(i,@BadSpellFlashEffect);
+
             if Send(i,@GetMana) = 0
             {
                Send(i,@MsgSendUser,#message_rsc=manabomb_hit_all);
@@ -139,7 +161,7 @@ messages:
          {
             % class is monster
             Send(i,@StartManaBomb);
-            Send(i,@StartEnchantment,#what=self,#time=MONSTER_EFFECT_TIME);
+            Send(i,@StartEnchantment,#what=self,#time=(MONSTER_BASE_EFFECT_TIME*iSpellPower));
          }
       }
 

--- a/kod/object/passive/spell/manabomb.kod
+++ b/kod/object/passive/spell/manabomb.kod
@@ -161,7 +161,7 @@ messages:
          {
             % class is monster
             Send(i,@StartManaBomb);
-            Send(i,@StartEnchantment,#what=self,#time=(MONSTER_BASE_EFFECT_TIME*iSpellPower));
+            Send(i,@StartEnchantment,#what=self,#time=Bound((MONSTER_BASE_EFFECT_TIME*iMana)/5,1000,35000));
          }
       }
 


### PR DESCRIPTION
Mana Bomb will now tell you how much mana the opponents you have hit
have remaining.

"Gar cries out as your mana bomb burns his spirit, leaving him with 45 mana!"

Monsters can now mana bomb for more mana depending on level/4.

Monsters that are hit by mana bombs will now cease spellcasting for 1
second per 5 mana bombed, up to 35 seconds.
Previously, they only stopped for ten seconds regardless of mana bomb
size.

http://openmeridian.org/forums/index.php/topic,269.0.html

http://wiki.openmeridian.org/index.php/Mana_Bomb_information_and_PvE_upgrades