### PR TITLE
Put feast hall door on a timer.  DMs can still manually open and close

### DIFF
--- a/kod/object/active/holder/room/duke2.kod
+++ b/kod/object/active/holder/room/duke2.kod
@@ -19,6 +19,12 @@ constants:
    FEAST_DOOR_CLOSED = 3
    FEAST_DOOR_OPEN = 4
 
+   FEAST_TIMER_CREATE_DELAY = 120000
+      
+   FEAST_HALL_DAYS_MIN = 7
+   FEAST_HALL_DAYS_MAX = 21
+   FEAST_HALL_DAYS_OPEN = 3
+      
    DOOR_TIME = 10000
 
    TO_ROW = 38
@@ -53,11 +59,12 @@ classvars:
 
    viTeleport_row = 39
    viTeleport_col = 16
-
+   
    viTerrain_Type = TERRAIN_CASTLE | TERRAIN_FOUNTAIN
 
 properties:
 
+   % timer for animation
    ptDoorTimer = $
 
    prRoom = room_Duke2
@@ -66,16 +73,32 @@ properties:
    piBaseLight = LIGHT_NICE
    piOutside_factor = 8
 
+   % timer for automating the feast hall
+   ptFeastTimer = $
+   
+   piDaysLeft = 0
+   
    prMusic = Duke2_music
 
    pbCeremonyHall = FALSE
+   
+   plFoyer = $
 
 messages:
 
    Constructed()
    {
+      plFoyer = [ 685, 1313, 915, 1363 ];
+      
       plLooping_sounds = [[ fountain_soundDuke2, 27, 16, 20, 40 ]];
-
+      
+      if (ptFeastTimer = $)
+      {
+         % don't create the timer yet, the feast hall may not be created yet and
+         % we need to check it's state, instead set a timer to check it and act then
+         CreateTimer(self,@CreateFeastTimer,FEAST_TIMER_CREATE_DELAY);
+      }
+      
       propagate;
    }
 
