### PR TITLE
Animate and Defile imp rate changes, lowered Animate cast time.

### DIFF
--- a/kod/object/passive/spell/animate.kod
+++ b/kod/object/passive/spell/animate.kod
@@ -27,11 +27,14 @@ resources:
    Animate_bad_target = "You can't cast animate on %s%s!"
    Animate_human_cast_rsc ="%s's corpse pulls itself up off the ground."
    Animate_human_failed_rsc ="%s's corpse remains inanimate on the ground."
-   Animate_mob_failed_rsc = "The %s's remains still lay lifeless and inanimate."
-   Animate_mob_cast_rsc = "The %s's remains come alive and rise up from the ground."
+   Animate_mob_failed_rsc = \
+      "The %s's remains still lay lifeless and inanimate."
+   Animate_mob_cast_rsc = \
+      "The %s's remains come alive and rise up from the ground."
    Animate_failed_rsc = "The remains are unable to be animated."
    Animate_too_many_rsc = "You are unable to control another minion."
-   Animate_failed_full_rsc = "There are too many monsters here to raise another."
+   Animate_failed_full_rsc = \
+      "There are too many monsters here to raise another."
 
    Animate_sound = qanimate.wav
 
@@ -47,14 +50,13 @@ classvars:
    viMana = 20
 
    viSpellExertion = 10
-   viCast_time = 20000
-   viChance_To_Increase = 75
-   viMeditate_ratio = 30
+   viCast_time = 10000
+   viChance_To_Increase = 20
+   viMeditate_ratio = 40
 
    vrSucceed_wav = Animate_sound
 
 properties:
-
 
 messages:
 
@@ -81,7 +83,8 @@ messages:
       if NOT IsClass(oTarget,&DeadBody)
       {
          Send(who,@MsgSendUser,#message_rsc=Animate_bad_target,
-               #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
+               #parm1=Send(oTarget,@GetDef),
+               #parm2=Send(oTarget,@GetName));
 
          return FALSE;
       }
@@ -99,8 +102,9 @@ messages:
 
          return FALSE;
       }
-      
-      if Send(who,@CheckPlayerMinionCount) >= Send(Send(SYS,@GetSettings),@GetPlayerMinionLimit)
+
+      if Send(who,@CheckPlayerMinionCount)
+            >= Send(Send(SYS,@GetSettings),@GetPlayerMinionLimit)
       {
          Send(who,@MsgSendUser,#message_rsc=Animate_too_many_rsc);
 
@@ -130,7 +134,7 @@ messages:
    CastSpell(who=$,lTargets=$,iSpellPower=1)
    {
       local oRisen, oRoom, iRow, iCol, iFine_Row, iFine_Col,
-            oTarget, iLevel, iNum, iDurationSecs;
+            oTarget, iLevel, iNum;
 
       oRoom = Send(who,@GetOwner);
       oTarget = First(lTargets);
@@ -193,9 +197,6 @@ messages:
          }
       }
 
-      iDurationSecs = ( ((iSpellPower/2) + Random(25,50))
-                           * MAX_RISEN_CONTROL_SECS/100 );
-
       % Add this creature to your minion list
       Send(who,@NewControlledMinion,#minion=oRisen);
 
@@ -204,7 +205,7 @@ messages:
       Send(self,@ModifyMonsterBehavior,#mob=oRisen);
 
       % Post this due to it needing to be done after the minion is placed.
-      Post(oRisen,@SetMaster,#oMaster=who,#DurationSecs=iDurationSecs);
+      Post(oRisen,@SetMaster,#oMaster=who);
 
       % Place the minion
       Send(oRoom,@NewHold,#what=oRisen,#new_row=iRow,#new_col=iCol,

--- a/kod/object/passive/spell/defile.kod
+++ b/kod/object/passive/spell/defile.kod
@@ -22,12 +22,13 @@ resources:
       "summoned to defile a corpse, "
       "transforming flesh and blood into magical energy for "
       "the caster.  "
-      "Requires fairy wings and the slain."
+      "Requires a fairy wing and the slain."
 
    defile_cast_rsc = "Your nausea betokens the imminence of Qor."
 
    defile_corpse_gone = \
-      "Your defile spell fails because the corpse has already returned to the earth."
+      "Your defile spell fails because the corpse has already "
+      "returned to the earth."
 
    defile_max = \
       "If you were to invite more eldritch energy inside of you, there is no "
@@ -50,7 +51,7 @@ classvars:
    viMana_bonus = 10
 
    viCast_time = 10000
-   viChance_to_Increase = 100
+   viChance_to_Increase = 25
    viMeditate_ratio = 30
 
    vrSucceed_wav = defile_sound
@@ -78,7 +79,7 @@ messages:
    CanPayCosts(who=$,lTargets=$)
    {
       local target, i;
-      
+
       % Can cast spell if the 1 target item is a corpse
       if Length(lTargets) <> 1
       {
@@ -97,7 +98,7 @@ messages:
 
       if NOT Send(target,@WasGoodPlayer)
       {
-         Send(who,@MsgSendUser,#message_rsc=defile_not_good);           
+         Send(who,@MsgSendUser,#message_rsc=defile_not_good);
 
          return FALSE;
       }
@@ -124,26 +125,27 @@ messages:
       {
          if abs(Send(who,@GetKarma)) < (iSpellpower + 1)
          {
-            iKarmaAct = bound(iKarmaAct,abs(Send(who,@GetKarma)),iSpellpower+1);
+            iKarmaAct = Bound(iKarmaAct,Abs(Send(who,@GetKarma)),iSpellpower+1);
          }
          else
          {
-            iKarmaAct = abs(send(who,@GetKarma));
+            iKarmaAct = Abs(Send(who,@GetKarma));
          }
 
-         Send(who,@AddKarma,#amount=send(who,@CalculateKarmaChangeFromAct,
-                            #karma_act=-iKarmaAct,#karma_doer=send(who,@GetKarma),#swing_factor=4));
+         Send(who,@AddKarma,#amount=Send(who,@CalculateKarmaChangeFromAct,
+               #karma_act=-iKarmaAct,
+               #karma_doer=Send(who,@GetKarma),#swing_factor=4));
       }
 
       Send(who,@MsgSendUser,#message_rsc=defile_cast_rsc);
       Send(who,@GainMana,#amount=(viMana_bonus+(iSpellPower/3)));
-      
+
       % Don't let them defile to over-max
       if Send(who,@GetMana) > Send(who,@GetMaxMana)
       {
          Send(who,@LoseMana,#amount=(Send(who,@GetMana)-Send(who,@GetMaxMana)));
       }
-      
+
       Send(oTarget,@Delete);
 
       propagate;


### PR DESCRIPTION
Forum thread: http://openmeridian.org/forums/index.php/topic,246.0.html

Animate chance to increase lowered from 75 to 20, meditate ratio raised from 30 to 40 and cast time lowered from 20 sec to 10 sec base. Removed unused duration code.

Defile chance to increase lowered from 100 to 25. Already has 10 sec cast time.

Both cast times are now in line with Portal of Life. Improve rates were artificially high due to errors with improving these spells that have already been fixed.
