### PR TITLE
Override EnterStateLimbo for revenants to prevent constant lowering of a player's piMonsterChasers. Stop target switching to offline players.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -1130,7 +1130,9 @@ messages:
             if IsClass(poMaster,&Player)
                AND NOT Send(poMaster,@IsLoggedOn)
             {
-               Post(self,@SetMaster,#oMaster=$);
+               % Send this rather than post, otherwise the master's
+               % piMonsterChasers isn't updated properly.
+               Send(self,@SetMaster,#oMaster=$);
             }
          }
       }
@@ -6297,8 +6299,15 @@ messages:
          return;
       }
 
+      if IsClass(what,&User)
+         AND NOT Send(what,@IsLoggedOn)
+      {
+         % Trying to switch to someone logged off. Can't do that.
+         return;
+      }
+
       piHatred = iHatred;
-      
+
       if poTarget <> $
          AND Send(poTarget,@GetOwner) = poOwner
          AND IsClass(poTarget,&user)

--- a/kod/object/active/holder/nomoveon/battler/monster/revenant.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/revenant.kod
@@ -119,7 +119,7 @@ messages:
 
       %% place near target in 3-8 seconds
       ptPlace = CreateTimer(self,@Place,Random(3000,8000));
-      
+
       propagate;
    }
 
@@ -166,7 +166,7 @@ messages:
          {
             iRow_sign=  1 ;
          }
-         
+
          if Random(1,2) = 1
          {
             iCol_sign= -1 ;
@@ -175,10 +175,10 @@ messages:
          {
             iCol_sign=  1 ;
          }
-         
+
          iRow = iTarg_row + iRow_sign*Random(3,6);
          iCol = iTarg_col + iCol_sign*Random(3,6);
-         
+
          if iRow >= 1
             AND iRow <= Send(poRoom,@GetRoomRows)
             AND iCol >= 1
@@ -187,12 +187,12 @@ messages:
             bValid_location = TRUE;
          }
       }
