### PR TITLE
Deactivate D3DPOOL_MANAGED again (due to few incompatible GPU)

### DIFF
--- a/clientd3d/d3ddriver.c
+++ b/clientd3d/d3ddriver.c
@@ -359,8 +359,8 @@ Bool D3DDriverProfileInit(void)
 
 	gD3DDriverProfile.texMemTotal = IDirect3DDevice9_GetAvailableTextureMem(gpD3DDevice);
 
-//	if (gD3DDriverProfile.texMemTotal < (32 * 1024 * 1024))
-	if (1)
+	if (gD3DDriverProfile.texMemTotal < (32 * 1024 * 1024))
+//	if (1)
 	{
 //		gD3DDriverProfile.texMemTotal = (32 * 1024 * 1024);
 		gD3DDriverProfile.bManagedTextures = TRUE;


### PR DESCRIPTION
This reverts https://github.com/Daenks/Meridian59_103/commit/e651a2c9fc4bf349962295aaabd26ce32224de99 , which enabled D3DPOOL_MANAGED.
There is 1 verified error report of a fully black-screen after login which is caused by this change.
And another one in the 103 globes which is very likely connected to this change.
