### PR TITLE
Set NPCs permanently in STATE_WAIT (disable move/chase timer).

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/council.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/council.kod
@@ -21,19 +21,26 @@ resources:
    Councilor_desc_rsc = ""
 
    blank_spec_rsc=""
-   con_token_delivered_rsc = "Thank you. You have done me a great service. %s %s"
-   con_duke_delivered_rsc = "I will pay more attention to the matters which concern the Duke."
-   con_princess_delivered_rsc = "I will look with more favor on the Princess Kateriina's ideas."
-   con_rebel_delivered_rsc = "I will look upon rebellion as a sign of good change."
-   con_neutral_delivered_rsc = "I shall endeavor to be as impartial at the court as ye."
+   con_token_delivered_rsc = \
+      "Thank you. You have done me a great service. %s %s"
+   con_duke_delivered_rsc = \
+      "I will pay more attention to the matters which concern the Duke."
+   con_princess_delivered_rsc = \
+      "I will look with more favor on the Princess Kateriina's ideas."
+   con_rebel_delivered_rsc = \
+      "I will look upon rebellion as a sign of good change."
+   con_neutral_delivered_rsc = \
+      "I shall endeavor to be as impartial at the court as ye."
 
 classvars:
    
    vrName = Councilor_name_rsc
    vrDesc = Councilor_desc_rsc
    vrIcon = Councilor_icon_rsc
-   viAttributes = MOB_LISTEN | MOB_RANDOM | MOB_RECEIVE 
-   viDefault_behavior = AI_NPC | AI_NOMOVE   %% mob doesn't move and cannot be attacked.
+   viAttributes = MOB_LISTEN | MOB_RANDOM | MOB_RECEIVE
+
+   % Mob doesn't move and cannot be attacked.
+   viDefault_behavior = AI_NPC | AI_NOMOVE
 
    viDefinite = ARTICLE_NONE
    viIndefinite = ARTICLE_NONE