-      
+
       Send(poRoom,@NewHold,#what=self,#new_row=iRow,#new_col=iCol);
       poTarget = poHauntee;
-      send(self,@EnterStateChase);
+      Send(self,@EnterStateChase);
       Post(poHauntee,@MsgSendUser,#message_rsc=Rev_coming_to_get_ya);
-      
+
       return;
    }
 
@@ -201,7 +201,7 @@ messages:
       piAnimation = ANIM_ATTACK;
       Send(poOwner,@SomethingChanged,#what=self);
       piAnimation = ANIM_NONE;
-      
+
       %Extra revenant penalty.. each time it hits, it drains away vigor
       %The 20% drain might be too high, but well see. *cackle*
       if Random(0,9) = 0
@@ -209,21 +209,22 @@ messages:
          Send(what,@MsgSendUser,#message_rsc=Rev_draining_effect);
          Send(what,@AddExertion,#amount=Send(what,@GetVigor)*10000/10);
       }
-      
+
       return;
    }
 
    SomethingMoved()
    {
       Send(Send(self,@GetOwner),@DeleteWallsAroundBattler,#who=self);
+
       propagate;
    }
-   
+
    SendLookAnimation()
    {
       AddPacket(1,ANIMATE_CYCLE);
       AddPacket(4,200,2,2,2,3);
-      
+
       return;
    }
 
@@ -240,12 +241,12 @@ messages:
       if piAnimation = ANIM_ATTACK
       {
          AddPacket(1,ANIMATE_ONCE,4,200,2,2,2,3,2,1);
-         
+
          return;
       }
 
       % if no body animation
-      
+
       propagate;
    }
 
@@ -267,19 +268,19 @@ messages:
       {
          Send(self,@RevenantWasAttacked,#what=what);
       }
-      
+
       propagate;
    }
 
    RevenantWasAttacked(what = $)
    {
       if what <> poHauntee and IsClass(what,&User) AND
-         (not Send(what,@CheckPlayerFlag,#flag=PFLAG_HAUNTED))
+         (NOT Send(what,@CheckPlayerFlag,#flag=PFLAG_HAUNTED))
       {
          Send(what,@MsgSendUser,#message_rsc=Rev_grouping_is_bad);
          Send(what,@SetPlayerFlag,#flag=PFLAG_HAUNTED,#value=TRUE);
       }
-      
+
       return;
    }
 
@@ -288,10 +289,10 @@ messages:
    {
       if poHauntee = victim
       {
-         post(self,@Delete);  % MUST post this
+         Post(self,@Delete);  % MUST post this
       }
-      
-      return ; 
+
+      return ;
    }
 
 
@@ -302,11 +303,94 @@ messages:
    %% If it's the target, delete revenant
    SomethingLeft(what = $)
    {
-      if what = poHauntee 
-      { 
-         post(self,@Delete); 
+      if what = poHauntee
+      {
+         Post(self,@Delete);
       }
-      
+
+      return;
+   }
+
+
+   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+   % State Transition Functions
+   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+   % Called when the user leaves the screen, as we're being deleted.
+   % We don't add to the target's piMonsterChasers, so override the
+   % superclass here.
+   EnterStateLimbo()
+   {
+      Send(self,@ClearBehavior);
+
+      poTarget = $;
+      piHatred = 0;
+      Send(self,@SetState,#bit=STATE_LIMBO);
+      % The whole point of the limbo state is that there are no timers to set.
+
+      return;
+   }
+
+   EnterStateWait(actnow=FALSE,delay=MOB_MOVE_TIMER_WAIT)
+   {
+      poTarget = $;
+      piHatred = 0;
+
+      Send(self,@SetState,#bit=STATE_WAIT);
+      Send(self,@ClearBehavior);
+
+      if actnow
+      {
+         Send(self,@WaitTimer);
+      }
+      else
+      {
+         ptBehavior = CreateTimer(self,@WaitTimer,delay);
+      }
+
+      return;
+   }
+
+   EnterStateMove( actnow=FALSE )
+   {
+      % Note: All monsters "move" even the ones who physically can't.
+      Send(self,@SetState,#bit=STATE_MOVE);
+
+      poTarget = $;
+      piHatred = 0;
+
+      Send(self,@ClearBehavior);
+
+      if actnow
+      {
+         Send(self,@MoveTimer);
+      }
+      else
+      {
+         ptBehavior = CreateTimer(self,@MoveTimer,Send(self,@GetMoveTime));
+      }
+
+      return;
+   }
+
+   TargetSwitch(what=$, iHatred = 0)
+   {
+      if what = $
+      {
+         Debug("BAD target we're switching to here!");
+
+         return;
+      }
+
+      piHatred = iHatred;
+      piState = (piState & VSTATE_VALIDITY_MASK);
+
+      % 'lock' sound
+      if vrSound_aware <> $
+      {
+         Send(poOwner,@SomethingWaveRoom,#what=self,#wave_rsc=vrSound_aware);
+      }
+
       return;
    }
 
@@ -317,7 +401,7 @@ messages:
    %% The only escape from haunting is the death of the revenant
    Killed(what = $)
    {
-      If what <> poHauntee
+      if what <> poHauntee
          AND IsClass(what,&User)
          AND (NOT Send(what,@checkPlayerFlag,#flag=PFLAG_HAUNTED))
       {
@@ -328,7 +412,7 @@ messages:
       Send(poHauntee,@SetPlayerFlag,#flag=PFLAG_HAUNTED,#value=FALSE);
       Send(poHauntee,@MsgSendUser,#message_rsc=Rev_vanquished);
       Send(self,@Delete);
-      
+
       return;  %% do not propagate (revenants leave no corpse or treasure)
    }
 
@@ -344,18 +428,17 @@ messages:
    CanMorphTo()
    {
       return FALSE;
-   }  
-   
+   }
+
    CanPlayerAdvanceOnMe()
-   {  
+   {
       return FALSE;
-   }    
- 
+   }
+
    CanEvilTwin()
    {
       return FALSE;
    }
-   
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-


### PR DESCRIPTION
Added the other state transitions that modify a target's piMonsterChasers. Revenants do not add to this, so they shouldn't subtract from it. Included TargetSwitch here also.