@@ -111,34 +134,25 @@ messages:
          {
             if NOT Send(Send(SYS,@FindRoomByNum,#num=RID_DUKE4),@IsLocked)
             {
-               Send(Send(SYS,@FindRoomByNum,#num=RID_DUKE4),@SetLocked,
-                    #value=1);
-               Send(self,@SetSector,#sector=FEAST_DOOR_OPEN,
-                    #animation=ANIMATE_FLOOR_LIFT,#height=356,#speed=0);
-               Send(self,@SetSector,#sector=FEAST_DOOR_CLOSED,
-                    #animation=ANIMATE_FLOOR_LIFT,#height=420,#speed=0);
-
-               Send(Send(SYS,@FindRoomByNum,#num=RID_DUKE4),
-                    @HustleUsersOutOfRoom,#new_rid=RID_DUKE2,
-                    #new_row=9,#new_col=15);
-               Send(Send(SYS,@FindRoomByNum,#num=RID_DUKE5),
-                    @HustleUsersOutOfRoom,#new_rid=RID_DUKE2,
-                    #new_row=10,#new_col=15);
-
+               Send(self,@LockFeastHall);
                Send(self,@SomethingWaveRoom,#what=what,#wave_rsc=Duke2_Hall_Close_Sound);
             }
             else
             {
-               Send(self,@SetSector,#sector=FEAST_DOOR_CLOSED,
-                    #animation=ANIMATE_FLOOR_LIFT,#height=356,#speed=0);
-               Send(self,@SetSector,#sector=FEAST_DOOR_OPEN,
-                    #animation=ANIMATE_FLOOR_LIFT,#height=419,#speed=0);
-               Send(Send(SYS,@FindRoomByNum,#num=RID_DUKE4),@SetLocked,
-                    #value=0);
+               Send(self,@UnlockFeastHall);
                Send(what,@MsgSendUser,#message_rsc=Duke2_West_Wing_Door_Open);
                Send(self,@SomethingWaveRoom,#what=what,
                     #wave_rsc=Duke2_Hall_Open_Sound);
             }
+            
+            % reset the timer (if dm opened the door the timer will close it for them)
+            % if the dm closed the door, sets a time for the next feast
+            if (ptFeastTimer <> $ AND IsTimer(ptFeastTimer) AND GetTimeRemaining(ptFeastTimer) > 0)
+            {
+               DeleteTimer(ptFeastTimer);
+            }
+            
+            Send(self,@CreateFeastTimer);
          }
 
          if Send(Send(SYS,@FindRoomByNum,#num=RID_DUKE4),@IsLocked)
@@ -180,12 +194,141 @@ messages:
       return;
    }
 
+   CreateFeastTimer()
+   {
+      local bHallLocked,iTime;
+      
+      bHallLocked = Send(Send(SYS,@FindRoomByNum,#num=RID_DUKE4),@IsLocked);
+      
+      if (piDaysLeft > 0)
+      {
+         ptFeastTimer = CreateTimer(self,@OnFeastHallTimer,86400000);
+         return;
+      }
+      
+      if (bHallLocked)
+      {
+         piDaysLeft = Random(FEAST_HALL_DAYS_MIN,FEAST_HALL_DAYS_MAX);
+      }
+      else
+      {
+         piDaysLeft = FEAST_HALL_DAYS_OPEN;
+      }
+
+      ptFeastTimer = CreateTimer(self,@OnFeastHallTimer,86400000);
+      
+      return;
+   }
+   
+   OnFeastHallTimer()
+   {
+      piDaysLeft = piDaysLeft - 1;
+
+      if (piDaysLeft > 0)
+      {
+         Send(self,@CreateFeastTimer);
+         return;
+      }
+      else
+      {
+         Send(self,@ToggleFeastHall,#auto=true);
+      }
+      
+      return;
+   }
+   
+   ToggleFeastHall(auto=false)
+   {
+      local bHallLocked;
+      
+      bHallLocked = Send(Send(SYS,@FindRoomByNum,#num=RID_DUKE4),@IsLocked);
+      
+      if (bHallLocked)
+      {
+         Send(self,@UnlockFeastHall);
+      }
+      else
+      {
+         Send(self,@LockFeastHall);
+      }
+      
+      % just in case this was called outside of the timer
+      if (ptFeastTimer <> $ AND NOT auto)
+      {
+         DeleteTimer(ptFeastTimer);
+         ptFeastTimer = $;
+      }
+            
+      Send(self,@CreateFeastTimer);
+      
+      return;
+   }
+   
+   LockFeastHall()
+   {
+      Send(self,@ClearFeastHallFoyer);
+   
+      Send(Send(SYS,@FindRoomByNum,#num=RID_DUKE4),@SetLocked,
+            #value=1);
+      Send(self,@SetSector,#sector=FEAST_DOOR_OPEN,
+            #animation=ANIMATE_FLOOR_LIFT,#height=356,#speed=0);
+      Send(self,@SetSector,#sector=FEAST_DOOR_CLOSED,
+            #animation=ANIMATE_FLOOR_LIFT,#height=420,#speed=0);
+
+      Send(Send(SYS,@FindRoomByNum,#num=RID_DUKE4),
+            @HustleUsersOutOfRoom,#new_rid=RID_DUKE2,
+            #new_row=9,#new_col=15);
+      Send(Send(SYS,@FindRoomByNum,#num=RID_DUKE5),
+            @HustleUsersOutOfRoom,#new_rid=RID_DUKE2,
+            #new_row=10,#new_col=15);
+
+      return;
+   }
+   
+   UnlockFeastHall()
+   {
+      Send(self,@SetSector,#sector=FEAST_DOOR_CLOSED,
+            #animation=ANIMATE_FLOOR_LIFT,#height=356,#speed=0);
+      Send(self,@SetSector,#sector=FEAST_DOOR_OPEN,
+            #animation=ANIMATE_FLOOR_LIFT,#height=419,#speed=0);
+      Send(Send(SYS,@FindRoomByNum,#num=RID_DUKE4),@SetLocked,
+            #value=0);
+            
+      return;
+   }
+   
+   ClearFeastHallFoyer()
+   {
+      local i, lPlayers;
+      
+      lPlayers = $;
+
+      if plFoyer <> $
+      {
+         lPlayers = Send(self,@FindUsersInArea,#lArea=plFoyer);
+      }
+      if lPlayers <> $
+      {
+         for i in lPlayers
+         {
+            Send(self,@Teleport,#what=i,#foyer=TRUE);
+         }
+      }
+      return;
+   }
+   
    Delete()
    {
       if (ptDoorTimer <> $)
       {
          DeleteTimer(ptDoorTimer);
          ptDoorTimer = $;
+      }
+      
+      if (ptFeastTimer <> $)
+      {
+         DeleteTimer(ptFeastTimer);
+         ptFeastTimer = $;
       }
 
       propagate;


### PR DESCRIPTION
Put feast hall door on a timer.  DMs can still manually open and close the door.  If left open the system will close the door after a set period  Players in the foyer to the feast hall will be blinked out when the system closes the door.  Players inside the feast hall and ballroom will be moved to the main hall.