@@ -55,6 +62,7 @@ messages:
    Delete()
    {
       Send(Send(SYS,@GetTokenGame),@CouncilorDeleted,#what=self);
+
       propagate;
    }
 
@@ -66,7 +74,8 @@ messages:
    CheckWhyWanted(obj=$,who=$)
    {
       local oMoney,spec_rsc,fact_rsc;
-      if isClass(obj,&Token)
+
+      if IsClass(obj,&Token)
       {
 
          spec_rsc=Send(self,@CheckSpecialDeliverer,#who=who);
@@ -79,12 +88,14 @@ messages:
          { fact_rsc=Con_princess_delivered_rsc;}
          if Send(who,@GetFaction)=FACTION_REBEL
          { fact_rsc=Con_rebel_delivered_rsc;}
-         
+
          Post(poOwner,@SomeoneSaid,#what=self,#type=SAY_RESOURCE,
-                 #string=Con_token_delivered_rsc,
-                 #parm1=fact_rsc,#parm2=spec_rsc);
-         return True;
+               #string=Con_token_delivered_rsc,
+               #parm1=fact_rsc,#parm2=spec_rsc);
+
+         return TRUE;
       }
+
       propagate;
    }
 
@@ -101,18 +112,49 @@ messages:
    GotoHomeroom()
    {
       local room;
-      room=Send(SYS,@FindRoomByNum,#num=viHomeroom);
-      if room=$ {debug("FindRoombyNum num=",viHomeroom,"returned null");return;}
+
+      room = Send(SYS,@FindRoomByNum,#num=viHomeroom);
+      if room=$
+      {
+         Debug("FindRoombyNum num=",viHomeroom,"returned null");
+
+         return;
+      }
+
       Send(room,@teleport,#what=self);
       Send(room,@SomethingMoved,#what=self,#new_row=viMyRow,#new_col=viMyCol);
       Send(room,@SomethingTurned,#what=self,#new_angle=viMyAngle);
+
       return;
    }
 
    CanMorphTo()
    {
       return FALSE;
-   }      
+   }
+
+   EnterStateWait()
+   {
+      % They shouldn't have acquired a target, but to be sure...
+      if poTarget <> $
+         AND Send(poTarget,@GetOwner) = poOwner
+         AND IsClass(poTarget,&user)
+      {
+         Send(poTarget,@SubtractFromMonsterChasers,
+               #level=Send(self,@GetLevel));
+      }
+
+      poTarget = $;
+      piHatred = 0;
+
+      % Leave them in the waiting state.
+      Send(self,@SetState,#bit=STATE_WAIT);
+      Send(self,@ClearBehavior);
+
+      % We no longer set a move timer for NPCs.
+
+      return;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/monster/factions.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/factions.kod
@@ -18,7 +18,9 @@ classvars:
    
    viDefinite = ARTICLE_NONE
    viIndefinite = ARTICLE_NONE
-   viDefault_behavior = AI_NPC | AI_NOMOVE   %% mob doesn't move and cannot be attacked.
+
+   % Mob doesn't move and cannot be attacked.
+   viDefault_behavior = AI_NPC | AI_NOMOVE
 
    viSpeed = SPEED_SLOW
    viQuestID = 0
@@ -37,9 +39,9 @@ messages:
       if viQuestID<> 0
       {
          Post(Send(SYS,@GetLibrary),@CreateQuest,#type=QST_PERM,#quester=self,
-              #reward= [QST_REWARD_SERVICE,viQuestID]);
+               #reward= [QST_REWARD_SERVICE,viQuestID]);
       }
-      
+
       return;
    }
 
@@ -53,7 +55,7 @@ messages:
    Delete()
    {
       Send(Send(SYS,@GetParliament),@LiegeDeleted,#what=self);
-      
+
       propagate;
    }
 
@@ -69,16 +71,16 @@ messages:
       room = Send(SYS,@FindRoomByNum,#num=viHomeroom);
       Send(room,@teleport,#what=self);
       Send(room,@SomethingMoved,#what=self,#new_row=viMyRow,
-           #new_col=viMyCol,#fine_row=viMyFR,#fine_col=viMyFC);
+            #new_col=viMyCol,#fine_row=viMyFR,#fine_col=viMyFC);
       Send(room,@SomethingTurned,#what=self,#new_angle=viMyAngle);
-      
+
       return;
    }
 
    NewHoldObject(what = $)
    {
       % Don't want them holding anything, so just delete it.
-      send(what,@Delete);
+      Send(what,@Delete);
 
       return;
    }
@@ -86,7 +88,30 @@ messages:
    CanMorphTo()
    {
       return FALSE;
-   }      
+   }
+
+   EnterStateWait()
+   {
+      % They shouldn't have acquired a target, but to be sure...
+      if poTarget <> $
+         AND Send(poTarget,@GetOwner) = poOwner
+         AND IsClass(poTarget,&user)
+      {
+         Send(poTarget,@SubtractFromMonsterChasers,
+               #level=Send(self,@GetLevel));
+      }
+
+      poTarget = $;
+      piHatred = 0;
+
+      % Leave them in the waiting state.
+      Send(self,@SetState,#bit=STATE_WAIT);
+      Send(self,@ClearBehavior);
+
+      % We no longer set a move timer for NPCs.
+
+      return;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/monster/temples.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/temples.kod
@@ -15,13 +15,18 @@ constants:
    include blakston.khd
 
 resources:
-   priestess_teach_quest_needed = "To learn that, you must first become my disciple by proving the strength of your faith."
+
+   priestess_teach_quest_needed = \
+      "To learn that, you must first become my disciple by proving "
+      "the strength of your faith."
 
 classvars:
-   
+
    viDefinite = ARTICLE_NONE
    viIndefinite = ARTICLE_NONE
-   viDefault_behavior = AI_NPC | AI_NOMOVE   %% mob doesn't move and cannot be attacked.
+
+   % Mob doesn't move and cannot be attacked.
+   viDefault_behavior = AI_NPC | AI_NOMOVE
 
    viSpeed = SPEED_SLOW
    viQuestID = 0
@@ -35,22 +40,22 @@ messages:
       if viQuestID <> 0
       {
          Post(Send(SYS,@GetLibrary),@CreateQuest,#type=QST_PERM,#quester=self,
-           #reward= [QST_REWARD_ID,viQuestID]);
+            #reward= [QST_REWARD_ID,viQuestID]);
       }
-      
+
       return;
    }
 
    Constructor()
-   "We start a permanent quest for becomming a disciple"
+   "We start a permanent quest for becoming a disciple"
    {
       Send(self,@InitPermQuest);
-      
+
       propagate;
    }
 
    CanAddSpell(who=$,num=0,report=FALSE)
-   "We require that a quest be done before 3-5 level spells can be learned"
+   "We require that a quest be done before 3-5 level spells can be learned."
    {
       local oSpell;
 
@@ -62,24 +67,24 @@ messages:
       }
       
       if Send(oSpell,@GetLevel) > 2 
-         AND NOT send(self,@HasDoneLearnQuest,#who=who)
+         AND NOT Send(self,@HasDoneLearnQuest,#who=who)
       {
          if report
          {
-            send(poOwner,@SomeoneSaid,#type=SAY_RESOURCE,#what=self, 
-                 #string=vrTeach_quest_needed);
+            Send(poOwner,@SomeoneSaid,#type=SAY_RESOURCE,#what=self,
+                  #string=vrTeach_quest_needed);
          }
-         
+
          return FALSE;
       }
-      
+
       propagate;
    }
 
    NewHoldObject(what = $)
    {
       % Don't want them holding anything, so just delete it.
-      send(what,@Delete);
+      Send(what,@Delete);
 
       return;
    }
@@ -87,7 +92,30 @@ messages:
    CanMorphTo()
    {
       return FALSE;
-   }      
+   }
+
+   EnterStateWait()
+   {
+      % They shouldn't have acquired a target, but to be sure...
+      if poTarget <> $
+         AND Send(poTarget,@GetOwner) = poOwner
+         AND IsClass(poTarget,&user)
+      {
+         Send(poTarget,@SubtractFromMonsterChasers,
+               #level=Send(self,@GetLevel));
+      }
+
+      poTarget = $;
+      piHatred = 0;
+
+      % Leave them in the waiting state.
+      Send(self,@SetState,#bit=STATE_WAIT);
+      Send(self,@ClearBehavior);
+
+      % We no longer set a move timer for NPCs.
+
+      return;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/monster/towns.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns.kod
@@ -15,19 +15,22 @@ constants:
    include blakston.khd
 
 classvars:
-   
+
    viDefinite = ARTICLE_NONE
    viIndefinite = ARTICLE_NONE
-   % Set default gender to male, monster's default is now neuter instead of male, so most of the
-   %  subclasses with undefined gender under here will assume male.
-   viGender = GENDER_MALE   
 
-   viDefault_behavior = AI_NPC | AI_NOMOVE   %% mob doesn't move and cannot be attacked.
+   % Set default gender to male, monster's default is now neuter instead of
+   % male, so most of the subclasses with undefined gender under here
+   % will assume male.
+   viGender = GENDER_MALE
+
+   % Mob doesn't move and cannot be attacked.
+   viDefault_behavior = AI_NPC | AI_NOMOVE
 
    viSpeed = SPEED_AVERAGE
 
 properties:
-   
+
    % Palette translations; used only for NPCs that use player face parts
    piFace_translation = PT_GRAY_TO_SKIN1
    piHair_translation = PT_HAIR_DKBROWN
@@ -42,7 +45,30 @@ messages:
    NewHoldObject(what = $)
    {
       % Don't want them holding anything, so just delete it.
-      send(what,@Delete);
+      Send(what,@Delete);
+
+      return;
+   }
+
+   EnterStateWait()
+   {
+      % They shouldn't have acquired a target, but to be sure...
+      if poTarget <> $
+         AND Send(poTarget,@GetOwner) = poOwner
+         AND IsClass(poTarget,&user)
+      {
+         Send(poTarget,@SubtractFromMonsterChasers,
+               #level=Send(self,@GetLevel));
+      }
+
+      poTarget = $;
+      piHatred = 0;
+
+      % Leave them in the waiting state.
+      Send(self,@SetState,#bit=STATE_WAIT);
+      Send(self,@ClearBehavior);
+
+      % We no longer set a move timer for NPCs.
 
       return;
    }


### PR DESCRIPTION
No more move timers, since they don't need to move, acquire targets or heal. Was unnecessary overhead having ~120 NPCs with timers going off 3 times a second.

NOTE: if a fighting NPC is ever made, don't make it a child of these classes (or edit these superclasses as necessary).
