### PR TITLE
Reactivate Necromancers & Hunters

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/lich.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/lich.kod
@@ -140,8 +140,7 @@ messages:
 
    Constructed(oNecromancerGuild=$)
    {
-      % Keep the scenario deactivated for now.
-      %send(send(SYS,@GetNecromancerBalance),@ActivateScenario);
+      Send(send(SYS,@GetNecromancerBalance),@ActivateScenario);
 
       pimax_Hit_Points = pimax_hit_Points * 2;
       piHit_Points = pimax_hit_points;


### PR DESCRIPTION
With the recent fixes to guild halls, the main fundamental weakness of
this scenario is now gone. Players cannot cheat to kill the lich in any
manner.

Therefore, let's give it a shot.

I reviewed much of the Sword of the Hunt, Amulet of the Three, lich
and necro guild code, and it's a gigantic scenario with lots of behind
the scenes machinations. If we can bring this content back to players
**exactly the way it was originally implemented,** I'll consider it a win.
If it doesn't end up working out, we can always think up modifications
later.