### PR TITLE
Beta Potions 2.0

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2164,6 +2164,7 @@
    PFLAG2_SQUELCHED_POSTS  = 0x001000
    % Sum of the other squelched flags.
    PFLAG2_SQUELCHED_ALL    = 0x001E00
+   PFLAG2_BETA_POTION      = 0x002000
 
    % Set of flags just for DM's
    % DM is completely invisible

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -685,6 +685,8 @@ resources:
       "Fair partings, and perhaps we will someday meet at the court."
       "\n\n"
       "----Baron of Cor Noth Township, Gerah Springer."
+      
+   player_Debug_playerlearnpoints = "%i out of %i learn points used."
 
    player_Debug_playercanlearn = \
       "Do the math for %s to learn a %i level spell from the %s school.  "
@@ -13158,6 +13160,11 @@ messages:
 
       if type = SAY_NORMAL AND IsClass(what,&Player)
       {
+         if what = self AND Send(self,@CheckPlayerFlag,#flag=PFLAG2_BETA_POTION,#flagset=2)
+         {
+            send(self,@BetaPotionSay,#string=string);
+         }
+         
          % si: removed (and what <> self) to allow communication
          % between shrunken head and owner.
          oSnoop = Send(self,@FindHolding,#class=&ShrunkenHead);
@@ -14170,6 +14177,76 @@ messages:
 
       return;
    }
+
+  BetaPotionSay(string = $)
+  {
+      local iSchool, iLevel, iAbility, iLearnPoints, iMaxLearnPoints, oLore;
+
+      oLore = Send(SYS,@GetLore);
+      if Send(oLore,@BetaPotionsEnabled) AND Send(Send(SYS,@GetParliament),@BetaPotionsEnabled)  
+         OR Send(SYS, @GetChaosNight)
+      {
+         iLearnPoints = 0;
+         iMaxLearnPoints = Send(Send(SYS, @GetSettings), @GetMaxLearnPoints) + 
+            (Send(self,@GetRawIntellect) * 2) / 5;
+
+         iSchool = send(oLore,@BetaPotionCheckSchool,#string=string);
+         iLevel = send(oLore,@BetaPotionCheckLevel,#string=string);
+         
+         % Default percentage we give for all spells and skills
+         iAbility = 99;
+
+         if iSchool <> 0 AND iLevel <> 0
+         {
+            % 10 is used for weaponcraft
+            if iSchool = SKS_FENCING
+            {
+               send(self,@GivePlayerAllSkills,#school=iSchool,#level=iLevel,#iability=iAbility,#upto=TRUE);
+            }
+            else
+            {
+               if iSchool = SS_SHALILLE
+               {
+                  % Can't add Shal'ille when already has Qor.
+                  if Send(self,@GetNumSpellsInSchool,#school=SS_QOR) 
+                  {
+                     return FALSE;
+                  }
+ 				 
+ 				   piKarma = MAX_GOOD * 100;
+ 				   Send(self,@NewKarma);
+ 			      }
+
+               if iSchool = SS_QOR
+               {
+                  % Can't add Qor when already has Shal'ille.
+                  if Send(self,@GetNumSpellsInSchool,#school=SS_SHALILLE) 
+                  {
+                     return FALSE;
+                  }
+
+                  piKarma = MAX_EVIL * 100;
+                  Send(self,@NewKarma);
+               }
+            }
+            send(self,@GivePlayerAllSpells,#school=iSchool,#level=iLevel,#iability=iAbility,#upto=TRUE);
+            iLearnPoints = Send(self,@GetTotalLearnPoints,#except=0);
+            send(self,@MsgSendUser,#message_rsc=player_Debug_playerlearnpoints,#parm1=iLearnPoints,#parm2=iMaxLearnPoints);
+         }
+
+ 		   % iLearnPoints should always equal iMaxLearnPoints,
+ 		   % only time it will go over if it is a DM
+ 		   if iLearnPoints >= iMaxLearnPoints
+ 		   {
+ 			   % Give reagents for spells
+ 			   Post(self,@AddReagentsForSpells,#iNumCasts=5);
+ 			 
+ 			   Send(self,@SetPlayerFlag,#flag=PFLAG2_BETA_POTION,#value=FALSE,#flagset=2);
+ 			   return TRUE;
+ 		   }
+      }
+      return;
+  }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/betap.kod
+++ b/kod/object/item/passitem/betap.kod
@@ -29,14 +29,14 @@ resources:
        "The size of the boost is directly related to how much time your "
        "character has spent online.  Thus, beta testers who have devoted "
        "more to the game have been rewarded greater.  "
-       "It will also give you all the spells up to level "
-   BetaPotion_Append4_rsc = " in the "
-   BetaPotion_Append5_rsc = " school of magic, limited by your Intellect.\n\n"
+       "Once you drink the potion, you can also select your schools of magic"
+       "by saying the name of the schools and the levels you wish to receive. "
+       "Limited by your Intellect you will only receive a certain amount of "
+       "points before the potion effect wears off.\n\n"
        "If you lose the potion in any way, shape or form (including if you give "
        "it to a friend and s/he quaffs it, or you step through the portal in "
        "Raza, or your little sister suicides your character just to spite you), "
-       "or you didn't get a potion in the school you wanted and threw it away, "
-       "you will NOT get another potion.  So don't ask.\n\n"
+       "or you just threw it away, you will NOT get another potion.  So don't ask.\n\n"
          
    BetaPotion_gulp_sound = drkptn.wav
 
@@ -45,6 +45,11 @@ resources:
    BetaPotion_bad_drink = \
       "You choke down the foul-tasting contents of the vial, realizing almost "
       "immediately that this was a pretty bad idea. Time has caused it to sour."
+      
+   BetaPotion_select_schools = \
+      "Add your schools until you are out of points. Say one of the following:\n"
+      "~B\"[SHAL'ILLE, QOR, KRAANAN, FAREN, RIIJA, JALA, WEAPONCRAFT]\"~n "
+      "followed by ~B\"LEVEL [ONE, TWO, THREE, FOUR, FIVE, SIX]\""
 
 classvars:
    
@@ -68,18 +73,14 @@ properties:
    piGoBadTime = 0
    piItem_flags = PT_GRAY_TO_RED
 
-   piSchool = 0
-   piLevel = 0
    piHealth = 0
    piHealthCap = 100
    pbGiveHealth = FALSE
 
 messages:
 
-   Constructor(school=SS_FAREN, level = 0, health = 0, giveHealth = FALSE, healthCap = 100)
+   Constructor(health = 0, giveHealth = FALSE, healthCap = 100)
    {
-      piSchool = school;
-      piLevel = level;
       piHealth = health;
       piHealthCap = healthCap;
       pbGiveHealth = giveHealth;
@@ -105,22 +106,6 @@ messages:
       AppendTempString(BetaPotion_Append2_rsc);
       AppendTempString(piHealthCap);
       AppendTempString(BetaPotion_Append3_rsc);
-      AppendTempString(piLevel);
-      AppendTempString(BetaPotion_Append4_rsc);
-      
-      if piSchool >= SKS_FENCING
-      {
-         % Any skill will do.
-         oSpellOrSkill = Send(SYS,@FindSkillByNum,#num=SKID_PUNCH); 
-      }
-      else
-      {
-         % Any spell will do.
-         oSpellOrSkill = Send(SYS,@FindSpellByNum,#num=SID_BONK); 
-      }
-      
-      AppendTempString(Send(oSpellOrSkill,@GetSchoolStr,#iSchool=piSchool));
-      AppendTempString(BetaPotion_Append5_rsc);
       
       return;
    }
@@ -130,7 +115,8 @@ messages:
       local HealthBoost, iBaseMaxHealth;
 
       if Send(Send(SYS,@GetLore),@BetaPotionsEnabled)
-         AND Send(Send(SYS,@GetParliament),@BetaPotionsEnabled)
+         AND Send(Send(SYS,@GetParliament),@BetaPotionsEnabled) 
+         OR Send(SYS, @GetChaosNight)
       {
          iBaseMaxHealth = Send(apply_on,@GetBaseMaxHealth);
          Send(apply_on,@MsgSendUser,#message_rsc=BetaPotion_worked);
@@ -150,19 +136,9 @@ messages:
             }
          }
          
-         if piLevel <> 0
-         {
-            if piSchool >= SKS_FENCING
-            {
-               Send(apply_on,@GivePlayerAllSkills,#school=piSchool,#level=piLevel,
-                    #iAbility=piHealth,#upto=TRUE);
-            }
-            else
-            {
-               Send(apply_on,@GivePlayerAllSpells,#school=piSchool,#level=piLevel,
-                    #iAbility=piHealth,#upto=TRUE);
-            }
-         }
+      Send(apply_on,@MsgSendUser,#message_rsc=BetaPotion_select_schools);
+      Post(apply_on,@SetPlayerFlag,#flag=PFLAG2_BETA_POTION,#value=TRUE,#flagset=2);
+
       }
       
       return;

--- a/kod/util/lore.kod
+++ b/kod/util/lore.kod
@@ -732,6 +732,101 @@ messages:
       return;
    }
 
+    BetaPotionCheckSchool(string = $)
+    "Check if player says the name of a school."
+    {
+ 	  local school;
+ 	  
+ 	  school = 0;
+ 	  
+ 	  if StringContain(string,"Shal'ille")
+ 	  {
+ 		 school = SS_SHALILLE;
+ 	  }
+ 	  
+ 	  if StringContain(string,"Qor")
+ 	  {
+ 		 school = SS_QOR;
+ 	  }
+ 	  
+ 	  if StringContain(string,"Kraanan")
+ 	  {
+ 		 school = SS_KRAANAN;
+ 	  }
+ 	  
+ 	  if StringContain(string,"Faren")
+ 	  {
+ 		 school = SS_FAREN;
+ 	  }
+ 	  
+ 	  if StringContain(string,"Riija")
+ 	  {
+ 		 school = SS_RIIJA;
+ 	  }
+ 	  
+ 	  if StringContain(string,"Jala")
+ 	  {
+ 		 school = SS_JALA;
+ 	  }
+ 	  
+ 	  if StringContain(string,"Weaponcraft")
+ 	  {
+ 		 % We use 10 to indicate skills.
+ 		 school = SKS_FENCING;
+ 	  }
+ 	  
+ 	  return school;
+    }
+
+    BetaPotionCheckLevel(string = $)
+    "Check if player also says the level."
+    {
+ 	  local level;
+     
+     level = 0;
+ 	  
+ 	  if StringContain(string,"one") OR
+ 	     StringContain(string,"1")
+ 	  {
+ 		 level = 1;
+ 	  }
+ 	  
+ 	  if StringContain(string,"two") OR
+ 		 StringContain(string,"2")
+ 	  {
+ 		 level = 2;
+ 	  }
+ 	  
+ 	  if StringContain(string,"three") OR
+ 		 StringContain(string,"3")
+ 	  {
+ 		 level = 3;
+ 	  }
+ 	  
+ 	  if StringContain(string,"four") OR
+ 		 StringContain(string,"4")
+ 	  {
+ 		 level = 4;
+ 	  }
+ 	  
+ 	  if StringContain(string,"five") OR
+ 		 StringContain(string,"5")
+ 	  {
+ 		 level = 5;
+ 	  }
+ 	  
+ 	  if StringContain(string,"six") OR
+ 		 StringContain(string,"6")
+ 	  {
+ 		 level = 6;
+ 	  }
+ 	  
+ 	  return level;
+    }
+    
+    %
+    % End of Beta Potion Code
+    %
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -6433,12 +6433,9 @@ messages:
       return;
    }
 
-   DistributeBetaPotions(giveHealth=TRUE, maxHP=150, HealthCap=150,
-                         giveSpells=TRUE, maxLevel=6,
-                         MaxPotionsPerPlayer=5, deadwood=0, allMax=FALSE)
+   DistributeBetaPotions(giveHealth=TRUE, maxHP=150, HealthCap=150, deadwood=0, allMax=TRUE)
    {
-      local i, temp, lFinal, iCount, iPosition, iCutoff, iNumPotions,
-            iSchool, iLevel, iHP;
+      local i, lFinal, iCount, iPosition, iCutoff, iHP;
 
       % We want to give players potions based on the amount of logged on
       %  time they've logged.  So let's sort em.
@@ -6456,9 +6453,6 @@ messages:
 
       iCount = 1;
       iHP = maxHP / 8;
-      iSchool = 0;
-      iLevel = 0;
-      iNumPotions = 1;
 
       for i in lFinal
       {
@@ -6476,48 +6470,36 @@ messages:
          {
             % If we're all max, give out max potions, but only one.
             iHP = maxHP;
-            iLevel = maxLevel;
-            iNumPotions = 1;
          }
          else
          {
             if iPosition > (100 - iCutoff)
             {
                iHP = maxHP;
-               iLevel = maxLevel;
-               iNumPotions = MaxPotionsPerPlayer;
             }
             else
             {
                if iPosition > (100 - (2 * iCutoff))
                {
                   iHP = (maxHP*4/5);
-                  iLevel = bound(maxLevel-1,1,$);
-                  iNumPotions = bound(MaxPotionsPerPlayer-1,1,$);
                }
                else
                {
                   if iPosition > (100 - (3 * iCutoff))
                   {
                      iHP = (maxHP*3/5);
-                     iLevel = bound(maxLevel-1,1,$);
-                     iNumPotions = bound(MaxPotionsPerPlayer-2,1,$);
                   }
                   else
                   {
                      if iPosition > (100 - (4 * iCutoff))
                      {
                         iHP = (maxHP*2/5);
-                        iLevel = bound(maxLevel-2,1,$);
-                        iNumPotions = bound(MaxPotionsPerPlayer-3,1,$);
                      }
                      else
                      {
                         if iPosition > deadwood
                         {
                            iHP = (maxHP*1/5);
-                           iLevel = bound(maxLevel-2,1,$);
-                           iNumPotions = bound(MaxPotionsPerPlayer-4,1,$);
                         }
                         else
                         {
@@ -6532,32 +6514,19 @@ messages:
             iCount = iCount + 1;
          }
 
-         temp = [ SS_QOR,SS_RIIJA,SS_KRAANAN,SS_SHALILLE,SS_FAREN,SS_JALA,SKS_FENCING ];
-
          if iHP = 0
          {
             Debug(Send(i,@GetTrueName),"Was deemed unworthy of boosting.");
          }
          else
          {
-            if NOT giveSpells
-            {
-               iLevel = 0;
-            }
 
             if NOT giveHealth
             {
                iHP = 0;
             }
 
-            while iNumPotions > 0 AND temp <> $
-            {
-               iSchool = Nth(temp,random(1,length(temp)));
-               temp = DelListElem(temp,iSchool);
-               Send(i,@Newhold,#what=Create(&BetaPotion,#health=iHP,#school=iSchool,
-                    #level=iLevel,#giveHealth=giveHealth,#healthCap=healthCap));
-               iNumPotions = iNumPotions - 1;
-            }
+            Send(i,@Newhold,#what=Create(&BetaPotion,#health=iHP,#giveHealth=giveHealth,#healthCap=healthCap));
          }
       }
 


### PR DESCRIPTION
Allow players to select their schools after drinking a beta potion. Based on the Intellect.

Beta potions only work during a frenzy or if the server is in beta mode.
To enable the server in beta mode:
- send o 0 FlipOnBeta
- Must also change the flag pbHiddenSwitch in Parliament class to enable beta mode fully.
