### PR TITLE
Code for simulated attacks and casts for testing player combat/spellcasting.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -423,6 +423,7 @@ messages:
       return iCastPower;
    }
 
+
    %%% Mana related stuff common to players and mobs.
 
    GetMaxMana()
@@ -527,10 +528,12 @@ messages:
       return;
    }
 
-   SimulateAttack(what=$,numAttack=1)
+   SimulateAttack(what=$,numAttack=1,iOffense=$,iDefense=$)
+   "Simulate 'numAttack' attacks from 'self' against 'what'. Can pass offense "
+   "and defense as iOffense and iDefense."
    {
       local iMiss, iHit, iHitDmg, iMin, iMax, use_weapon, stroke_id,
-            iChanceToHit, iDamage,iScalefactor, stroke_obj, iOffense, iDefense;
+            iChanceToHit, iDamage,iScalefactor, stroke_obj;
 
       iMiss = 0;
       iHit = 0;
@@ -564,8 +567,14 @@ messages:
       {
          % This is the generic checks and the calculation of chance
          % to hit and damage.
-         iDefense = Send(what,@GetDefense,#what=self,#stroke_obj=stroke_obj);
-         iOffense = Send(self,@GetOffense,#what=what,#stroke_obj=stroke_obj);
+         if iDefense = $
+         {
+            iDefense = Send(what,@GetDefense,#what=self,#stroke_obj=stroke_obj);
+         }
+         if iOffense = $
+         {
+            iOffense = Send(self,@GetOffense,#what=what,#stroke_obj=stroke_obj);
+         }
 
          iChanceToHit = (iOffense* EQUAL_CHANCE_HIT) / iDefense;
          iChanceToHit = bound(iChanceToHit,125,2000);
@@ -583,8 +592,9 @@ messages:
             }
 
             iDamage = Send(what,@SimulateDamage,#what=self,#damage=iDamage,
-               #atype=Send(self,@GetDamageType),#aspell=Send(self,@GetSpellType),
-               #scalefactor=iScalefactor);
+                           #atype=Send(self,@GetDamageType),
+                           #aspell=Send(self,@GetSpellType),
+                           #scalefactor=iScalefactor);
             iHitDmg = iHitDmg + iDamage;
             iHit = iHit + 1;
             if iDamage > iMax

--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -527,6 +527,92 @@ messages:
       return;
    }
 
+   SimulateAttack(what=$,numAttack=1)
+   {
+      local iMiss, iHit, iHitDmg, iMin, iMax, use_weapon, stroke_id,
+            iChanceToHit, iDamage,iScalefactor, stroke_obj, iOffense, iDefense;
+
+      iMiss = 0;
+      iHit = 0;
+      iHitDmg = 0;
+      iMin = 100;
+      iMax = 0;
+
+      % Get use_weapon
+      use_weapon = Send(self,@GetWeapon);
+
+      if (use_weapon = $) OR IsClass(use_weapon,&Spell)
+      {
+         stroke_id = SKID_PUNCH;
+      }
+      else
+      {
+         stroke_id = Send(use_weapon,@GetDefaultStrokeNumber);
+      }
+
+      if use_weapon = $ OR NOT IsClass(use_weapon,&Spell)
+      {
+         stroke_obj = Send(SYS,@FindSkillByNum,#num=stroke_id);
+      }
+      else
+      {
+         % Use the "weapon" (spell) as the stroke object.
+         stroke_obj = use_weapon;
+      }
+
+      while numAttack > 0
+      {
+         % This is the generic checks and the calculation of chance
+         % to hit and damage.
+         iDefense = Send(what,@GetDefense,#what=self,#stroke_obj=stroke_obj);
+         iOffense = Send(self,@GetOffense,#what=what,#stroke_obj=stroke_obj);
+
+         iChanceToHit = (iOffense* EQUAL_CHANCE_HIT) / iDefense;
+         iChanceToHit = bound(iChanceToHit,125,2000);
+         if iChanceToHit >= random(1,1000)
+         {
+            % We hit!
+            iDamage = Send(self,@GetDamage,#what=what,#stroke_obj=stroke_obj);
+            iScalefactor = 1000;
+
+            % Scale damage with chance to hit beyond 100 percent.
+            if iChanceToHit > 1000 AND Send(Send(SYS,@GetSettings),
+                                             @GetDamageScaling)
+            {
+               iScalefactor = iChanceToHit;
+            }
+
+            iDamage = Send(what,@SimulateDamage,#what=self,#damage=iDamage,
+               #atype=Send(self,@GetDamageType),#aspell=Send(self,@GetSpellType),
+               #scalefactor=iScalefactor);
+            iHitDmg = iHitDmg + iDamage;
+            iHit = iHit + 1;
+            if iDamage > iMax
+            {
+               iMax = iDamage;
+            }
+            if iDamage < iMin
+            {
+               iMin = iDamage;
+            }
+         }
+         else
+         {
+            % Miss. Log it.
+            iMiss = iMiss + 1;
+         }
+         numAttack = numAttack - 1;
+      }
+
+      Debug("Number of attacks is ",iHit+iMiss," and average damage is ",
+            iHitDmg/(iHit+iMiss),". Max damage was ",iMax," and min damage ",
+            iMin,". ",Send(what,@GetTrueName)," had ",iDefense," defense and ",
+            Send(self,@GetTrueName)," had ",iOffense," offense. Hit percentage",
+            " was ",(iHit*100)/(iHit+iMiss)," percent.");
+
+      return;
+   }
+
    %%% Combat functionality.
 
    % This does one attack by the battler.

--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -423,7 +423,6 @@ messages:
       return iCastPower;
    }
 
-
    %%% Mana related stuff common to players and mobs.
 
    GetMaxMana()
@@ -528,12 +527,12 @@ messages:
       return;
    }
 
-   SimulateAttack(what=$,numAttack=1,iOffense=$,iDefense=$)
-   "Simulate 'numAttack' attacks from 'self' against 'what'. Can pass offense "
+   SimulateAttack(what=$,numAttacks=1,iOffense=$,iDefense=$)
+   "Simulate 'numAttacks' attacks from 'self' against 'what'. Can pass offense "
    "and defense as iOffense and iDefense."
    {
       local iMiss, iHit, iHitDmg, iMin, iMax, use_weapon, stroke_id,
-            iChanceToHit, iDamage,iScalefactor, stroke_obj;
+            iChanceToHit, iDamage,iScalefactor, stroke_obj, iFracDmg;
 
       iMiss = 0;
       iHit = 0;
@@ -563,22 +562,23 @@ messages:
          stroke_obj = use_weapon;
       }
 
-      while numAttack > 0
+      % This is the generic checks and the calculation of chance
+      % to hit and damage.
+      if iDefense = $
       {
-         % This is the generic checks and the calculation of chance
-         % to hit and damage.
-         if iDefense = $
-         {
-            iDefense = Send(what,@GetDefense,#what=self,#stroke_obj=stroke_obj);
-         }
-         if iOffense = $
-         {
-            iOffense = Send(self,@GetOffense,#what=what,#stroke_obj=stroke_obj);
-         }
+         iDefense = Send(what,@GetDefense,#what=self,#stroke_obj=stroke_obj);
+      }
+      if iOffense = $
+      {
+         iOffense = Send(self,@GetOffense,#what=what,#stroke_obj=stroke_obj);
+      }
 
-         iChanceToHit = (iOffense* EQUAL_CHANCE_HIT) / iDefense;
-         iChanceToHit = bound(iChanceToHit,125,2000);
-         if iChanceToHit >= random(1,1000)
+      iChanceToHit = (iOffense* EQUAL_CHANCE_HIT) / iDefense;
+      iChanceToHit = Bound(iChanceToHit,125,2000);
+
+      while numAttacks > 0
+      {
+         if iChanceToHit >= Random(1,1000)
          {
             % We hit!
             iDamage = Send(self,@GetDamage,#what=what,#stroke_obj=stroke_obj);
@@ -611,11 +611,12 @@ messages:
             % Miss. Log it.
             iMiss = iMiss + 1;
          }
-         numAttack = numAttack - 1;
+         numAttacks = numAttacks - 1;
       }
 
-      Debug("Number of attacks is ",iHit+iMiss," and average damage is ",
-            iHitDmg/(iHit+iMiss),". Max damage was ",iMax," and min damage ",
+      iFracDmg = (iHitDmg * 10 * (iHit)) MOD 10;
+      GodLog("Number of attacks is ",iHit+iMiss," and average damage per swing is ",
+            iHitDmg/(iHit+iMiss),".",iFracDmg,". Max damage was ",iMax," and min damage ",
             iMin,". ",Send(what,@GetTrueName)," had ",iDefense," defense and ",
             Send(self,@GetTrueName)," had ",iOffense," offense. Hit percentage",
             " was ",(iHit*100)/(iHit+iMiss)," percent.");

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5156,7 +5156,6 @@ messages:
             damage = Send(i,@ModifyDefenseDamage,#who=self,
                            #what=what,#damage=damage,
                            #atype=atype,#aspell=aspell);
-            Send(i,@DefendingHit,#who=self,#what=what);
          }
 
          iResistance = Send(self,@ResistanceCheck,#atype=atype,#aspell=aspell);

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5132,6 +5132,90 @@ messages:
       propagate;
    }
 
+   % Simulated attack damage
+   SimulateDamage(what=$,damage=$,atype=0,aspell=0,bonus=0,scalefactor=1000,
+               absolute=FALSE)
+   {
+      local i, iResistance, oSoldierShield, oGort, iLimit, origdamage;
+
+      origdamage = damage;
+
+      if NOT absolute
+      {
+         % Armor of Gort has a special effect that must go first
+         oGort = Send(SYS,@FindSpellByNum,#Num=SID_ARMOR_OF_GORT);
+         if Send(self,@IsEnchanted,#what=oGort)
+         {
+            damage = Send(oGort,@PriorityModifyDefenseDamage,#who=self,
+                           #what=what,#damage=damage,
+                           #atype=atype,#aspell=aspell);
+         }
+
+         for i in plDefense_modifiers
+         {
+            damage = Send(i,@ModifyDefenseDamage,#who=self,
+                           #what=what,#damage=damage,
+                           #atype=atype,#aspell=aspell);
+            Send(i,@DefendingHit,#who=self,#what=what);
+         }
+
+         iResistance = Send(self,@ResistanceCheck,#atype=atype,#aspell=aspell);
+
+         for i in plRadiusEnchantments
+         {
+            iResistance = Send(Nth(i,1),@ModifyResistance,#attacker=what,
+                  #atype=atype,#iPower=Nth(i,2),
+                  #caster=Nth(i,3),#resistance=iResistance);
+         }
+
+         damage = Send(self,@GetDamageFromResistance,
+                        #what=damage,#value=iResistance);
+
+         % Add attmods AFTER resistance/suscep mods.
+         damage = damage + bonus;
+
+         damage = damage * scalefactor / 1000;
+      }
+
+      if NOT absolute and damage <= 0
+      {
+         damage = 1;
+      }
+
+      if NOT absolute
+      {
+         % If we have more health than twice our max, no percent limit on damage.
+         % If we are outlaw or murderer, no percent limit on damage.
+         if piHealth < (piBase_Max_Health * 2)
+            AND ((NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
+               AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER))
+               OR Send(Send(SYS,@GetSettings),@DamageCapProtectionMurderersEnabled))
+         {
+            % Cap damage to 1/3 of max health (+2 so we "round up")
+            iLimit = (piBase_Max_Health + (MAX_HEALTH_DAMAGE_FRACTION-1))
+                                             / MAX_HEALTH_DAMAGE_FRACTION;
+            damage = Bound(damage,$,iLimit);
+         }
+
+         % maximum of 30 damage per hit.
+         damage = bound(damage,$,MAX_DAMAGE_PER_HIT);
+      }
+
+      % Faction enemies an extra 15% damage to each other, above caps.
+      if what <> $ AND IsClass(what,&Player)
+      {
+         oSoldierShield = Send(what,@FindUsing,#class=&SoldierShield,
+                                 #damage=TRUE);
+         if oSoldierShield <> $
+            AND Send(oSoldierShield,@IsEnemyAttack,#what=self,#damage=TRUE)
+         {
+            damage = (damage * 115)/100;
+         }
+      }
+
+      return damage;
+   }
+
    % Handles damage done to player
    AssessDamage(what=$,damage=$,atype=0,aspell=0,stroke_obj=$,bonus=0,
             scalefactor=1000,report=TRUE,report_resistance=TRUE,absolute=FALSE)

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1323,6 +1323,103 @@ messages:
       return TRUE;
    }
 
+   SimulateCast(numCasts=1,who=$,iSpellpower=$,oTarget=$)
+   "Simulates the casting of a spell from 'who', at spellpower 'iSpellPower', "
+   "on 'oTarget'. Casts the spell 'numCasts' times."
+   {
+      local iFizzle, iNum, iStat, iSuccess, iSuccessDec, iSuccessPerc, oRoom,
+            lJalaInfo, oJalaSpell, lJalaState, iDistance, i;
+
+      if who = $ OR oTarget = $
+      {
+         Debug("Bad parameters sent to SimulateCast.");
+
+         return FALSE;
+      }
+
+      oRoom = Send(who,@GetOwner);
+      if oRoom = $
+      {
+         Debug("Caster needs to be logged on to use SimulateCast!");
+
+         return FALSE;
+      }
+
+      if NOT Send(oTarget,@IsLoggedOn)
+      {
+         Debug("Target needs to be logged on to use SimulateCast!");
+
+         return FALSE;
+      }
+
+      if iSpellpower = $
+      {
+         iSpellPower = Send(self,@GetSpellpower,#who=who);
+      }
+
+      iSuccess = 0;
+      iFizzle = 0;
+      iStat = Send(self,@GetRequisiteStat,#who=who);
+      iNum = ((100-iStat)*iSpellpower/100) + iStat;
+
+      if Send(who,@IsAffectedByRadiusEnchantment,#byClass=&HinderSpell)
+      {
+         for i in Send(who,@GetRadiusEnchantments)
+         {
+            iNum = Send(Nth(i,1),@GetAlteredChance,#chance=iNum,
+                        #what=self,#lRadiusState=i);
+         }
+      }
+
+      iNum = Bound(iNum,5,99);
+
+      if NOT Send(oRoom,@LineOfSight,#obj1=who,#obj2=oTarget)
+      {
+         iDistance = Send(who,@SquaredDistanceTo,#what=oTarget);
+         iDistance = iDistance / 4;
+         if iDistance > iNum / 2
+         {
+            iNum = iNum / 2;
+         }
+         else
+         {
+            if iDistance < iNum / 2
+            {
+               iNum = iNum - iDistance;
+            }
+         }
+      }
+
+      % At this point SuccessChance just rolls iNum vs. random 1-100.
+      while numCasts > 0
+      {
+         if Random(1,100) > iNum
+         {
+            % This is a spell fail. Record the fizzle.
+            iFizzle = iFizzle + 1;
+         }
+         else
+         {
+            % We cast! Record it.
+            iSuccess = iSuccess + 1;
+         }
+         numCasts = numCasts - 1;
+      }
+
+      % Successful cast percent.
+      iSuccessPerc = iSuccess*100/(iSuccess+iFizzle);
+      % Two decimal places.
+      iSuccessDec = iSuccess*10000/(iSuccess+iFizzle) MOD 100;
+      GodLog("Number of casts is ",iSuccess+iFizzle,". Caster ",
+            Send(who,@GetTrueName)," had ",iSpellPower," spellpower. ",
+            Send(self,@GetName),"cast successfully on ",
+            Send(oTarget,@GetTrueName)," ",iSuccessPerc,".",iSuccessDec,
+            " percent of the time. ",iSuccess," successes and ",
+            iFizzle," fizzles.");
+
+      return;
+   }
+
    PayCosts(who=$,iSpellpower=0,lTargets=$)
    "Check for failed spell here.  A failed spell costs half the mana cost, "
    "half the exertion, and no reagents."


### PR DESCRIPTION
SimulateAttack will simulate an attack between two players a given number of times, and log the results to the GodLog. Records number of successful hits and misses, min damage, max damage, average damage per swing (damage per second), attacker offense and target defense, and percentage of hits landed. Can be passed number of attacks, attacker, target, offense and defense as parameters (will use the combatants' offense and defense if none given). Combatants do not need to be logged in to run this.

Also included is SimulateCast, which simulates the casting of a spell on a target by an attacker. Can also take spellpower and number of casts as parameters. Returns the number of successful casts and fizzles, the percentage of successful casts and the spellpower. Both combatants need to be logged on for this to run.

SimulateDamage in player.kod is required for SimulateAttack to work (but should not be called independently).

Intended for use on 104.
