### PR TITLE
Add a check for $ minion list when minions attack something.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -1554,7 +1554,8 @@ messages:
          % the caster himself. Other minions can attack the caster, to prevent
          % Seducing something just to kill it.
          lMinions = Send(poMaster,@GetControlledMinions);
-         if FindListElem(lMinions,what)
+         if (lMinions <> $
+               AND FindListElem(lMinions,what))
             OR (IsClass(self,&Reflection)
                AND what = poMaster)
          {


### PR DESCRIPTION
If a player has an evil twin cast, the evil twin will have a master but will not be on the player's minion list. This is expected behavior of evil twins because they usually attack only the initial target. This pull request adds a $ check for the minion list to prevent errors if there is no list.
