### PR TITLE
Persist for PvE radius enchants

### DIFF
--- a/kod/object/passive/spell/radiusench/jala/invigor.kod
+++ b/kod/object/passive/spell/radiusench/jala/invigor.kod
@@ -62,6 +62,7 @@ classvars:
    viMeditate_ratio = 10
 
    viAffectsEveryone = TRUE
+   viCasterPersist = TRUE
 
 properties:
 

--- a/kod/object/passive/spell/radiusench/jala/melcholy.kod
+++ b/kod/object/passive/spell/radiusench/jala/melcholy.kod
@@ -65,6 +65,7 @@ classvars:
    viMeditate_ratio = 20
 
    viAffectsEveryone = TRUE
+   viCasterPersist = TRUE
 
 properties:
 

--- a/kod/object/passive/spell/radiusench/jala/mirth.kod
+++ b/kod/object/passive/spell/radiusench/jala/mirth.kod
@@ -65,6 +65,7 @@ classvars:
    viMeditate_ratio = 20
 
    viAffectsEveryone = TRUE
+   viCasterPersist = TRUE
 
 properties:
 

--- a/kod/object/passive/spell/radiusench/jala/rejuven.kod
+++ b/kod/object/passive/spell/radiusench/jala/rejuven.kod
@@ -61,6 +61,7 @@ classvars:
    viMeditate_ratio = 50
 
    viAffectsEveryone = TRUE
+   viCasterPersist = TRUE
 
 properties:
 

--- a/kod/object/passive/spell/radiusench/jala/restorat.kod
+++ b/kod/object/passive/spell/radiusench/jala/restorat.kod
@@ -62,6 +62,7 @@ classvars:
    viMeditate_ratio = 20
 
    viAffectsEveryone = TRUE
+   viCasterPersist = TRUE
 
 properties:
 


### PR DESCRIPTION
Added Caster Persist = TRUE to mirth, melancholy, and the regeneration
spells. This means they'll stay active when the caster moves through
doors. Being mostly PvE spells, there's no real reason for the annoyance
of having these spells drop constantly.

This is especially annoying in CV, which has many same-zone doors.