### PR TITLE
Timer fix for teleporting monsters.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -917,6 +917,15 @@ messages:
          propagate;
       }
 
+      % Mobs can change owner, i.e. wanderers. This lets them react properly
+      % to leaving a room with users and arriving in a room without them.
+      if poOwner <> $
+         AND Send(poOwner,@IsUserInRoom)
+         AND NOT Send(what,@IsUserInRoom)
+      {
+         Post(self,@LastUserLeft);
+      }
+
       if Send(what,@IsUserInRoom)
       {
          Send(self,@StartBasicTimers);


### PR DESCRIPTION
Wandering NPCs who teleport from a screen with users to a screen without them were reacting as if users were still on screen, and causing some timer issues. This allows the appropriate actions to be taken by the mob if there are no users on their new screen, i.e. clearing timers and resetting conditional sale items (none currently in for wandering NPCs but this will work now).
