### PR TITLE
Post setting of poOriginal to $ to avoid errors with reflections and evil twins.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -142,11 +142,22 @@ messages:
                #parm2=Send(self,@GetName,#cap=FALSE));
       }
 
-      poOriginal = $;
+      Post(self,@RemoveOriginal);
       poCaster = $;
+      if poArrow <> $
+      {
+         Send(poArrow,@Delete);
+      }
       poArrow = $;
 
       propagate;
+   }
+
+   RemoveOriginal()
+   {
+      poOriginal = $;
+
+      return;
    }
 
    SomethingKilled(what=$,victim=$)

--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -254,10 +254,21 @@ messages:
          ptSomethingChanged = $;
       }
 
-      poOriginal = $;
-      Send(poArrow,@Delete);
+      if poArrow <> $
+      {
+         Send(poArrow,@Delete);
+      }
+      poArrow = $;
+      Post(self,@RemoveOriginal);
 
       propagate;
+   }
+
+   RemoveOriginal()
+   {
+      poOriginal = $;
+
+      return;
    }
 
    GetOriginal()


### PR DESCRIPTION
On rare instances, someone looking at a reflection or evil twin while it
is in the process of being deleted will cause errors to be thrown as it
tries to send messages to $. This can occur with other messages that
call ToCliObject in user.kod. The removal of poOriginal will now be
posted, so any calls that require this data will still succeed while in
the process of deletion.