### PR TITLE
Raise default teleport delay after attack to 4 min.

### DIFF
--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -85,7 +85,8 @@ properties:
 
    % Can't cast a teleport spell until this long after attacking someone.  Prevents
    % hit-and-run.  If 0, there's no restriction on when the spell can be cast.
-   piTeleportAttackDelaySec = 2 * 60
+   % Time in seconds.
+   piTeleportAttackDelaySec = 240
 
    % Rescue always takes at least this long to cast
    piRescueBaseDelaySec = 15


### PR DESCRIPTION
Raise the default from 2 min to 4 min.
