### PR TITLE
Radius Enchantment Toggle

### DIFF
--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -167,6 +167,7 @@ messages:
             if Nth(i,1) = who
             {
                Send(self,@BreakTrance,#who=who,#event=EVENT_STEER);
+               return FALSE;
             }
          }
       }


### PR DESCRIPTION
If you have a Radius Enchantment up and attempt to cast it again, it will
cancel instead of recasting. This basically turns a cast hotkey into a
toggle for the spell (and only that spell).
