### PR TITLE
Allow BP_REQ_USE to show reagent bag contents.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -138,6 +138,7 @@ resources:
    player_use_full_hands = "Your hands are too full to use that."
    player_not_using = "You are not using that."
    player_not_holding = "You are not even holding %s%s."
+   player_regbag_empty = "The reagent bag is empty."
    
    player_hit_color_red = "~r"
    player_hit_color_blue = "~b"
@@ -3677,6 +3678,20 @@ messages:
               #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName));
 
          return FALSE;
+      }
+
+      if IsClass(what,&ReagentBag)
+      {
+         if Send(what,@GetReagentBagContents) = $
+         {
+            Send(self,@MsgSendUser,#message_rsc=player_regbag_empty);
+
+            return FALSE;
+         }
+
+         Send(self,@UserObjectContents,#what=what);
+
+         return TRUE;
       }
 
       iUse_type = Send(what,@GetItemUseType);


### PR DESCRIPTION
Allows fast showing of contents for the old client by highlighting in inventory and pressing 'u', and allows the action bar of the new client to open it.
