### PR TITLE
Fix poOriginal checks and deletion in reflection/ET. Fix minion behavior towards revenants due to increased hatred from vision code. Revenant place timer fix.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -164,6 +164,8 @@ messages:
    {
       % Delete the evil twin if the original dies.
       if victim = poOriginal
+         OR (poCaster <> $
+            AND victim = poCaster)
       {
          Post(self,@Delete);
       }
@@ -218,11 +220,20 @@ messages:
 
    ReqSomethingEntered(what=$)
    {
-      if NOT Send(poOriginal,@IsLoggedOn)
+      if poOriginal = $
       {
-         Post(self,@Delete);
+         return;
       }
-      
+      else
+      {
+         if NOT Send(poOriginal,@IsLoggedOn)
+         {
+            Post(self,@Delete);
+
+            return;
+         }
+      }
+
       propagate;
    }
 
@@ -230,13 +241,15 @@ messages:
    {
       if poOriginal = $
       {
-         Post(self,@Delete);
+         return;
       }
 
       if IsClass(poOriginal,&Player)
          AND NOT Send(poOriginal,@IsLoggedOn)
       {
          Post(self,@Delete);
+
+         return;
       }
 
       if what = poOriginal
@@ -246,7 +259,7 @@ messages:
          {
             Post(self,@Delete);
 
-            propagate;
+            return;
          }
          else
          {
@@ -259,20 +272,25 @@ messages:
 
    GotoOriginal()
    {
+      local oOriginalOwner;
+
       if poOriginal = $
       {
-         Post(self,@Delete);
-
          return;
       }
 
-      Send(Send(poOriginal,@GetOwner),@NewHold,#what=self,
-           #new_row = Send(poOriginal,@GetRow),#new_col = Send(poOriginal,@GetCol),
-           #new_angle = Send(poOriginal,@GetAngle));
-      if poOriginal <> poMaster
+      if Send(poOriginal,@IsLoggedOn)
       {
-         Post(self,@TargetSwitch,#what=poOriginal,#iHatred=1000);
-         Post(self,@EnterStateChase);
+         oOriginalOwner = Send(poOriginal,@GetOwner);
+         Send(oOriginalOwner,@NewHold,#what=self,
+               #new_row = Send(poOriginal,@GetRow),
+               #new_col = Send(poOriginal,@GetCol),
+               #new_angle = Send(poOriginal,@GetAngle));
+         if poOriginal <> poMaster
+         {
+            Post(self,@TargetSwitch,#what=poOriginal,#iHatred=1000);
+            Post(self,@EnterStateChase);
+         }
       }
 
       return;
@@ -281,6 +299,11 @@ messages:
 
    GetOriginalInfo()
    {
+      if poOriginal = $
+      {
+         return;
+      }
+
       vrIcon = Send(poOriginal,@GetPlayerIcon);
       vrName = Send(poOriginal,@GetTrueName);
       piGender = Send(poOriginal,@GetGender);
@@ -295,8 +318,6 @@ messages:
 
       if poOriginal = $
       {
-         Post(self,@Delete);
-
          return 0;
       }
 
@@ -309,6 +330,11 @@ messages:
    {
       local iWeapon;
 
+      if poOriginal = $
+      {
+         return 0;
+      }
+
       iWeapon = Send(poOriginal,@GetWeapon);
       if iWeapon <> $
       {
@@ -318,13 +344,13 @@ messages:
       return 1;
    }
 
-   % This returns the battler's ability to-hit.  Ranges from 1 to 1000
+   % This returns the battler's ability to-hit.
    GetOffense(what = $, stroke_obj=$)
    {
       return Send(poOriginal,@GetOffense,#what=what,#stroke_obj=stroke_obj);
    }
 
-   % This returns the battler's ability to avoid being hit.  Ranges from 1 to 1000.
+   % This returns the battler's ability to avoid being hit.
    GetDefense(what = $, stroke_obj=$)
    {
       return Send(poOriginal,@GetDefense,#what=what,#stroke_obj=stroke_obj);
@@ -333,6 +359,11 @@ messages:
    GetDamage(what=$,stroke_obj=$)
    {
       local oStroke;
+
+      if poOriginal = $
+      {
+         return 0;
+      }
 
       oStroke = stroke_obj;
       if IsClass(poOriginal,&Player)
@@ -548,16 +579,16 @@ messages:
 
    SendAnimation()
    {
-       Send(poOriginal,@SendAnimation,#iAnimation=piAnimation);
+      Send(poOriginal,@SendAnimation,#iAnimation=piAnimation);
 
-       return;
+      return;
    }
 
    SendOverlays()
    {
-       Send(poOriginal,@SendOverlays,#iAnimation=piAnimation);
+      Send(poOriginal,@SendOverlays,#iAnimation=piAnimation);
 
-       return;
+      return;
    }
 
    GetIllusionForm()
@@ -569,8 +600,6 @@ messages:
    {
       if poOriginal = $
       {
-         Post(self,@Delete);
-
          return;
       }
 
@@ -584,6 +613,19 @@ messages:
       Send(what,@SendLookPlayer,#what=poOriginal);
 
       return;
+   }
+
+   SpecialHatredBehavior(what=$)
+   {
+      % Trying to reduce the tendency of reflections to turn on themselves
+      %  or their master.
+      if IsClass(what,&Revenant)
+         OR IsClass(what,&EvilTwin)
+      {
+         return -2000;
+      }
+
+      return 0;
    }
 
    GetCaster()

--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -152,13 +152,17 @@ messages:
    {
       if poOriginal = $
       {
-         Post(self,@Delete);
+         return;
       }
-
-      if IsClass(poOriginal,&Player)
-         AND NOT Send(poOriginal,@IsLoggedOn)
+      else
       {
-         Post(self,@Delete);
+         if IsClass(poOriginal,&Player)
+            AND NOT Send(poOriginal,@IsLoggedOn)
+         {
+            Post(self,@Delete);
+
+            return;
+         }
       }
 
       propagate;
@@ -168,15 +172,16 @@ messages:
    {
       if poOriginal = $
       {
-         Post(self,@Delete);
+         return;
       }
-      else
+
+      if IsClass(poOriginal,&Player)
+         AND NOT Send(poOriginal,@IsLoggedOn)
       {
-         if IsClass(poOriginal,&Player)
-            AND NOT Send(poOriginal,@IsLoggedOn)
-         {
-            Post(self,@Delete);
-         }
+         % This happens when the original leaves (i.e. logs off), and the
+         % reflection is deleted when it is removed from the system list.
+         % We don't need to delete it again here.
+         return;
       }
 
       propagate;
@@ -188,6 +193,8 @@ messages:
       if victim = poOriginal
       {
          Post(self,@Delete);
+
+         return;
       }
 
       propagate;
@@ -199,7 +206,7 @@ messages:
 
       if poOriginal = $
       {
-         Send(self,@Delete);
+         return;
       }
 
       % Ignore mana drain for non-players.
@@ -208,9 +215,10 @@ messages:
          return;
       }
 
-      if not Send(poOriginal,@IsLoggedOn)
+      if NOT Send(poOriginal,@IsLoggedOn)
       {
          Send(self,@Delete);
+
          return;
       }
 
@@ -235,7 +243,7 @@ messages:
 
       if poOwner <> $
          AND (IsClass(poOriginal,&Monster)
-            OR Send(poOriginal,@isLoggedOn))
+            OR Send(poOriginal,@IsLoggedOn))
       {
          Send(poOwner,@SomeoneSaid,#type=SAY_MESSAGE,#string=reflection_delete,
               #what=self,#parm1=Send(self,@GetDef,#cap=TRUE),
@@ -285,7 +293,7 @@ messages:
    {
       if poOriginal = $
       {
-         Post(self,@Delete);
+         return;
       }
 
       if IsClass(poOriginal,&Player)
@@ -312,8 +320,6 @@ messages:
 
       if poOriginal = $
       {
-         Post(self,@Delete);
-
          return 0;
       }
 
@@ -328,7 +334,7 @@ messages:
 
       if poOriginal = $
       {
-         Post(self,@Delete);
+         return 0;
       }
 
       if IsClass(poOriginal,&Player)
@@ -361,6 +367,11 @@ messages:
    GetDamage(what = $, stroke_obj=$)
    {
       local oStroke;
+
+      if poOriginal = $
+      {
+         return 0;
+      }
 
       oStroke = stroke_obj;
       if IsClass(poOriginal,&Player)
@@ -395,7 +406,7 @@ messages:
    {
       if poOriginal = $
       {
-         post(self,@Delete);
+         return;
       }
 
       % Our source object changed; tell everyone that we've changed, too.
@@ -422,10 +433,12 @@ messages:
    }
 
    SomethingChangedTimer()
-   "Tell room that we've changed.  This is on a timer to avoid tons of changes sent all at once."
+   "Tell room that we've changed.  This is on a timer to avoid tons "
+   "of changes sent all at once."
    {
       ptSomethingChanged = $;
-      if (poOwner <> $) 
+      if poOriginal <> $
+         AND poOwner <> $
       {
          Post(poOwner,@SomethingChanged,#what=self);
       }
@@ -439,6 +452,7 @@ messages:
       {
          Debug("Reflection called with invalid $ SetOriginal");
       }
+
       poOriginal = who;
       piMax_Hit_Points = piSpellpower / 3;
       piMax_hit_points = Bound(piMax_hit_points,15,40);
@@ -559,6 +573,11 @@ messages:
          return;
       }
 
+      if poOriginal = $
+      {
+         return;
+      }
+
       if IsClass(poOriginal,&Player)
       {
          if Send(poOriginal,@CheckPlayerFlag,#flag=PFLAG_INVISIBLE)
@@ -634,7 +653,7 @@ messages:
          OR IsClass(what,&Revenant)
          OR IsClass(what,&EvilTwin)
       {
-         return -100;
+         return -1000;
       }
 
       return 0;

--- a/kod/object/active/holder/nomoveon/battler/monster/revenant.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/revenant.kod
@@ -131,6 +131,17 @@ messages:
       propagate;
    }
 
+   Delete()
+   {
+      if ptPlace <> $
+      {
+         DeleteTimer(ptPlace);
+      }
+      ptPlace = $;
+
+      propagate;
+   }
+
    Place()
    "Sets revenant down near (but not too near) his target"
    {

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/tostwn/tswatch.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/tostwn/tswatch.kod
@@ -1090,6 +1090,7 @@ messages:
                      j = Send(poOwner,@HolderExtractObject,#data=i);
                      if IsClass(j,&Monster)
                         AND NOT (Send(j,@GetBehavior) & AI_NPC)
+                        AND NOT (Send(j,@GetMaster) = poChampion)
                      {
                         Post(j,@Delete);
                      }
@@ -1880,9 +1881,9 @@ messages:
 
    Teleport(what=$, goinplay=FALSE, outofplay=FALSE)
    {
-      local i, bInList, iAmount;
+      local i, bInList, iAmount, lMinions;
 
-      if goinplay OR Send(self,@IsCombatant,#who=what)   
+      if goinplay OR Send(self,@IsCombatant,#who=what)
       {
          % teleport to the playing field
          bInList = FALSE;
@@ -1891,28 +1892,31 @@ messages:
             if First(i) = what
             {
                bInList = TRUE;
-            }   
+            }
          }
 
-         if NOT bInList
+         if IsClass(what,&Player)
          {
-            plUserStats = Cons([ what,Send(what,@GetHealth),
-                                 Send(what,@GetMana),Send(what,@GetVigor)
-                               ],plUserStats);     
-         }
+            if NOT bInList
+            {
+               plUserStats = Cons([ what,Send(what,@GetHealth),
+                                    Send(what,@GetMana),Send(what,@GetVigor)
+                                  ],plUserStats);     
+            }
 
-         if Send(what,@GetHealth) < Send(what,@GetMaxHealth)
-         {
-            Send(what,@GainHealthNormal,#amount=200);
-         }
+            if Send(what,@GetHealth) < Send(what,@GetMaxHealth)
+            {
+               Send(what,@GainHealthNormal,#amount=200);
+            }
 
-         if Send(what,@GetMana) < Send(what,@GetMaxMana)
-         {
-            iAmount = Send(what,@GetMaxMana) - Send(what,@GetMana);
-            Send(what,@GainMana,#amount=iAmount);
-         }
+            if Send(what,@GetMana) < Send(what,@GetMaxMana)
+            {
+               iAmount = Send(what,@GetMaxMana) - Send(what,@GetMana);
+               Send(what,@GainMana,#amount=iAmount);
+            }
 
-         Send(what,@AddExertion,#amount=-2000000);
+            Send(what,@AddExertion,#amount=-2000000);
+         }
       }
       else
       {
@@ -1931,10 +1935,25 @@ messages:
       }
 
       Send(poOwner,@Teleport,#what=what,#goinplay=goinplay,
-           #outofplay=outofplay);
+            #outofplay=outofplay);
+      if IsClass(what,&Player)
+      {
+         lMinions = Send(what,@GetControlledMinions);
+         if lMinions <> $
+         {
+            for i in lMinions
+            {
+               if Send(i,@GetOwner) = Send(self,@GetOwner)
+               {
+                  Send(poOwner,@Teleport,#what=i,#goinplay=goinplay,
+                        #outofplay=outofplay);
+               }
+            }
+         }
+      }
 
       return;
-    }
+   }
 
    ClearCombatants()
    {

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -1125,7 +1125,7 @@ messages:
 
       for i in plReflections
       {
-         if first(i) = what
+         if First(i) = what
          {
             for j in Nth(i,2)
             {
@@ -1139,14 +1139,15 @@ messages:
             break;
          }
       }
+
       if (poQormas <> $)
       {
-         Send(poQormas, @UserLogoff, #who = what);
+         Send(poQormas,@UserLogoff,#who=what);
       }
 
       return;
    }
-   
+
    DeletePlayerReflections(who = $)
    {
       local i, j;
@@ -1156,45 +1157,45 @@ messages:
 
       for i in plReflections
       {
-         if first(i) = who
+         if First(i) = who
          {
             for j in Nth(i,2)
             {
-               Send(j,@Delete);
+               Post(j,@Delete);
             }
 
             break;
          }
       }
-      
+
       return;
    }
 
-   AddReflection(who = $, oreflection = $)
+   AddReflection(who = $, oReflection = $)
    {
-      local i,j;
+      local i, j;
 
       % Remember: plReflections format is:
       % [[player,[ref1,ref2]],[player2,[ref1,ref2]],...]
 
       for i in plReflections
       {
-         if first(i) = who
+         if First(i) = who
          {
-            SetNth(i,2,cons(oreflection,Nth(i,2)));
+            SetNth(i,2,Cons(oReflection,Nth(i,2)));
 
             return;
          }
       }
 
-      plReflections = cons([who,[oreflection]],plReflections);
+      plReflections = Cons([who,[oReflection]],plReflections);
 
       return;
    }
 
-   RemoveReflection(oreflection = $)
+   RemoveReflection(oReflection = $)
    {
-      local i,j;
+      local i, j;
 
       % Remember: plReflections format is:
       % [[player,[ref1,ref2]],[player2,[ref1,ref2]],...]
@@ -1203,7 +1204,7 @@ messages:
       {
          for j in Nth(i,2)
          {
-            if j = oreflection
+            if j = oReflection
             {
                SetNth(i,2,DelListElem(Nth(i,2),j));
             }
@@ -1211,13 +1212,16 @@ messages:
 
          if Length(Nth(i,2)) = 0
          {
-            plReflections = DelListElem(plReflections,i);
+            if FindListElem(plReflections,i)
+            {
+               plReflections = DelListElem(plReflections,i);
+            }
          }
       }
 
       return;
    }
-   
+
    GetReflectionsList()
    {
       return plReflections;
@@ -1225,20 +1229,20 @@ messages:
 
    CleanReflectionList()
    {
-      local i,j;
+      local i, j;
 
       % Remember: plReflections format is:
       % [[player,[ref1,ref2]],[player2,[ref1,ref2]],...]
 
       for i in plReflections
       {
-         if first(i) = $
-            OR (IsClass(first(i),&Player)
-                AND (NOT Send(first(i),@IsLoggedOn)))
+         if First(i) = $
+            OR (IsClass(First(i),&Player)
+               AND (NOT Send(First(i),@IsLoggedOn)))
          {
             for j in Nth(i,2)
             {
-               Send(j,@delete);
+               Send(j,@Delete);
             }
          }
       }


### PR DESCRIPTION
More messages in reflection and evil twin that need checking for a $ poOriginal. Fix delete being called multiple times, and adjust hatred behavior of reflection/ET vs. revenants to allow for increased hatred
from vision check. Delete any remaining ptPlace timer for revenants when the revenant is deleted.