### PR TITLE
Fix crashes due to lost DirectX device (UAC, opening other games, ctrl-alt-del, etc).

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -1224,7 +1224,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 				D3DRenderShutDown();
 				gFrame = 0;
 				D3DRenderInit(hMain);
-				D3DGeometryBuildNew(room, &gWorldPoolStatic);
+				ResetUserData();
+				//D3DGeometryBuildNew(room, &gWorldPoolStatic);
 			}
 		}
 	}


### PR DESCRIPTION
This still has a memory leak somewhere, meridian.exe gains 30mb of memory usage every time the device is lost/recovered. Putting it up in case someone else knows off-hand where it might be.

Edit: another issue, this causes player names to be drawn as boxes.
