### PR TITLE
Raise avar shaman HP to 120, swap Sandstorm for Heat, raise piMax_mana to 30.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/avshaman.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/avshaman.kod
@@ -78,7 +78,7 @@ classvars:
    viSpeed = SPEED_SLOW
    viDefault_behavior = \
       AI_FIGHT_AGGRESSIVE | AI_MOVE_OPTIMAL_RANGE | AI_FIGHT_MONSTERS
-   viLevel = 100
+   viLevel = 120
    viDifficulty = 8
    viKarma = 80
    viCashmin = 500
@@ -99,6 +99,7 @@ properties:
    piAnimation = ANIM_NONE
    piColor_Translation = PT_PURPLETORED
 
+   piMax_mana = 30
    piSpellPower = 75
 
 messages:
@@ -129,7 +130,7 @@ messages:
                       ];
 
       plSpellBook = [ [SID_HOLD,5,40], [SID_MANA_BOMB,6,70],
-                      [SID_SAND_STORM,4,85], [SID_EVIL_TWIN,10,90],
+                      [SID_HEAT,4,85], [SID_EVIL_TWIN,10,90],
                       [SID_EARTHQUAKE,10,100] ];
 
       propagate;


### PR DESCRIPTION
These are from the thread and ideas suggested by Oriumpor: http://openmeridian.org/forums/index.php/topic,333.0.html.

HP raised from 100HP to 120HP bringing them more in line with the other avars, and hopefully increasing the viability of building on the island further. Also in that vein, Sandstorm has been swapped for Heat and this also makes them more synergistic with avar chieftains (which use a ranged attack that Sandstorm now affects).

Raised their piMax_mana from 20 to 30; spell chance is still reasonably low (~14%) but they will be slightly more able to cast more spells.
