### PR TITLE
Offense & Defense changes

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -9972,6 +9972,7 @@ messages:
          {
             if IsClass(i,&JewelofFroz)
                OR IsClass(i,&Weapon)
+               OR IsClass(i,&Torch)
             {
                iFrozCount = iFrozCount + 1;
             }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -9911,7 +9911,7 @@ messages:
    RefreshPlayerVisualGear()
    {
       local n, plRefreshItemTypes, i, iHighestLayer, oHighestGear,
-            iLowestLayer, oLowestGear, oSoldierShield, bSoldierShieldSlung;
+            iLowestLayer, oLowestGear, oSoldierShield, bSoldierShieldSlung, iFrozCount;
 
       plRefreshItemTypes = [ITEM_USE_SHIRT,ITEM_USE_BODY,ITEM_USE_LEGS];
 
@@ -9960,6 +9960,8 @@ messages:
             Send(oLowestGear,@DoPlayerArt);
          }
       }
+      
+      iFrozCount = 0;
 
       % Check for Soldier Shield sling
       bSoldierShieldSlung = FALSE;
@@ -9968,10 +9970,16 @@ messages:
       {
          for i in plUsing
          {
+            if IsClass(i,&JewelofFroz)
+            {
+               iFrozCount = iFrozCount + 1;
+            }
+         
             if (IsClass(i,&Shield)
                AND NOT IsClass(i,&SoldierShield))
                OR IsClass(i,&Bow)
                OR IsClass(i,&Lute)
+               OR iFrozCount > 1
             {
                Send(oSoldierShield,@SlingOnBack,#report=FALSE);
                bSoldierShieldSlung = TRUE;

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -9971,6 +9971,7 @@ messages:
          for i in plUsing
          {
             if IsClass(i,&JewelofFroz)
+               OR IsClass(i,&Weapon)
             {
                iFrozCount = iFrozCount + 1;
             }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4789,7 +4789,7 @@ messages:
 
          if oWeapon <> $
          {
-            iOffense = Send(oWeapon,@ModifyHitRoll,#target=what,
+            iOffense = Send(oWeapon,@ModifyHitRoll,#who=self,#target=what,
                   #hit_roll=iOffense);
          }
       }

--- a/kod/object/item/passitem/attmod/frozjewl.kod
+++ b/kod/object/item/passitem/attmod/frozjewl.kod
@@ -67,17 +67,7 @@ messages:
          return hit_roll;
       }
 
-      if stroke_obj <> $
-         AND IsClass(stroke_obj,&Spell)
-      {
-         Send(self,@DoFlash);
-      
-         % Adjust bonus by how strong the wielder is relative to their maximum potential.
-         % Throwaway characters will get very little benefit.
-         return hit_roll + (30 * Send(self,@GetHealthBonus,#who=who));
-      }
-      
-      return hit_roll + 50;
+      return hit_roll + 150;
    }
    
    ModifyDamage(who=$,what=$,damage=$,stroke_obj=$)
@@ -99,9 +89,7 @@ messages:
          if Send(who,@LoseMana,#amount=iMana) <> 0
          {
             % Add big damage if we spent the mana.
-            % Adjust it by how strong the wielder is relative to their maximum potential.
-            % Throwaway characters will get very little benefit.
-            return damage + Send(self,@GetHealthBonus,#who=who);
+            return damage + Random(3,5);
          }
 
          % Add a small amount of damage.
@@ -109,31 +97,6 @@ messages:
       }
       
       return damage;
-   }
-   
-   GetHealthBonus(who=$)
-   {
-      local hp;
-
-      hp = Send(who,@GetBaseMaxHealth);
-      if hp < 50
-      {
-         return 1;
-      }
-      if hp < 75
-      {
-         return Random(1,2);
-      }
-      if hp < 100
-      {
-         return Random(1,3);
-      }
-      if hp < 125
-      {
-         return Random(2,3);
-      }
-
-      return Random(3,5);
    }
 
    WeaponHitTarget()

--- a/kod/object/item/passitem/defmod/shield/soldshld.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld.kod
@@ -461,6 +461,8 @@ messages:
          OR IsClass(what,&Bow)
          OR IsClass(what,&Lute)
          OR IsClass(what,&Totem)
+         OR (IsClass(what,&JewelofFroz)
+               AND Send(poOwner,@IsUsingA,#class=&JewelofFroz)
       {
          Send(self,@SlingOnBack,#report=FALSE);
          return TRUE;
@@ -469,9 +471,6 @@ messages:
    }
 
    %%% For putting the shield on our back
-
-   % This is used for Bows and Lutes, currently.
-
    SlingOnBack(report=TRUE)
    {
       if piOverlayHotspot <> HS_SHIELD_BACK

--- a/kod/object/item/passitem/defmod/shield/soldshld.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld.kod
@@ -462,7 +462,8 @@ messages:
          OR IsClass(what,&Lute)
          OR IsClass(what,&Totem)
          OR (IsClass(what,&JewelofFroz)
-               AND Send(poOwner,@IsUsingA,#class=&JewelofFroz))
+               AND (Send(poOwner,@IsUsingA,#class=&JewelofFroz)
+                       OR Send(poOwner,@IsUsingA,#class=&Weapon)))
       {
          Send(self,@SlingOnBack,#report=FALSE);
          return TRUE;

--- a/kod/object/item/passitem/defmod/shield/soldshld.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld.kod
@@ -463,7 +463,8 @@ messages:
          OR IsClass(what,&Totem)
          OR (IsClass(what,&JewelofFroz)
                AND (Send(poOwner,@IsUsingA,#class=&JewelofFroz)
-                       OR Send(poOwner,@IsUsingA,#class=&Weapon)))
+                       OR Send(poOwner,@IsUsingA,#class=&Weapon)
+                       OR Send(poOwner,@IsUsingA,#class=&Torch)))
       {
          Send(self,@SlingOnBack,#report=FALSE);
          return TRUE;

--- a/kod/object/item/passitem/defmod/shield/soldshld.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld.kod
@@ -462,7 +462,7 @@ messages:
          OR IsClass(what,&Lute)
          OR IsClass(what,&Totem)
          OR (IsClass(what,&JewelofFroz)
-               AND Send(poOwner,@IsUsingA,#class=&JewelofFroz)
+               AND Send(poOwner,@IsUsingA,#class=&JewelofFroz))
       {
          Send(self,@SlingOnBack,#report=FALSE);
          return TRUE;

--- a/kod/object/passive/spell/persench/Eagleyes.kod
+++ b/kod/object/passive/spell/persench/Eagleyes.kod
@@ -167,7 +167,7 @@ messages:
    {
       local iFactor, oWeapon;
 
-      iFactor = Send(who,@GetEnchantedState,#what=self);
+      iFactor = Send(who,@GetEnchantedState,#what=self) * 2;
 
       oWeapon = Send(who,@LookupPlayerWeapon);
 
@@ -201,7 +201,7 @@ messages:
       AppendTempString("Your current ");
       AppendTempString(Send(self,@GetName));
       AppendTempString(" enchantment adds ");
-      AppendTempString(Send(who,@GetEnchantedState,#what=self));
+      AppendTempString(Send(who,@GetEnchantedState,#what=self)*2);
       AppendTempString(" offense and 1 damage to your ranged attacks.");
 
       propagate;

--- a/kod/object/passive/spell/persench/bless.kod
+++ b/kod/object/passive/spell/persench/bless.kod
@@ -107,7 +107,7 @@ messages:
 
    ModifyHitRoll(who=$,what=$,hit_roll=$)
    {
-      return hit_roll + Send(who,@GetEnchantedState,#what=self);
+      return hit_roll + Send(who,@GetEnchantedState,#what=self) * 2;
    }
    
    ModifyDamage(who=$,what=$,damage=$)
@@ -121,7 +121,7 @@ messages:
       AppendTempString("Your current ");
       AppendTempString(Send(self,@GetName));
       AppendTempString(" enchantment adds ");
-      AppendTempString(Send(who,@GetEnchantedState,#what=self));
+      AppendTempString(Send(who,@GetEnchantedState,#what=self)*2);
       AppendTempString(" offense and 0-");
       AppendTempString(Send(who,@GetEnchantedState,#what=self)/33);
       AppendTempString(" attack damage.");

--- a/kod/object/passive/spell/persench/karahol.kod
+++ b/kod/object/passive/spell/persench/karahol.kod
@@ -127,7 +127,7 @@ messages:
    % Stuff we handle to be an attack modifier
    ModifyHitRoll(who=$,what=$,hit_roll=$)
    {
-      return hit_roll + 100 + (Send(who,@GetEnchantedState,#what=self)*2);
+      return hit_roll + 100 + (Send(who,@GetEnchantedState,#what=self)*4);
    }
    
    ModifyDamage(who=$,what=$,damage=$)
@@ -146,7 +146,7 @@ messages:
       AppendTempString("Your current ");
       AppendTempString(Send(self,@GetName));
       AppendTempString(" enchantment adds ");
-      AppendTempString(100 + (Send(who,@GetEnchantedState,#what=self) * 2));
+      AppendTempString(100 + (Send(who,@GetEnchantedState,#what=self) * 4));
       AppendTempString(" offense and 1-");
       AppendTempString(1 + (Send(who,@GetEnchantedState,#what=self)/20));
       AppendTempString(" attack damage. When it expires, it will paralyze you for ");

--- a/kod/object/passive/spell/persench/touchatk.kod
+++ b/kod/object/passive/spell/persench/touchatk.kod
@@ -210,7 +210,7 @@ messages:
 
    ModifyHitRoll(who=$,what=$,hit_roll=$)
    {
-      return hit_roll + (300*Send(who,@GetBaseMaxHealth) / (100+Send(who,@GetStamina)));
+      return hit_roll;
    }
 
    GetAttackType(weapon_used=$)

--- a/kod/object/passive/spell/persench/touchatk.kod
+++ b/kod/object/passive/spell/persench/touchatk.kod
@@ -208,6 +208,11 @@ messages:
       return Send(who,@GetSpellAbility,#spell_num=viSpell_num);
    }
 
+   ModifyHitRoll(who=$,what=$,hit_roll=$)
+   {
+      return hit_roll + (300*Send(who,@GetBaseMaxHealth) / (100+Send(who,@GetStamina)));
+   }
+
    GetAttackType(weapon_used=$)
    {
       return viAttackType;

--- a/kod/object/passive/spell/roomench/forceslt.kod
+++ b/kod/object/passive/spell/roomench/forceslt.kod
@@ -143,7 +143,7 @@ messages:
       local iSpellpower,iHitMod;
 
       iSpellpower = send(send(who,@GetOwner),@GetEnchantmentState,#what=self);
-      iHitMod = iSpellpower + 50;  %% 50 - 150
+      iHitMod = iSpellpower*2 + 50;  %% 50 - 250
       
       return hit_roll + iHitMod;
    }
@@ -174,7 +174,7 @@ messages:
       AppendTempString(Send(self,@GetName));
       AppendTempString(" enchantment currently adds ");
       
-      iState = Send(Send(who,@GetOwner),@GetEnchantedState,#what=self);
+      iState = Send(Send(who,@GetOwner),@GetEnchantedState,#what=self)*2;
       
       AppendTempString(iState + 50);
       AppendTempString(" offense to the attacks of good players and ");


### PR DESCRIPTION
Here's a pull to get people thinking about offense and defense. This nerfs
nobody, instead opting to empower personal enchantments and Forces
of Light with double the offense for spellpower-based components. I chose
these sources because they can be purged by spell or proc, or opponents
might not have the buffs up.

* Touch spells have had their Jewels of Frozzes upgraded. Jewels now
always give 150 offense and can be dual-wielded with a soldier shield.
They also now always give 3-5 damage. The HP limiting component
has been removed, as tof mules don't really seem to be an issue anymore
due to a host of other changes. JoF offense will also now show up
correctly in the offense stat bar. Previously, it was only showing +50,
when it could have been as much as +150. You can also now use one JoF
without a shield to boost a melee weapon by 150 offense (but not damage).
Touch spells should now be reaching ~1300 with 1 aim, jonas, all buffs, gaunts,
and 99%s. With 50 aim, they should reach ~1700. These values are higher
than weapons generally, because reaching them requires two jewels of froz,
and thus 4 mana per attack, no shield, no weapon, and the added
vulnerability that goes with that.

* Kara'hol's Curse offense bonus based on spellpower doubled. Can now
offer up to 496 offense. Worth it for such a dangerous spell.

* Eagle Eyes offense for ranged weapons doubled, up to 198 based on
spellpower.

* Bless offense doubled, up to 198 based on spellpower.

* Forces of Light offense bonus based on spellpower doubled, up to 250
total.