### PR TITLE
Move minimap flags, name color flags, move on type, object type and drawing effect flags into their own separate fields. Object flags now just holds boolean flags, and all fields can be used for future content.

### DIFF
--- a/clientd3d/animate.c
+++ b/clientd3d/animate.c
@@ -190,7 +190,7 @@ Bool AnimateObject(object_node *obj, int dt)
       DWORD angleFlash;
       obj->bounceTime += min(dt,50);
       if (obj->bounceTime > TIME_FLASH)
-	 obj->bounceTime -= TIME_FLASH;
+         obj->bounceTime -= TIME_FLASH;
       angleFlash = NUMDEGREES * obj->bounceTime / TIME_FLASH;
       obj->lightAdjust = FIXED_TO_INT(fpMul(FLASH_LEVEL, SIN(angleFlash)));
       need_redraw = TRUE;
@@ -209,7 +209,7 @@ Bool AnimateObject(object_node *obj, int dt)
       int anglePhase;
       obj->phaseTime += min(dt,40);
       if (obj->phaseTime > TIME_FULL_OBJECT_PHASE)
-	 obj->phaseTime -= TIME_FULL_OBJECT_PHASE;
+         obj->phaseTime -= TIME_FULL_OBJECT_PHASE;
       anglePhase = numPhases * obj->phaseTime / TIME_FULL_OBJECT_PHASE;
       obj->drawingflags = (~DRAWFX_EFFECT_MASK & obj->drawingflags) | phaseStates[anglePhase];
       need_redraw = TRUE;

--- a/clientd3d/animate.c
+++ b/clientd3d/animate.c
@@ -211,7 +211,7 @@ Bool AnimateObject(object_node *obj, int dt)
       if (obj->phaseTime > TIME_FULL_OBJECT_PHASE)
          obj->phaseTime -= TIME_FULL_OBJECT_PHASE;
       anglePhase = numPhases * obj->phaseTime / TIME_FULL_OBJECT_PHASE;
-      obj->drawingflags = (~DRAWFX_EFFECT_MASK & obj->drawingflags) | phaseStates[anglePhase];
+      obj->drawingtype = (~DRAWFX_EFFECT_MASK & obj->drawingtype) | phaseStates[anglePhase];
       need_redraw = TRUE;
    }
    // Animate object's overlays

--- a/clientd3d/animate.c
+++ b/clientd3d/animate.c
@@ -37,9 +37,9 @@ static DWORD timeLastFrame;
 
 #define TIME_FULL_OBJECT_PHASE 1800
 static int phaseStates[] = {
-   OF_DRAW_PLAIN,OF_TRANSLUCENT75,OF_TRANSLUCENT50,OF_TRANSLUCENT25,OF_INVISIBLE,
-   OF_INVISIBLE,OF_INVISIBLE,
-   OF_TRANSLUCENT25,OF_TRANSLUCENT50,OF_TRANSLUCENT75,OF_DRAW_PLAIN};
+   DRAWFX_DRAW_PLAIN,DRAWFX_TRANSLUCENT75,DRAWFX_TRANSLUCENT50,DRAWFX_TRANSLUCENT25,DRAWFX_INVISIBLE,
+   DRAWFX_INVISIBLE,DRAWFX_INVISIBLE,
+   DRAWFX_TRANSLUCENT25,DRAWFX_TRANSLUCENT50,DRAWFX_TRANSLUCENT75,DRAWFX_DRAW_PLAIN};
 static int numPhases = sizeof(phaseStates) / sizeof(int);
 
 extern room_type current_room;
@@ -179,13 +179,13 @@ Bool AnimateObject(object_node *obj, int dt)
    Bool need_redraw = False;
    list_type over_list;
 
-   if (OF_FLICKERING == (OF_BOUNCING & obj->flags))
+   if (OF_FLICKERING == (OF_FLICKERING & obj->flags))
    {
       obj->lightAdjust = rand() % FLICKER_LEVEL;
       need_redraw = TRUE;
    }
 
-   if (OF_FLASHING == (OF_BOUNCING & obj->flags))
+   if (OF_FLASHING == (OF_FLASHING & obj->flags))
    {
       DWORD angleFlash;
       obj->bounceTime += min(dt,50);
@@ -211,7 +211,7 @@ Bool AnimateObject(object_node *obj, int dt)
       if (obj->phaseTime > TIME_FULL_OBJECT_PHASE)
 	 obj->phaseTime -= TIME_FULL_OBJECT_PHASE;
       anglePhase = numPhases * obj->phaseTime / TIME_FULL_OBJECT_PHASE;
-      obj->flags = (~OF_EFFECT_MASK & obj->flags) | phaseStates[anglePhase];
+      obj->drawingflags = (~DRAWFX_EFFECT_MASK & obj->drawingflags) | phaseStates[anglePhase];
       need_redraw = TRUE;
    }
    // Animate object's overlays

--- a/clientd3d/animate.c
+++ b/clientd3d/animate.c
@@ -211,7 +211,7 @@ Bool AnimateObject(object_node *obj, int dt)
       if (obj->phaseTime > TIME_FULL_OBJECT_PHASE)
          obj->phaseTime -= TIME_FULL_OBJECT_PHASE;
       anglePhase = numPhases * obj->phaseTime / TIME_FULL_OBJECT_PHASE;
-      obj->drawingtype = (~DRAWFX_EFFECT_MASK & obj->drawingtype) | phaseStates[anglePhase];
+      obj->drawingtype = phaseStates[anglePhase];
       need_redraw = TRUE;
    }
    // Animate object's overlays

--- a/clientd3d/client3d.c
+++ b/clientd3d/client3d.c
@@ -116,7 +116,7 @@ list_type GetObjects3D(int x, int y, int distance, int pos_flags, int neg_flags,
 /*
  * GetObjectByPosition:  Return the room_contents_node for the closest object
  *   under (x, y), or NULL if none.  Arguments are as in GetObjects3D above,
- *   except that function also handles drawingflags and this one does not.
+ *   except that function also handles drawingtype and this one does not.
  */
 room_contents_node *GetObjectByPosition(int x, int y, int distance, int pos_flags, int neg_flags)
 {

--- a/clientd3d/client3d.c
+++ b/clientd3d/client3d.c
@@ -39,12 +39,13 @@ extern RECT rcBackgroundOveray;
  *   The list is newly allocated and should be freed by the caller.
  *   The "distance" field of each element in the list is also filled in.
  */
-list_type GetObjects3D(int x, int y, int distance, int pos_flags, int neg_flags)
+list_type GetObjects3D(int x, int y, int distance, int pos_flags, int neg_flags,
+                       BYTE pos_drawingflags, BYTE neg_drawingflags)
 {
    static room_contents_node sunNode;
    list_type new_list = NULL;
    room_contents_node *r;
-   int i, pos_effect, neg_effect, obj_flags;
+   int i, obj_flags, obj_drawingflags;
    extern Bool map;
 
    if (IsBlind())
@@ -53,44 +54,39 @@ list_type GetObjects3D(int x, int y, int distance, int pos_flags, int neg_flags)
    if (map)
       return NULL;
 
-   // Split out object drawing effects
-   pos_effect = GetDrawingEffect(pos_flags);
-   neg_effect = GetDrawingEffect(neg_flags);
-   pos_flags &= ~OF_EFFECT_MASK;
-   neg_flags &= ~OF_EFFECT_MASK;
-
    for (i=0; i < num_visible_objects; i++)
    {
       if (distance > 0 && visible_objects[i].distance > distance)
-	 continue;
+         continue;
 
       r = GetRoomObjectById(visible_objects[i].id);
       if (r == NULL)
-	 continue;
+         continue;
 
       if (visible_objects[i].id != r->obj.id)
-	 continue;
+         continue;
 
       // Check screen area, if desired
       if (x != NO_COORD_CHECK && y != NO_COORD_CHECK)
       {
-	 if (visible_objects[i].left_col > x ||
-	  visible_objects[i].right_col < x ||
-	  visible_objects[i].top_row > y ||
-	  visible_objects[i].bottom_row < y)
-	    continue;
+         if (visible_objects[i].left_col > x ||
+         visible_objects[i].right_col < x ||
+         visible_objects[i].top_row > y ||
+         visible_objects[i].bottom_row < y)
+            continue;
       }
 
       obj_flags = r->obj.flags;
+      obj_drawingflags = r->obj.drawingflags;
 
-      if ((pos_effect != 0 && GetDrawingEffect(obj_flags) != pos_effect) ||
-	  (neg_effect != 0 && GetDrawingEffect(obj_flags) == neg_effect))
-	 continue;
+      if ((pos_drawingflags != 0 && GetDrawingEffect(obj_drawingflags) != pos_drawingflags)
+      || (neg_drawingflags != 0 && GetDrawingEffect(obj_drawingflags) == neg_drawingflags))
+         continue;
 
       if ((pos_flags == 0 || (obj_flags & pos_flags) != 0) && (obj_flags & neg_flags) == 0)
       {
-	 r->distance = visible_objects[i].distance;
-	 new_list = list_add_sorted_item(new_list, r, CompareRoomObjectDistance);
+         r->distance = visible_objects[i].distance;
+         new_list = list_add_sorted_item(new_list, r, CompareRoomObjectDistance);
       }
    }
 
@@ -100,18 +96,18 @@ list_type GetObjects3D(int x, int y, int distance, int pos_flags, int neg_flags)
       for (l = current_room.bg_overlays; l != NULL; l = l->next)
       {
          BackgroundOverlay *overlay = (BackgroundOverlay *)(l->data);
-	 if (overlay->drawn)
-	 {
-	    POINT pt;
-	    pt.x = x;
-	    pt.y = y;
-	    if (PtInRect(&overlay->rcScreen,pt))
-	    {
-	       memset(&sunNode,0,sizeof(sunNode));
-	       memcpy(&sunNode.obj,&overlay->obj,sizeof(object_node));
-	       new_list = list_add_item(new_list,&sunNode);
-	    }
-	 }
+         if (overlay->drawn)
+         {
+            POINT pt;
+            pt.x = x;
+            pt.y = y;
+            if (PtInRect(&overlay->rcScreen,pt))
+            {
+               memset(&sunNode,0,sizeof(sunNode));
+               memcpy(&sunNode.obj,&overlay->obj,sizeof(object_node));
+               new_list = list_add_item(new_list,&sunNode);
+            }
+         }
       }
    }
    return new_list;
@@ -119,7 +115,8 @@ list_type GetObjects3D(int x, int y, int distance, int pos_flags, int neg_flags)
 /************************************************************************/
 /*
  * GetObjectByPosition:  Return the room_contents_node for the closest object
- *   under (x, y), or NULL if none.  Arguments are as in GetObjects3D above.
+ *   under (x, y), or NULL if none.  Arguments are as in GetObjects3D above,
+ *   except that function also handles drawingflags and this one does not.
  */
 room_contents_node *GetObjectByPosition(int x, int y, int distance, int pos_flags, int neg_flags)
 {

--- a/clientd3d/client3d.c
+++ b/clientd3d/client3d.c
@@ -79,8 +79,8 @@ list_type GetObjects3D(int x, int y, int distance, int pos_flags, int neg_flags,
       obj_flags = r->obj.flags;
       obj_drawingflags = r->obj.drawingflags;
 
-      if ((pos_drawingflags != 0 && GetDrawingEffect(obj_drawingflags) != pos_drawingflags)
-      || (neg_drawingflags != 0 && GetDrawingEffect(obj_drawingflags) == neg_drawingflags))
+      if ((pos_drawingflags != 0 && obj_drawingflags != pos_drawingflags)
+      || (neg_drawingflags != 0 && obj_drawingflags == neg_drawingflags))
          continue;
 
       if ((pos_flags == 0 || (obj_flags & pos_flags) != 0) && (obj_flags & neg_flags) == 0)

--- a/clientd3d/client3d.c
+++ b/clientd3d/client3d.c
@@ -40,12 +40,12 @@ extern RECT rcBackgroundOveray;
  *   The "distance" field of each element in the list is also filled in.
  */
 list_type GetObjects3D(int x, int y, int distance, int pos_flags, int neg_flags,
-                       BYTE pos_drawingflags, BYTE neg_drawingflags)
+                       BYTE pos_drawingtype, BYTE neg_drawingtype)
 {
    static room_contents_node sunNode;
    list_type new_list = NULL;
    room_contents_node *r;
-   int i, obj_flags, obj_drawingflags;
+   int i, obj_flags, obj_drawingtype;
    extern Bool map;
 
    if (IsBlind())
@@ -77,10 +77,10 @@ list_type GetObjects3D(int x, int y, int distance, int pos_flags, int neg_flags,
       }
 
       obj_flags = r->obj.flags;
-      obj_drawingflags = r->obj.drawingflags;
+      obj_drawingtype = r->obj.drawingtype;
 
-      if ((pos_drawingflags != 0 && obj_drawingflags != pos_drawingflags)
-      || (neg_drawingflags != 0 && obj_drawingflags == neg_drawingflags))
+      if ((pos_drawingtype != 0 && obj_drawingtype != pos_drawingtype)
+      || (neg_drawingtype != 0 && obj_drawingtype == neg_drawingtype))
          continue;
 
       if ((pos_flags == 0 || (obj_flags & pos_flags) != 0) && (obj_flags & neg_flags) == 0)

--- a/clientd3d/client3d.h
+++ b/clientd3d/client3d.h
@@ -23,7 +23,7 @@ PDIB GetPointFloorTexture(int x, int y);
 int GetPointDepth(int x, int y);
 
 M59EXPORT list_type    GetObjects3D(int x, int y, int distance, int pos_flags, int neg_flags,
-                                    BYTE pos_drawingflags, BYTE neg_drawingflags);
+                                    BYTE pos_drawingtype, BYTE neg_drawingtype);
 M59EXPORT room_contents_node *GetObjectByPosition(int x, int y, int distance, int pos_flags, int neg_flags);
 int          GetVisibleObjects(ObjectRange **objs);
 ObjectRange *FindVisibleObjectById(ID obj_id);

--- a/clientd3d/client3d.h
+++ b/clientd3d/client3d.h
@@ -22,7 +22,8 @@ PDIB GetPointCeilingTexture(int x, int y);
 PDIB GetPointFloorTexture(int x, int y);
 int GetPointDepth(int x, int y);
 
-M59EXPORT list_type    GetObjects3D(int x, int y, int distance, int pos_flags, int neg_flags);
+M59EXPORT list_type    GetObjects3D(int x, int y, int distance, int pos_flags, int neg_flags,
+                                    BYTE pos_drawingflags, BYTE neg_drawingflags);
 M59EXPORT room_contents_node *GetObjectByPosition(int x, int y, int distance, int pos_flags, int neg_flags);
 int          GetVisibleObjects(ObjectRange **objs);
 ObjectRange *FindVisibleObjectById(ID obj_id);

--- a/clientd3d/color.c
+++ b/clientd3d/color.c
@@ -61,7 +61,9 @@ static char colorinfo[][15] = {
 
 static char color_section[] = "Colors";  /* Section for colors in INI file */
 
-// Colors for drawing player names
+/* Colors for drawing player names. These are no longer
+   needed since we send RGB hex values. Keeping these
+   here for now.
 #define NAME_COLOR_NORMAL_FG   PALETTERGB(255, 255, 255)
 #define NAME_COLOR_OUTLAW_FG   PALETTERGB(252, 128, 0)
 #define NAME_COLOR_KILLER_FG   PALETTERGB(255, 0, 0)
@@ -71,7 +73,7 @@ static char color_section[] = "Colors";  /* Section for colors in INI file */
 #define NAME_COLOR_DM_FG       PALETTEINDEX(254) // cyan
 #define NAME_COLOR_MOD_FG      PALETTERGB(0, 120, 255)
 #define NAME_COLOR_BLACK_FG    PALETTERGB(0, 0, 0)
-#define NAME_COLOR_DAENKS_FG   PALETTERGB(179,0,179)
+#define NAME_COLOR_DAENKS_FG   PALETTERGB(179,0,179)*/
 
 extern HPALETTE hPal;
 
@@ -435,31 +437,18 @@ WORD GetItemListColor(HWND hwnd, int type, int flags)
 * GetPlayerNameColor:  Return color that player's name should be drawn in,
 *   depending on player's object flags
 */
-COLORREF GetPlayerNameColor(int flags,char*name)
+COLORREF GetPlayerNameColor(object_node* obj, char *name)
 {
-	if (GetDrawingEffect(flags) == OF_BLACK)
-		return NAME_COLOR_BLACK_FG;
+   int r, g, b;
 
-	switch (GetPlayerFlags(flags))
-	{
-		case PF_DM:
-			return NAME_COLOR_DM_FG;
-		case PF_KILLER:
-			return NAME_COLOR_KILLER_FG;
-		case PF_OUTLAW:
-			return NAME_COLOR_OUTLAW_FG;
-		case PF_CREATOR:
-			return NAME_COLOR_DAENKS_FG;
-		case PF_SUPER:
-			return NAME_COLOR_SUPER_FG;
-		case PF_MODERATOR:
-			return NAME_COLOR_MOD_FG;
-		case PF_EVENTCHAR:
-			return NAME_COLOR_EVENT_FG;
-            
-    default:
-			return NAME_COLOR_NORMAL_FG;
-	}
+   if (GetDrawingEffect(obj->flags) == OF_BLACK)
+      return PALETTERGB(0,0,0);
+
+     r = (obj->namecolor & 0xFF0000) >> 16;
+     g = (obj->namecolor & 0x00FF00) >> 8;
+     b = (obj->namecolor & 0x0000FF);
+
+     return PALETTERGB(r, g, b);
 }
 
 /****************************************************************************/
@@ -467,26 +456,13 @@ COLORREF GetPlayerNameColor(int flags,char*name)
 * GetPlayerWhoNameColor:  Return color that player's name should be drawn on
 *   the who list, depending on player's object flags
 */
-COLORREF GetPlayerWhoNameColor(int flags,char*name)
+COLORREF GetPlayerWhoNameColor(object_node* obj, char *name)
 {
-    switch (GetPlayerFlags(flags))
-    {
-        case PF_DM:
-            return NAME_COLOR_DM_FG;
-        case PF_CREATOR:
-            return NAME_COLOR_DAENKS_FG;
-        case PF_SUPER:
-            return NAME_COLOR_SUPER_FG;
-        case PF_EVENTCHAR:
-            return NAME_COLOR_EVENT_FG;
-        case PF_KILLER:
-            return NAME_COLOR_KILLER_FG;
-        case PF_OUTLAW:
-            return NAME_COLOR_OUTLAW_FG;
-        case PF_MODERATOR:
-            return NAME_COLOR_MOD_FG;
+     int r, g, b;
 
-        default:
-            return NAME_COLOR_NORMAL_FG;
-    }
+     r = (obj->namecolor & 0xFF0000) >> 16;
+     g = (obj->namecolor & 0x00FF00) >> 8;
+     b = (obj->namecolor & 0x0000FF);
+
+      return PALETTERGB(r, g, b);
 }

--- a/clientd3d/color.c
+++ b/clientd3d/color.c
@@ -441,7 +441,7 @@ COLORREF GetPlayerNameColor(object_node* obj, char *name)
 {
    int r, g, b;
 
-   if (obj->drawingflags == DRAWFX_BLACK)
+   if (obj->drawingtype == DRAWFX_BLACK)
       return PALETTERGB(0,0,0);
 
      r = (obj->namecolor & 0xFF0000) >> 16;

--- a/clientd3d/color.c
+++ b/clientd3d/color.c
@@ -441,7 +441,7 @@ COLORREF GetPlayerNameColor(object_node* obj, char *name)
 {
    int r, g, b;
 
-   if (GetDrawingEffect(obj->drawingflags) == DRAWFX_BLACK)
+   if (obj->drawingflags == DRAWFX_BLACK)
       return PALETTERGB(0,0,0);
 
      r = (obj->namecolor & 0xFF0000) >> 16;

--- a/clientd3d/color.c
+++ b/clientd3d/color.c
@@ -441,7 +441,7 @@ COLORREF GetPlayerNameColor(object_node* obj, char *name)
 {
    int r, g, b;
 
-   if (GetDrawingEffect(obj->flags) == OF_BLACK)
+   if (GetDrawingEffect(obj->drawingflags) == DRAWFX_BLACK)
       return PALETTERGB(0,0,0);
 
      r = (obj->namecolor & 0xFF0000) >> 16;

--- a/clientd3d/color.h
+++ b/clientd3d/color.h
@@ -52,8 +52,8 @@ void ColorsCreate(Bool use_defaults);
 void ColorsDestroy(void);
 M59EXPORT COLORREF GetColor(WORD color);
 M59EXPORT HBRUSH GetBrush(WORD color);
-COLORREF GetPlayerNameColor(int flags,char*name);
-COLORREF GetPlayerWhoNameColor(int flags,char*name);
+COLORREF GetPlayerNameColor(object_node* obj,char *name);
+COLORREF GetPlayerWhoNameColor(object_node* obj,char *name);
 
 void UserSelectColor(WORD color);
 void UserSelectColors(WORD fg, WORD bg);

--- a/clientd3d/d3dcache.h
+++ b/clientd3d/d3dcache.h
@@ -209,6 +209,7 @@ typedef struct d3d_render_chunk_new
 	Bool				(*pMaterialFctn)(struct d3d_render_chunk_new *pChunk);
 	d3d_render_cache	*pRenderCache;
 	u_int				flags;
+	BYTE				drawingflags;
 	u_int				curIndex;
 	u_int				startIndex;
 	u_int				numIndices;
@@ -246,6 +247,7 @@ typedef struct d3d_render_packet_new
 	int					effect;
 	int					numStages;
 	u_int				flags;
+	BYTE				drawingflags;
 	u_int				curChunk;
 	u_int				size;
 	d3d_render_chunk_new	renderChunks[PACKET_SIZE];

--- a/clientd3d/d3dcache.h
+++ b/clientd3d/d3dcache.h
@@ -209,7 +209,7 @@ typedef struct d3d_render_chunk_new
 	Bool				(*pMaterialFctn)(struct d3d_render_chunk_new *pChunk);
 	d3d_render_cache	*pRenderCache;
 	u_int				flags;
-	BYTE				drawingflags;
+	BYTE				drawingtype;
 	u_int				curIndex;
 	u_int				startIndex;
 	u_int				numIndices;
@@ -247,7 +247,7 @@ typedef struct d3d_render_packet_new
 	int					effect;
 	int					numStages;
 	u_int				flags;
-	BYTE				drawingflags;
+	BYTE				drawingtype;
 	u_int				curChunk;
 	u_int				size;
 	d3d_render_chunk_new	renderChunks[PACKET_SIZE];

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -3524,7 +3524,7 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
 			((float)pRNode->boundingHeightAdjust * 4.0f), (float)pRNode->motion.y);
 		MatrixMultiply(&xForm, &rot, &mat);
 
-		fg_color = GetPlayerNameColor(pRNode->obj.flags, pName);
+		fg_color = GetPlayerNameColor(&pRNode->obj, pName);
 
 		// Some names never grow darker, they use PALETTEINDEX().
 		if (HIBYTE(HIWORD(fg_color)) == HIBYTE(HIWORD(PALETTEINDEX(0))))

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -285,9 +285,9 @@ d3d_render_packet_new	*D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDI
 												PDIB pDib, BYTE xLat0, BYTE xLat1, BYTE effect);
 float					D3DRenderObjectLightGetNearest(room_contents_node *pRNode);
 void					D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
-							Draw3DParams *params, int flags);
+							Draw3DParams *params, BYTE flags);
 void					D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DParams *params,
-							BOOL underlays, int flags);
+							BOOL underlays, BYTE flags);
 void					D3DRenderProjectilesDrawNew(d3d_render_pool_new *pPool, room_type *room, Draw3DParams *params);
 void					D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DParams *params);
 void					D3DRenderPlayerOverlayOverlaysDraw(d3d_render_pool_new *pPool, list_type overlays,
@@ -4260,10 +4260,9 @@ int D3DRenderIsEnabled(void)
 
 void D3DRenderPaletteSet(UINT xlatID0, UINT xlatID1, BYTE flags)
 {
-	xlat	*pXLat0, *pXLat1;
+	xlat	*pXLat0, *pXLat1, *pXLatGrey;
 	Color	*pPalette;
 	int		i;
-	BYTE	effect;
 
 	return;
 
@@ -4271,9 +4270,8 @@ void D3DRenderPaletteSet(UINT xlatID0, UINT xlatID1, BYTE flags)
 	pXLat1 = FindStandardXlat(xlatID1);
 
 	pPalette = base_palette;
-	effect = flags;
 
-	switch (effect)
+	switch (flags)
 	{
 		case DRAWFX_DRAW_PLAIN:
 		case DRAWFX_DOUBLETRANS:
@@ -4316,11 +4314,24 @@ void D3DRenderPaletteSet(UINT xlatID0, UINT xlatID1, BYTE flags)
 		case DRAWFX_DITHERINVIS:
 			for (i = 0; i < 256; i++)
 			{
-				pXLat0 = FindStandardXlat(xlatID0);
-				pXLat1 = FindStandardXlat(xlatID1);
-				gPalette[i].peRed = pPalette[fastXLAT(i, pXLat1)].red;
-				gPalette[i].peGreen = pPalette[fastXLAT(i, pXLat1)].green;
-				gPalette[i].peBlue = pPalette[fastXLAT(i, pXLat1)].blue;
+				gPalette[i].peRed = pPalette[fastXLAT(i, pXLat0)].red;
+				gPalette[i].peGreen = pPalette[fastXLAT(i, pXLat0)].green;
+				gPalette[i].peBlue = pPalette[fastXLAT(i, pXLat0)].blue;
+
+				if (i == 254)
+					gPalette[i].peFlags = 0;
+				else
+					gPalette[i].peFlags = 255;
+			}
+		break;
+
+		case DRAWFX_DITHERGREY:
+			pXLatGrey = FindStandardXlat(XLAT_FILTERWHITE90);
+			for (i = 0; i < 256; i++)
+			{
+				gPalette[i].peRed = pPalette[fastXLAT(i, pXLatGrey)].red;
+				gPalette[i].peGreen = pPalette[fastXLAT(i, pXLatGrey)].green;
+				gPalette[i].peBlue = pPalette[fastXLAT(i, pXLatGrey)].blue;
 
 				if (i == 254)
 					gPalette[i].peFlags = 0;
@@ -4396,7 +4407,7 @@ void D3DRenderPaletteSet(UINT xlatID0, UINT xlatID1, BYTE flags)
 
 void D3DRenderPaletteSetNew(UINT xlatID0, UINT xlatID1, BYTE flags)
 {
-	xlat	*pXLat0, *pXLat1;
+	xlat	*pXLat0, *pXLat1, *pXLatGrey;
 	Color	*pPalette;
 	int		i;
 	BYTE	effect;
@@ -4450,11 +4461,24 @@ void D3DRenderPaletteSetNew(UINT xlatID0, UINT xlatID1, BYTE flags)
 		case DRAWFX_DITHERINVIS:
 			for (i = 0; i < 256; i++)
 			{
-				pXLat0 = FindStandardXlat(xlatID0);
-				pXLat1 = FindStandardXlat(xlatID1);
-				gPalette[i].peRed = pPalette[fastXLAT(i, pXLat1)].red;
-				gPalette[i].peGreen = pPalette[fastXLAT(i, pXLat1)].green;
-				gPalette[i].peBlue = pPalette[fastXLAT(i, pXLat1)].blue;
+				gPalette[i].peRed = pPalette[fastXLAT(i, pXLat0)].red;
+				gPalette[i].peGreen = pPalette[fastXLAT(i, pXLat0)].green;
+				gPalette[i].peBlue = pPalette[fastXLAT(i, pXLat0)].blue;
+
+				if (i == 254)
+					gPalette[i].peFlags = 0;
+				else
+					gPalette[i].peFlags = 255;
+			}
+		break;
+
+		case DRAWFX_DITHERGREY:
+			pXLatGrey = FindStandardXlat(XLAT_FILTERWHITE90);
+			for (i = 0; i < 256; i++)
+			{
+				gPalette[i].peRed = pPalette[fastXLAT(i, pXLatGrey)].red;
+				gPalette[i].peGreen = pPalette[fastXLAT(i, pXLatGrey)].green;
+				gPalette[i].peBlue = pPalette[fastXLAT(i, pXLatGrey)].blue;
 
 				if (i == 254)
 					gPalette[i].peFlags = 0;
@@ -6791,7 +6815,7 @@ d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDI
 }
 
 void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
-							 Draw3DParams *params, int flags)
+							 Draw3DParams *params, BYTE flags)
 {
 	D3DMATRIX			mat, rot, trans;
 	int					angleHeading, anglePitch, i, curObject;
@@ -6987,6 +7011,8 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 			bgra.a = D3DRENDER_TRANS50;
 		if (pRNode->obj.drawingtype == DRAWFX_DITHERINVIS)
 			bgra.a = D3DRENDER_TRANS50;
+		if (pRNode->obj.drawingtype == DRAWFX_DITHERGREY)
+			bgra.a = D3DRENDER_TRANS50;
 
 		for (i = 0; i < 4; i++)
 		{
@@ -7178,8 +7204,7 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 			pPacket->pMaterialFctn = &D3DMaterialObjectPacket;
 			pChunk = D3DRenderChunkNew(pPacket);
 			assert(pChunk);
-
-			pChunk->drawingtype = pRNode->obj.drawingtype | DRAWFX_TRANSLUCENT50;
+			pChunk->drawingtype = DRAWFX_TRANSLUCENT50;
 			pChunk->numIndices = 4;
 			pChunk->numVertices = 4;
 			pChunk->numPrimitives = pChunk->numVertices - 2;
@@ -7259,7 +7284,7 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 }
 
 void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DParams *params,
-						   BOOL underlays, int flags)
+						   BOOL underlays, BYTE flags)
 {
 	D3DMATRIX			mat, rot, trans;
 	int					angleHeading, anglePitch, i, curObject;
@@ -7571,7 +7596,7 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 					pChunk = D3DRenderChunkNew(pPacket);
 					assert(pChunk);
 
-					pChunk->drawingtype = pRNode->obj.drawingtype;
+					pChunk->drawingtype = DRAWFX_TRANSLUCENT50;;
 					pChunk->numIndices = 4;
 					pChunk->numVertices = 4;
 					pChunk->numPrimitives = pChunk->numVertices - 2;
@@ -7673,6 +7698,8 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 					if (pRNode->obj.drawingtype == DRAWFX_DITHERTRANS)
 						bgra.a = D3DRENDER_TRANS50;
 					if (pRNode->obj.drawingtype == DRAWFX_DITHERINVIS)
+						bgra.a = D3DRENDER_TRANS50;
+					if (pRNode->obj.drawingtype == DRAWFX_DITHERGREY)
 						bgra.a = D3DRENDER_TRANS50;
 
 					for (i = 0; i < 4; i++)
@@ -7894,7 +7921,7 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 						pChunk = D3DRenderChunkNew(pPacket);
 						assert(pChunk);
 
-						pChunk->drawingtype = pRNode->obj.drawingtype | DRAWFX_TRANSLUCENT50;
+						pChunk->drawingtype = DRAWFX_TRANSLUCENT50;
 						pChunk->numIndices = 4;
 						pChunk->numVertices = 4;
 						pChunk->numPrimitives = pChunk->numVertices - 2;
@@ -8238,6 +8265,8 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 			bgra.a = D3DRENDER_TRANS50;
 		if (pRNode->obj.drawingtype == DRAWFX_DITHERINVIS)
 			bgra.a = D3DRENDER_TRANS50;
+		if (pRNode->obj.drawingtype == DRAWFX_DITHERGREY)
+			bgra.a = D3DRENDER_TRANS50;
 
 		pChunk->xyz[0].x = pChunk->xyz[1].x = objArea.x;
 		pChunk->xyz[0].z = pChunk->xyz[3].z = objArea.y;
@@ -8488,6 +8517,8 @@ void D3DRenderPlayerOverlayOverlaysDraw(d3d_render_pool_new *pPool, list_type ov
 			if (pRNode->obj.drawingtype == DRAWFX_DITHERTRANS)
 				bgra.a = D3DRENDER_TRANS50;
 			if (pRNode->obj.drawingtype == DRAWFX_DITHERINVIS)
+				bgra.a = D3DRENDER_TRANS50;
+			if (pRNode->obj.drawingtype == DRAWFX_DITHERGREY)
 				bgra.a = D3DRENDER_TRANS50;
 
 			for (i = 0; i < 4; i++)
@@ -9764,7 +9795,10 @@ Bool D3DMaterialObjectChunk(d3d_render_chunk_new *pChunk)
 	else if (pChunk->drawingtype == DRAWFX_DITHERINVIS)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS50 - 1);
-	else
+	else if (pChunk->drawingtype == DRAWFX_DITHERGREY)
+		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
+                                      D3DRENDER_TRANS50 - 1);
+   else
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF, TEMP_ALPHA_REF);
 
 	if (pChunk->isTargeted)
@@ -9873,7 +9907,9 @@ Bool D3DMaterialObjectInvisibleChunk(d3d_render_chunk_new *pChunk)
 	else if (pChunk->drawingtype == DRAWFX_DITHERINVIS)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS50 - 1);
-   
+	else if (pChunk->drawingtype == DRAWFX_DITHERGREY)
+		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
+                                      D3DRENDER_TRANS50 - 1);
 	return TRUE;
 }
 

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -1115,7 +1115,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 		pRNode = GetRoomObjectById(player.id);
 
 		// player is invisible
-		if (pRNode->obj.drawingflags == DRAWFX_INVISIBLE)
+		if (pRNode->obj.drawingtype == DRAWFX_INVISIBLE)
 		{
 			IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
 			IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, decl2dc);
@@ -3446,7 +3446,7 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
 		if (pRNode->obj.id == player.id)
 			continue;
 
-		if (!(pRNode->obj.flags & OF_PLAYER) || (pRNode->obj.drawingflags == DRAWFX_INVISIBLE))
+		if (!(pRNode->obj.flags & OF_PLAYER) || (pRNode->obj.drawingtype == DRAWFX_INVISIBLE))
 			continue;
 
 		vector.x = pRNode->motion.x - player.x;
@@ -3678,12 +3678,12 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
 				pChunk->indices[2] = 0;
 				pChunk->indices[3] = 3;
 
-				if (pRNode->obj.drawingflags == DRAWFX_SECONDTRANS)
+				if (pRNode->obj.drawingtype == DRAWFX_SECONDTRANS)
 				{
 					pChunk->xLat0 = 0;
 					pChunk->xLat1 = pRNode->obj.secondtranslation;
 				}
-				else if (pRNode->obj.drawingflags == DRAWFX_DOUBLETRANS)
+				else if (pRNode->obj.drawingtype == DRAWFX_DOUBLETRANS)
 				{
 					pChunk->xLat0 = pRNode->obj.translation;
 					pChunk->xLat1 = pRNode->obj.secondtranslation;
@@ -6833,12 +6833,12 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 
 		if (flags == DRAWFX_INVISIBLE)
 		{
-			if (pRNode->obj.drawingflags != DRAWFX_INVISIBLE)
+			if (pRNode->obj.drawingtype != DRAWFX_INVISIBLE)
 				continue;
 		}
 		else
 		{
-			if (pRNode->obj.drawingflags == DRAWFX_INVISIBLE)
+			if (pRNode->obj.drawingtype == DRAWFX_INVISIBLE)
 				continue;
 		}
 
@@ -6852,12 +6852,12 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 		if (NULL == pDib)
 			continue;
 
-		if (pRNode->obj.drawingflags == DRAWFX_SECONDTRANS)
+		if (pRNode->obj.drawingtype == DRAWFX_SECONDTRANS)
 		{
 			xLat0 = 0;
 			xLat1 = pRNode->obj.secondtranslation;
 		}
-		else if (pRNode->obj.drawingflags == DRAWFX_DOUBLETRANS)
+		else if (pRNode->obj.drawingtype == DRAWFX_DOUBLETRANS)
 		{
 			xLat0 = pRNode->obj.translation;
 			xLat1 = pRNode->obj.secondtranslation;
@@ -6869,14 +6869,14 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 		}
 
 		pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDib, xLat0, xLat1,
-			pRNode->obj.drawingflags);
+			pRNode->obj.drawingtype);
 		if (NULL == pPacket)
 			return;
 
 		pChunk = D3DRenderChunkNew(pPacket);
 		assert(pChunk);
 
-		pChunk->drawingflags = pRNode->obj.drawingflags;
+		pChunk->drawingtype = pRNode->obj.drawingtype;
 
 		if (flags == DRAWFX_INVISIBLE)
 		{
@@ -6959,7 +6959,7 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 
 		lastDistance = 0;
 
-		if (pRNode->obj.drawingflags == DRAWFX_BLACK)
+		if (pRNode->obj.drawingtype == DRAWFX_BLACK)
 		{
 			bgra.b = bgra.g = bgra.r = 0;
 			bgra.a = 255;
@@ -6977,15 +6977,15 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 			bgra.r = 255.0f;
 		}*/
 
-		if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT25)
+		if (pRNode->obj.drawingtype == DRAWFX_TRANSLUCENT25)
 			bgra.a = D3DRENDER_TRANS25;
-		if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT50)
+		if (pRNode->obj.drawingtype == DRAWFX_TRANSLUCENT50)
 			bgra.a = D3DRENDER_TRANS50;
-		if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT75)
+		if (pRNode->obj.drawingtype == DRAWFX_TRANSLUCENT75)
 			bgra.a = D3DRENDER_TRANS75;
-		if (pRNode->obj.drawingflags == DRAWFX_DITHERTRANS)
+		if (pRNode->obj.drawingtype == DRAWFX_DITHERTRANS)
 			bgra.a = D3DRENDER_TRANS50;
-		if (pRNode->obj.drawingflags == DRAWFX_DITHERINVIS)
+		if (pRNode->obj.drawingtype == DRAWFX_DITHERINVIS)
 			bgra.a = D3DRENDER_TRANS50;
 
 		for (i = 0; i < 4; i++)
@@ -7169,17 +7169,17 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 		}
 
 		if (pRNode->obj.id != INVALID_ID && pRNode->obj.id == GetUserTargetID() &&
-			(pRNode->obj.drawingflags != DRAWFX_INVISIBLE))
+			(pRNode->obj.drawingtype != DRAWFX_INVISIBLE))
 		{
 			pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDib, xLat0, xLat1,
-				pRNode->obj.drawingflags);
+				pRNode->obj.drawingtype);
 			if (NULL == pPacket)
 				return;
 			pPacket->pMaterialFctn = &D3DMaterialObjectPacket;
 			pChunk = D3DRenderChunkNew(pPacket);
 			assert(pChunk);
 
-			pChunk->drawingflags = pRNode->obj.drawingflags | DRAWFX_TRANSLUCENT50;
+			pChunk->drawingtype = pRNode->obj.drawingtype | DRAWFX_TRANSLUCENT50;
 			pChunk->numIndices = 4;
 			pChunk->numVertices = 4;
 			pChunk->numPrimitives = pChunk->numVertices - 2;
@@ -7304,12 +7304,12 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 
 		if (flags == DRAWFX_INVISIBLE)
 		{
-			if (pRNode->obj.drawingflags != DRAWFX_INVISIBLE)
+			if (pRNode->obj.drawingtype != DRAWFX_INVISIBLE)
 				continue;
 		}
 		else
 		{
-			if (pRNode->obj.drawingflags == DRAWFX_INVISIBLE)
+			if (pRNode->obj.drawingtype == DRAWFX_INVISIBLE)
 				continue;
 		}
 
@@ -7542,12 +7542,12 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 
 				if (bHotspot)
 				{
-					if (pRNode->obj.drawingflags == DRAWFX_SECONDTRANS)
+					if (pRNode->obj.drawingtype == DRAWFX_SECONDTRANS)
 					{
 						xLat0 = 0;
 						xLat1 = pRNode->obj.secondtranslation;
 					}
-					else if (pRNode->obj.drawingflags == DRAWFX_DOUBLETRANS)
+					else if (pRNode->obj.drawingtype == DRAWFX_DOUBLETRANS)
 					{
 						xLat0 = pOverlay->translation;
 						xLat1 = pRNode->obj.secondtranslation;
@@ -7559,7 +7559,7 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 					}
 
 					pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDibOv, xLat0, xLat1,
-						pRNode->obj.drawingflags);
+						pRNode->obj.drawingtype);
 //					pPacket = D3DRenderPacketNew(pPool);
 	//				pPacket = D3DRenderPacketNew(pPool);
 	//				pPacket = NULL;
@@ -7571,7 +7571,7 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 					pChunk = D3DRenderChunkNew(pPacket);
 					assert(pChunk);
 
-					pChunk->drawingflags = pRNode->obj.drawingflags;
+					pChunk->drawingtype = pRNode->obj.drawingtype;
 					pChunk->numIndices = 4;
 					pChunk->numVertices = 4;
 					pChunk->numPrimitives = pChunk->numVertices - 2;
@@ -7646,7 +7646,7 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 
 					lastDistance = 0;
 
-					if (pRNode->obj.drawingflags == DRAWFX_BLACK)
+					if (pRNode->obj.drawingtype == DRAWFX_BLACK)
 					{
 						bgra.b = bgra.g = bgra.r = 0;
 						bgra.a = 255;
@@ -7664,15 +7664,15 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 						bgra.r = 255.0f;
 					}*/
 
-					if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT25)
+					if (pRNode->obj.drawingtype == DRAWFX_TRANSLUCENT25)
 						bgra.a = D3DRENDER_TRANS25;
-					if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT50)
+					if (pRNode->obj.drawingtype == DRAWFX_TRANSLUCENT50)
 						bgra.a = D3DRENDER_TRANS50;
-					if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT75)
+					if (pRNode->obj.drawingtype == DRAWFX_TRANSLUCENT75)
 						bgra.a = D3DRENDER_TRANS75;
-					if (pRNode->obj.drawingflags == DRAWFX_DITHERTRANS)
+					if (pRNode->obj.drawingtype == DRAWFX_DITHERTRANS)
 						bgra.a = D3DRENDER_TRANS50;
-					if (pRNode->obj.drawingflags == DRAWFX_DITHERINVIS)
+					if (pRNode->obj.drawingtype == DRAWFX_DITHERINVIS)
 						bgra.a = D3DRENDER_TRANS50;
 
 					for (i = 0; i < 4; i++)
@@ -7883,10 +7883,10 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 					}
 
 					if (pRNode->obj.id != INVALID_ID && pRNode->obj.id == GetUserTargetID() &&
-						(pRNode->obj.drawingflags != DRAWFX_INVISIBLE))
+						(pRNode->obj.drawingtype != DRAWFX_INVISIBLE))
 					{
 						pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDibOv, xLat0, xLat1,
-															pRNode->obj.drawingflags);
+															pRNode->obj.drawingtype);
 						if (NULL == pPacket)
 							continue;
 						pPacket->pMaterialFctn = &D3DMaterialObjectPacket;
@@ -7894,7 +7894,7 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 						pChunk = D3DRenderChunkNew(pPacket);
 						assert(pChunk);
 
-						pChunk->drawingflags = pRNode->obj.drawingflags | DRAWFX_TRANSLUCENT50;
+						pChunk->drawingtype = pRNode->obj.drawingtype | DRAWFX_TRANSLUCENT50;
 						pChunk->numIndices = 4;
 						pChunk->numVertices = 4;
 						pChunk->numPrimitives = pChunk->numVertices - 2;
@@ -8107,7 +8107,7 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 	int i, count;
 	object_node *obj;
 	list_type overlays;
-	BYTE drawingflags;
+	BYTE drawingtype;
 
 	d3d_render_packet_new	*pPacket;
 	d3d_render_chunk_new	*pChunk;
@@ -8127,9 +8127,9 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 	// Get player's object drawing flags for special drawing effects
 	pRNode = GetRoomObjectById(player.id);
 	if (pRNode == NULL)
-		drawingflags = 0;
+		drawingtype = 0;
 	else
-		drawingflags = pRNode->obj.drawingflags;
+		drawingtype = pRNode->obj.drawingtype;
 
 	for (i=0; i < NUM_PLAYER_OVERLAYS; i++)
 	{
@@ -8158,12 +8158,12 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 			D3DRenderPlayerOverlayOverlaysDraw(pPool, overlays, pDib, room, params,
 				&objArea, TRUE);
 
-		if (obj->drawingflags == DRAWFX_SECONDTRANS)
+		if (obj->drawingtype == DRAWFX_SECONDTRANS)
 		{
 			xLat0 = 0;
 			xLat1 = obj->secondtranslation;
 		}
-		else if (obj->drawingflags == DRAWFX_DOUBLETRANS)
+		else if (obj->drawingtype == DRAWFX_DOUBLETRANS)
 		{
 			xLat0 = obj->translation;
 			xLat1 = obj->secondtranslation;
@@ -8175,7 +8175,7 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 		}
 
 		pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDib, xLat0, xLat1,
-			pRNode->obj.drawingflags);
+			pRNode->obj.drawingtype);
 		if (NULL == pPacket)
 			return;
 
@@ -8188,7 +8188,7 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 		pChunk->xLat0 = xLat0;
 		pChunk->xLat1 = xLat1;
 
-		if (pRNode->obj.drawingflags == DRAWFX_INVISIBLE)
+		if (pRNode->obj.drawingtype == DRAWFX_INVISIBLE)
 		{
 			pPacket->pMaterialFctn = &D3DMaterialObjectInvisiblePacket;
 			pChunk->pMaterialFctn = &D3DMaterialObjectInvisibleChunk;
@@ -8199,11 +8199,11 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 			pChunk->pMaterialFctn = &D3DMaterialObjectChunk;
 		}
 
-		pChunk->drawingflags = pRNode->obj.drawingflags;
+		pChunk->drawingtype = pRNode->obj.drawingtype;
 
 		MatrixIdentity(&pChunk->xForm);
 
-		if (pRNode->obj.drawingflags == DRAWFX_BLACK)
+		if (pRNode->obj.drawingtype == DRAWFX_BLACK)
 		{
 			bgra.b = bgra.g = bgra.r = 0;
 			bgra.a = 255;
@@ -8228,15 +8228,15 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 			bgra.a = 255;*/
 		}
 
-		if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT25)
+		if (pRNode->obj.drawingtype == DRAWFX_TRANSLUCENT25)
 			bgra.a = D3DRENDER_TRANS25;
-		if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT50)
+		if (pRNode->obj.drawingtype == DRAWFX_TRANSLUCENT50)
 			bgra.a = D3DRENDER_TRANS50;
-		if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT75)
+		if (pRNode->obj.drawingtype == DRAWFX_TRANSLUCENT75)
 			bgra.a = D3DRENDER_TRANS75;
-		if (pRNode->obj.drawingflags == DRAWFX_DITHERTRANS)
+		if (pRNode->obj.drawingtype == DRAWFX_DITHERTRANS)
 			bgra.a = D3DRENDER_TRANS50;
-		if (pRNode->obj.drawingflags == DRAWFX_DITHERINVIS)
+		if (pRNode->obj.drawingtype == DRAWFX_DITHERINVIS)
 			bgra.a = D3DRENDER_TRANS50;
 
 		pChunk->xyz[0].x = pChunk->xyz[1].x = objArea.x;
@@ -8248,7 +8248,7 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 
 		for (count = 0; count < 4; count++)
 		{
-			if (pRNode->obj.drawingflags == DRAWFX_INVISIBLE)
+			if (pRNode->obj.drawingtype == DRAWFX_INVISIBLE)
 			{
 				pChunk->st1[count].s = pChunk->xyz[count].x / gScreenWidth;
 				pChunk->st1[count].t = pChunk->xyz[count].z / gScreenHeight;
@@ -8322,7 +8322,7 @@ void D3DRenderPlayerOverlayOverlaysDraw(d3d_render_pool_new *pPool, list_type ov
 	Overlay				*pOverlay;
 	int					i, zBias;
 	float				lastDistance, screenW, screenH;
-	BYTE				xLat0, xLat1, drawingflags;
+	BYTE				xLat0, xLat1, drawingtype;
 
 	d3d_render_packet_new	*pPacket;
 	d3d_render_chunk_new	*pChunk;
@@ -8334,9 +8334,9 @@ void D3DRenderPlayerOverlayOverlaysDraw(d3d_render_pool_new *pPool, list_type ov
 	pRNode = GetRoomObjectById(player.id);
 
 	if (pRNode == NULL)
-		drawingflags = 0;
+		drawingtype = 0;
 	else
-		drawingflags = pRNode->obj.drawingflags;
+		drawingtype = pRNode->obj.drawingtype;
 
 	pass = 0;
 
@@ -8423,12 +8423,12 @@ void D3DRenderPlayerOverlayOverlaysDraw(d3d_render_pool_new *pPool, list_type ov
 				xyz[i].z += objArea->y;
 			}
 
-			if (pRNode->obj.drawingflags == DRAWFX_SECONDTRANS)
+			if (pRNode->obj.drawingtype == DRAWFX_SECONDTRANS)
 			{
 				xLat0 = 0;
 				xLat1 = pRNode->obj.secondtranslation;
 			}
-			else if (pRNode->obj.drawingflags == DRAWFX_DOUBLETRANS)
+			else if (pRNode->obj.drawingtype == DRAWFX_DOUBLETRANS)
 			{
 				xLat0 = pOverlay->translation;
 				xLat1 = pRNode->obj.secondtranslation;
@@ -8440,21 +8440,21 @@ void D3DRenderPlayerOverlayOverlaysDraw(d3d_render_pool_new *pPool, list_type ov
 			}
 
 			pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDibOv, xLat0, xLat1,
-				pRNode->obj.drawingflags);
+				pRNode->obj.drawingtype);
 			if (NULL == pPacket)
 				return;
 
 			pChunk = D3DRenderChunkNew(pPacket);
 			assert(pChunk);
 
-			pChunk->drawingflags = pRNode->obj.drawingflags;
+			pChunk->drawingtype = pRNode->obj.drawingtype;
 			pChunk->numIndices = 4;
 			pChunk->numVertices = 4;
 			pChunk->numPrimitives = pChunk->numVertices - 2;
 			pChunk->xLat0 = xLat0;
 			pChunk->xLat1 = xLat1;
 			
-			if (pRNode->obj.drawingflags == DRAWFX_INVISIBLE)
+			if (pRNode->obj.drawingtype == DRAWFX_INVISIBLE)
 			{
 				pPacket->pMaterialFctn = &D3DMaterialObjectInvisiblePacket;
 				pChunk->pMaterialFctn = &D3DMaterialObjectInvisibleChunk;
@@ -8469,7 +8469,7 @@ void D3DRenderPlayerOverlayOverlaysDraw(d3d_render_pool_new *pPool, list_type ov
 
 			lastDistance = 0;
 
-			if (pRNode->obj.drawingflags == DRAWFX_BLACK)
+			if (pRNode->obj.drawingtype == DRAWFX_BLACK)
 			{
 				bgra.b = bgra.g = bgra.r = 0;
 				bgra.a = 255;
@@ -8479,20 +8479,20 @@ void D3DRenderPlayerOverlayOverlaysDraw(d3d_render_pool_new *pPool, list_type ov
 				D3DObjectLightingCalc(room, pRNode, &bgra, 0);
 			}
 
-			if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT25)
+			if (pRNode->obj.drawingtype == DRAWFX_TRANSLUCENT25)
 				bgra.a = D3DRENDER_TRANS25;
-			if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT50)
+			if (pRNode->obj.drawingtype == DRAWFX_TRANSLUCENT50)
 				bgra.a = D3DRENDER_TRANS50;
-			if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT75)
+			if (pRNode->obj.drawingtype == DRAWFX_TRANSLUCENT75)
 				bgra.a = D3DRENDER_TRANS75;
-			if (pRNode->obj.drawingflags == DRAWFX_DITHERTRANS)
+			if (pRNode->obj.drawingtype == DRAWFX_DITHERTRANS)
 				bgra.a = D3DRENDER_TRANS50;
-			if (pRNode->obj.drawingflags == DRAWFX_DITHERINVIS)
+			if (pRNode->obj.drawingtype == DRAWFX_DITHERINVIS)
 				bgra.a = D3DRENDER_TRANS50;
 
 			for (i = 0; i < 4; i++)
 			{
-				if (pRNode->obj.drawingflags == DRAWFX_INVISIBLE)
+				if (pRNode->obj.drawingtype == DRAWFX_INVISIBLE)
 				{
 					pChunk->st1[i].s = xyz[i].x / gScreenWidth;
 					pChunk->st1[i].t = xyz[i].z / gScreenHeight;
@@ -9736,7 +9736,7 @@ Bool D3DMaterialObjectChunk(d3d_render_chunk_new *pChunk)
 
 	if ((pChunk->xLat0) || (pChunk->xLat1))
 	{
-		D3DRenderPaletteSet(pChunk->xLat0, pChunk->xLat1, pChunk->drawingflags);
+		D3DRenderPaletteSet(pChunk->xLat0, pChunk->xLat1, pChunk->drawingtype);
 		lastXLat0 = pChunk->xLat0;
 		lastXLat1 = pChunk->xLat1;
 	}
@@ -9750,18 +9750,18 @@ Bool D3DMaterialObjectChunk(d3d_render_chunk_new *pChunk)
 	// layer-ordering is saved in pChunk->zBias
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_DEPTHBIAS, F2DW((float)pChunk->zBias * -0.00001f));
 
-	if (pChunk->drawingflags == DRAWFX_TRANSLUCENT25)
+	if (pChunk->drawingtype == DRAWFX_TRANSLUCENT25)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS25 - 1);
-	else if (pChunk->drawingflags == DRAWFX_TRANSLUCENT50)
+	else if (pChunk->drawingtype == DRAWFX_TRANSLUCENT50)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS50 - 1);
-	else if (pChunk->drawingflags == DRAWFX_TRANSLUCENT75)
+	else if (pChunk->drawingtype == DRAWFX_TRANSLUCENT75)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS75 - 1);
-	else if (pChunk->drawingflags == DRAWFX_DITHERTRANS)
+	else if (pChunk->drawingtype == DRAWFX_DITHERTRANS)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF, 1);
-	else if (pChunk->drawingflags == DRAWFX_DITHERINVIS)
+	else if (pChunk->drawingtype == DRAWFX_DITHERINVIS)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS50 - 1);
 	else
@@ -9844,7 +9844,7 @@ Bool D3DMaterialObjectInvisibleChunk(d3d_render_chunk_new *pChunk)
 
 	if ((pChunk->xLat0) || (pChunk->xLat1))
 	{
-		D3DRenderPaletteSet(pChunk->xLat0, pChunk->xLat1, pChunk->drawingflags);
+		D3DRenderPaletteSet(pChunk->xLat0, pChunk->xLat1, pChunk->drawingtype);
 		lastXLat0 = pChunk->xLat0;
 		lastXLat1 = pChunk->xLat1;
 	}
@@ -9858,19 +9858,19 @@ Bool D3DMaterialObjectInvisibleChunk(d3d_render_chunk_new *pChunk)
 	// layer-ordering is saved in pChunk->zBias
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_DEPTHBIAS, F2DW((float)pChunk->zBias * -0.00001f));
 
-	if (pChunk->drawingflags == DRAWFX_TRANSLUCENT25)
+	if (pChunk->drawingtype == DRAWFX_TRANSLUCENT25)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS25 - 1);
-	else if (pChunk->drawingflags == DRAWFX_TRANSLUCENT50)
+	else if (pChunk->drawingtype == DRAWFX_TRANSLUCENT50)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS50 - 1);
-	else if (pChunk->drawingflags == DRAWFX_TRANSLUCENT75)
+	else if (pChunk->drawingtype == DRAWFX_TRANSLUCENT75)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS75 - 1);
-	else if (pChunk->drawingflags == DRAWFX_DITHERTRANS)
+	else if (pChunk->drawingtype == DRAWFX_DITHERTRANS)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       1);
-	else if (pChunk->drawingflags == DRAWFX_DITHERINVIS)
+	else if (pChunk->drawingtype == DRAWFX_DITHERINVIS)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS50 - 1);
    

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -1115,7 +1115,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 		pRNode = GetRoomObjectById(player.id);
 
 		// player is invisible
-		if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_INVISIBLE)
+		if (pRNode->obj.drawingflags == DRAWFX_INVISIBLE)
 		{
 			IDirect3DDevice9_SetVertexShader(gpD3DDevice, NULL);
 			IDirect3DDevice9_SetVertexDeclaration(gpD3DDevice, decl2dc);
@@ -3446,7 +3446,7 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
 		if (pRNode->obj.id == player.id)
 			continue;
 
-		if (!(pRNode->obj.flags & OF_PLAYER) || (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_INVISIBLE))
+		if (!(pRNode->obj.flags & OF_PLAYER) || (pRNode->obj.drawingflags == DRAWFX_INVISIBLE))
 			continue;
 
 		vector.x = pRNode->motion.x - player.x;
@@ -3678,12 +3678,12 @@ void D3DRenderNamesDraw3D(d3d_render_cache_system *pCacheSystem, d3d_render_pool
 				pChunk->indices[2] = 0;
 				pChunk->indices[3] = 3;
 
-				if (pRNode->obj.drawingflags & DRAWFX_SECONDTRANS)
+				if (pRNode->obj.drawingflags == DRAWFX_SECONDTRANS)
 				{
 					pChunk->xLat0 = 0;
 					pChunk->xLat1 = pRNode->obj.secondtranslation;
 				}
-				else if (pRNode->obj.drawingflags & DRAWFX_DOUBLETRANS)
+				else if (pRNode->obj.drawingflags == DRAWFX_DOUBLETRANS)
 				{
 					pChunk->xLat0 = pRNode->obj.translation;
 					pChunk->xLat1 = pRNode->obj.secondtranslation;
@@ -4271,7 +4271,7 @@ void D3DRenderPaletteSet(UINT xlatID0, UINT xlatID1, BYTE flags)
 	pXLat1 = FindStandardXlat(xlatID1);
 
 	pPalette = base_palette;
-	effect = GetDrawingEffect(flags);
+	effect = flags;
 
 	switch (effect)
 	{
@@ -4405,7 +4405,7 @@ void D3DRenderPaletteSetNew(UINT xlatID0, UINT xlatID1, BYTE flags)
 	pXLat1 = FindStandardXlat(xlatID1);
 
 	pPalette = base_palette;
-	effect = GetDrawingEffect(flags);
+	effect = flags;
 
 	switch (effect)
 	{
@@ -6831,14 +6831,14 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 		if (pRNode->obj.id == player.id)
 			continue;
 
-		if (flags & DRAWFX_INVISIBLE)
+		if (flags == DRAWFX_INVISIBLE)
 		{
-			if (GetDrawingEffect(pRNode->obj.drawingflags) != DRAWFX_INVISIBLE)
+			if (pRNode->obj.drawingflags != DRAWFX_INVISIBLE)
 				continue;
 		}
 		else
 		{
-			if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_INVISIBLE)
+			if (pRNode->obj.drawingflags == DRAWFX_INVISIBLE)
 				continue;
 		}
 
@@ -6852,12 +6852,12 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 		if (NULL == pDib)
 			continue;
 
-		if (pRNode->obj.drawingflags & DRAWFX_SECONDTRANS)
+		if (pRNode->obj.drawingflags == DRAWFX_SECONDTRANS)
 		{
 			xLat0 = 0;
 			xLat1 = pRNode->obj.secondtranslation;
 		}
-		else if (pRNode->obj.drawingflags & DRAWFX_DOUBLETRANS)
+		else if (pRNode->obj.drawingflags == DRAWFX_DOUBLETRANS)
 		{
 			xLat0 = pRNode->obj.translation;
 			xLat1 = pRNode->obj.secondtranslation;
@@ -6869,7 +6869,7 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 		}
 
 		pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDib, xLat0, xLat1,
-			GetDrawingEffect(pRNode->obj.drawingflags));
+			pRNode->obj.drawingflags);
 		if (NULL == pPacket)
 			return;
 
@@ -6878,7 +6878,7 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 
 		pChunk->drawingflags = pRNode->obj.drawingflags;
 
-		if (flags & DRAWFX_INVISIBLE)
+		if (flags == DRAWFX_INVISIBLE)
 		{
 			pPacket->pMaterialFctn = &D3DMaterialObjectInvisiblePacket;
 			pChunk->pMaterialFctn = &D3DMaterialObjectInvisibleChunk;
@@ -6959,7 +6959,7 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 
 		lastDistance = 0;
 
-		if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_BLACK)
+		if (pRNode->obj.drawingflags == DRAWFX_BLACK)
 		{
 			bgra.b = bgra.g = bgra.r = 0;
 			bgra.a = 255;
@@ -6977,15 +6977,15 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 			bgra.r = 255.0f;
 		}*/
 
-		if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_TRANSLUCENT25)
+		if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT25)
 			bgra.a = D3DRENDER_TRANS25;
-		if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_TRANSLUCENT50)
+		if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT50)
 			bgra.a = D3DRENDER_TRANS50;
-		if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_TRANSLUCENT75)
+		if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT75)
 			bgra.a = D3DRENDER_TRANS75;
-		if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_DITHERTRANS)
+		if (pRNode->obj.drawingflags == DRAWFX_DITHERTRANS)
 			bgra.a = D3DRENDER_TRANS50;
-		if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_DITHERINVIS)
+		if (pRNode->obj.drawingflags == DRAWFX_DITHERINVIS)
 			bgra.a = D3DRENDER_TRANS50;
 
 		for (i = 0; i < 4; i++)
@@ -7093,7 +7093,7 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 			center.y = (topLeft.y + bottomLeft.y) / 2.0f;
 			center.z = topLeft.z;
 
-			if (flags & DRAWFX_INVISIBLE)
+			if (flags == DRAWFX_INVISIBLE)
 			{
 				pChunk->st1[0].s = D3DRENDER_CLIP_TO_SCREEN_X(bottomRight.x, gScreenWidth) / gScreenWidth;
 				pChunk->st1[0].t = D3DRENDER_CLIP_TO_SCREEN_Y(topLeft.y, gScreenHeight) / gScreenHeight;
@@ -7169,10 +7169,10 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 		}
 
 		if (pRNode->obj.id != INVALID_ID && pRNode->obj.id == GetUserTargetID() &&
-			(GetDrawingEffect(pRNode->obj.drawingflags) != DRAWFX_INVISIBLE))
+			(pRNode->obj.drawingflags != DRAWFX_INVISIBLE))
 		{
 			pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDib, xLat0, xLat1,
-				GetDrawingEffect(pRNode->obj.drawingflags));
+				pRNode->obj.drawingflags);
 			if (NULL == pPacket)
 				return;
 			pPacket->pMaterialFctn = &D3DMaterialObjectPacket;
@@ -7190,7 +7190,7 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 
 			MatrixMultiply(&pChunk->xForm, &rot, &mat);
 
-			if (flags & DRAWFX_INVISIBLE)
+			if (flags == DRAWFX_INVISIBLE)
 			{
 				pChunk->pMaterialFctn = &D3DMaterialObjectInvisibleChunk;
 			}
@@ -7302,14 +7302,14 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 		if (pRNode->obj.id == player.id)
 			continue;
 
-		if (flags & DRAWFX_INVISIBLE)
+		if (flags == DRAWFX_INVISIBLE)
 		{
-			if (GetDrawingEffect(pRNode->obj.drawingflags) != DRAWFX_INVISIBLE)
+			if (pRNode->obj.drawingflags != DRAWFX_INVISIBLE)
 				continue;
 		}
 		else
 		{
-			if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_INVISIBLE)
+			if (pRNode->obj.drawingflags == DRAWFX_INVISIBLE)
 				continue;
 		}
 
@@ -7542,12 +7542,12 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 
 				if (bHotspot)
 				{
-					if (pRNode->obj.drawingflags & DRAWFX_SECONDTRANS)
+					if (pRNode->obj.drawingflags == DRAWFX_SECONDTRANS)
 					{
 						xLat0 = 0;
 						xLat1 = pRNode->obj.secondtranslation;
 					}
-					else if (pRNode->obj.drawingflags & DRAWFX_DOUBLETRANS)
+					else if (pRNode->obj.drawingflags == DRAWFX_DOUBLETRANS)
 					{
 						xLat0 = pOverlay->translation;
 						xLat1 = pRNode->obj.secondtranslation;
@@ -7559,7 +7559,7 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 					}
 
 					pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDibOv, xLat0, xLat1,
-						GetDrawingEffect(pRNode->obj.drawingflags));
+						pRNode->obj.drawingflags);
 //					pPacket = D3DRenderPacketNew(pPool);
 	//				pPacket = D3DRenderPacketNew(pPool);
 	//				pPacket = NULL;
@@ -7581,7 +7581,7 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 
 					zBias++;
 
-					if (flags & DRAWFX_INVISIBLE)
+					if (flags == DRAWFX_INVISIBLE)
 					{
 						pPacket->pMaterialFctn = &D3DMaterialObjectInvisiblePacket;
 						pChunk->pMaterialFctn = &D3DMaterialObjectInvisibleChunk;
@@ -7646,7 +7646,7 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 
 					lastDistance = 0;
 
-					if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_BLACK)
+					if (pRNode->obj.drawingflags == DRAWFX_BLACK)
 					{
 						bgra.b = bgra.g = bgra.r = 0;
 						bgra.a = 255;
@@ -7664,15 +7664,15 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 						bgra.r = 255.0f;
 					}*/
 
-					if (GetDrawingEffectIndex(pRNode->obj.drawingflags) == DRAWFX_TRANSLUCENT25)
+					if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT25)
 						bgra.a = D3DRENDER_TRANS25;
-					if (GetDrawingEffectIndex(pRNode->obj.drawingflags) == DRAWFX_TRANSLUCENT50)
+					if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT50)
 						bgra.a = D3DRENDER_TRANS50;
-					if (GetDrawingEffectIndex(pRNode->obj.drawingflags) == DRAWFX_TRANSLUCENT75)
+					if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT75)
 						bgra.a = D3DRENDER_TRANS75;
-					if (GetDrawingEffectIndex(pRNode->obj.drawingflags) == DRAWFX_DITHERTRANS)
+					if (pRNode->obj.drawingflags == DRAWFX_DITHERTRANS)
 						bgra.a = D3DRENDER_TRANS50;
-					if (GetDrawingEffectIndex(pRNode->obj.drawingflags) == DRAWFX_DITHERINVIS)
+					if (pRNode->obj.drawingflags == DRAWFX_DITHERINVIS)
 						bgra.a = D3DRENDER_TRANS50;
 
 					for (i = 0; i < 4; i++)
@@ -7773,7 +7773,7 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 						center.y = (topLeft.y + bottomLeft.y) / 2.0f;
 						center.z = topLeft.z;
 
-						if (flags & DRAWFX_INVISIBLE)
+						if (flags == DRAWFX_INVISIBLE)
 						{
 							pChunk->st1[0].s = D3DRENDER_CLIP_TO_SCREEN_X(bottomRight.x, gScreenWidth) / gScreenWidth;
 							pChunk->st1[0].t = D3DRENDER_CLIP_TO_SCREEN_Y(topLeft.y, gScreenHeight) / gScreenHeight;
@@ -7883,10 +7883,10 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 					}
 
 					if (pRNode->obj.id != INVALID_ID && pRNode->obj.id == GetUserTargetID() &&
-						(GetDrawingEffect(pRNode->obj.drawingflags) != DRAWFX_INVISIBLE))
+						(pRNode->obj.drawingflags != DRAWFX_INVISIBLE))
 					{
 						pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDibOv, xLat0, xLat1,
-															GetDrawingEffect(pRNode->obj.drawingflags));
+															pRNode->obj.drawingflags);
 						if (NULL == pPacket)
 							continue;
 						pPacket->pMaterialFctn = &D3DMaterialObjectPacket;
@@ -7905,7 +7905,7 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 
 						MatrixMultiply(&pChunk->xForm, &rot, &mat);
 
-						if (flags & DRAWFX_INVISIBLE)
+						if (flags == DRAWFX_INVISIBLE)
 						{
 							pChunk->pMaterialFctn = &D3DMaterialObjectInvisibleChunk;
 						}
@@ -8158,12 +8158,12 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 			D3DRenderPlayerOverlayOverlaysDraw(pPool, overlays, pDib, room, params,
 				&objArea, TRUE);
 
-		if (obj->drawingflags & DRAWFX_SECONDTRANS)
+		if (obj->drawingflags == DRAWFX_SECONDTRANS)
 		{
 			xLat0 = 0;
 			xLat1 = obj->secondtranslation;
 		}
-		else if (obj->drawingflags & DRAWFX_DOUBLETRANS)
+		else if (obj->drawingflags == DRAWFX_DOUBLETRANS)
 		{
 			xLat0 = obj->translation;
 			xLat1 = obj->secondtranslation;
@@ -8175,7 +8175,7 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 		}
 
 		pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDib, xLat0, xLat1,
-			GetDrawingEffect(pRNode->obj.drawingflags));
+			pRNode->obj.drawingflags);
 		if (NULL == pPacket)
 			return;
 
@@ -8188,7 +8188,7 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 		pChunk->xLat0 = xLat0;
 		pChunk->xLat1 = xLat1;
 
-		if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_INVISIBLE)
+		if (pRNode->obj.drawingflags == DRAWFX_INVISIBLE)
 		{
 			pPacket->pMaterialFctn = &D3DMaterialObjectInvisiblePacket;
 			pChunk->pMaterialFctn = &D3DMaterialObjectInvisibleChunk;
@@ -8203,7 +8203,7 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 
 		MatrixIdentity(&pChunk->xForm);
 
-		if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_BLACK)
+		if (pRNode->obj.drawingflags == DRAWFX_BLACK)
 		{
 			bgra.b = bgra.g = bgra.r = 0;
 			bgra.a = 255;
@@ -8228,15 +8228,15 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 			bgra.a = 255;*/
 		}
 
-		if (GetDrawingEffectIndex(pRNode->obj.drawingflags) == DRAWFX_TRANSLUCENT25)
+		if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT25)
 			bgra.a = D3DRENDER_TRANS25;
-		if (GetDrawingEffectIndex(pRNode->obj.drawingflags) == DRAWFX_TRANSLUCENT50)
+		if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT50)
 			bgra.a = D3DRENDER_TRANS50;
-		if (GetDrawingEffectIndex(pRNode->obj.drawingflags) == DRAWFX_TRANSLUCENT75)
+		if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT75)
 			bgra.a = D3DRENDER_TRANS75;
-		if (GetDrawingEffectIndex(pRNode->obj.drawingflags) == DRAWFX_DITHERTRANS)
+		if (pRNode->obj.drawingflags == DRAWFX_DITHERTRANS)
 			bgra.a = D3DRENDER_TRANS50;
-		if (GetDrawingEffectIndex(pRNode->obj.drawingflags) == DRAWFX_DITHERINVIS)
+		if (pRNode->obj.drawingflags == DRAWFX_DITHERINVIS)
 			bgra.a = D3DRENDER_TRANS50;
 
 		pChunk->xyz[0].x = pChunk->xyz[1].x = objArea.x;
@@ -8248,7 +8248,7 @@ void D3DRenderPlayerOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Dr
 
 		for (count = 0; count < 4; count++)
 		{
-			if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_INVISIBLE)
+			if (pRNode->obj.drawingflags == DRAWFX_INVISIBLE)
 			{
 				pChunk->st1[count].s = pChunk->xyz[count].x / gScreenWidth;
 				pChunk->st1[count].t = pChunk->xyz[count].z / gScreenHeight;
@@ -8423,12 +8423,12 @@ void D3DRenderPlayerOverlayOverlaysDraw(d3d_render_pool_new *pPool, list_type ov
 				xyz[i].z += objArea->y;
 			}
 
-			if (pRNode->obj.drawingflags & DRAWFX_SECONDTRANS)
+			if (pRNode->obj.drawingflags == DRAWFX_SECONDTRANS)
 			{
 				xLat0 = 0;
 				xLat1 = pRNode->obj.secondtranslation;
 			}
-			else if (pRNode->obj.drawingflags & DRAWFX_DOUBLETRANS)
+			else if (pRNode->obj.drawingflags == DRAWFX_DOUBLETRANS)
 			{
 				xLat0 = pOverlay->translation;
 				xLat1 = pRNode->obj.secondtranslation;
@@ -8440,7 +8440,7 @@ void D3DRenderPlayerOverlayOverlaysDraw(d3d_render_pool_new *pPool, list_type ov
 			}
 
 			pPacket = D3DRenderPacketFindMatch(pPool, NULL, pDibOv, xLat0, xLat1,
-				GetDrawingEffect(pRNode->obj.drawingflags));
+				pRNode->obj.drawingflags);
 			if (NULL == pPacket)
 				return;
 
@@ -8454,7 +8454,7 @@ void D3DRenderPlayerOverlayOverlaysDraw(d3d_render_pool_new *pPool, list_type ov
 			pChunk->xLat0 = xLat0;
 			pChunk->xLat1 = xLat1;
 			
-			if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_INVISIBLE)
+			if (pRNode->obj.drawingflags == DRAWFX_INVISIBLE)
 			{
 				pPacket->pMaterialFctn = &D3DMaterialObjectInvisiblePacket;
 				pChunk->pMaterialFctn = &D3DMaterialObjectInvisibleChunk;
@@ -8469,7 +8469,7 @@ void D3DRenderPlayerOverlayOverlaysDraw(d3d_render_pool_new *pPool, list_type ov
 
 			lastDistance = 0;
 
-			if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_BLACK)
+			if (pRNode->obj.drawingflags == DRAWFX_BLACK)
 			{
 				bgra.b = bgra.g = bgra.r = 0;
 				bgra.a = 255;
@@ -8479,20 +8479,20 @@ void D3DRenderPlayerOverlayOverlaysDraw(d3d_render_pool_new *pPool, list_type ov
 				D3DObjectLightingCalc(room, pRNode, &bgra, 0);
 			}
 
-			if (GetDrawingEffectIndex(pRNode->obj.drawingflags) == DRAWFX_TRANSLUCENT25)
+			if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT25)
 				bgra.a = D3DRENDER_TRANS25;
-			if (GetDrawingEffectIndex(pRNode->obj.drawingflags) == DRAWFX_TRANSLUCENT50)
+			if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT50)
 				bgra.a = D3DRENDER_TRANS50;
-			if (GetDrawingEffectIndex(pRNode->obj.drawingflags) == DRAWFX_TRANSLUCENT75)
+			if (pRNode->obj.drawingflags == DRAWFX_TRANSLUCENT75)
 				bgra.a = D3DRENDER_TRANS75;
-			if (GetDrawingEffectIndex(pRNode->obj.drawingflags) == DRAWFX_DITHERTRANS)
+			if (pRNode->obj.drawingflags == DRAWFX_DITHERTRANS)
 				bgra.a = D3DRENDER_TRANS50;
-			if (GetDrawingEffectIndex(pRNode->obj.drawingflags) == DRAWFX_DITHERINVIS)
+			if (pRNode->obj.drawingflags == DRAWFX_DITHERINVIS)
 				bgra.a = D3DRENDER_TRANS50;
 
 			for (i = 0; i < 4; i++)
 			{
-				if (GetDrawingEffect(pRNode->obj.drawingflags) == DRAWFX_INVISIBLE)
+				if (pRNode->obj.drawingflags == DRAWFX_INVISIBLE)
 				{
 					pChunk->st1[i].s = xyz[i].x / gScreenWidth;
 					pChunk->st1[i].t = xyz[i].z / gScreenHeight;
@@ -9750,18 +9750,18 @@ Bool D3DMaterialObjectChunk(d3d_render_chunk_new *pChunk)
 	// layer-ordering is saved in pChunk->zBias
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_DEPTHBIAS, F2DW((float)pChunk->zBias * -0.00001f));
 
-	if (GetDrawingEffect(pChunk->drawingflags) == DRAWFX_TRANSLUCENT25)
+	if (pChunk->drawingflags == DRAWFX_TRANSLUCENT25)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS25 - 1);
-	else if (GetDrawingEffect(pChunk->drawingflags) == DRAWFX_TRANSLUCENT50)
+	else if (pChunk->drawingflags == DRAWFX_TRANSLUCENT50)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS50 - 1);
-	else if (GetDrawingEffect(pChunk->drawingflags) == DRAWFX_TRANSLUCENT75)
+	else if (pChunk->drawingflags == DRAWFX_TRANSLUCENT75)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS75 - 1);
-	else if (GetDrawingEffect(pChunk->drawingflags) == DRAWFX_DITHERTRANS)
+	else if (pChunk->drawingflags == DRAWFX_DITHERTRANS)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF, 1);
-	else if (GetDrawingEffect(pChunk->drawingflags) == DRAWFX_DITHERINVIS)
+	else if (pChunk->drawingflags == DRAWFX_DITHERINVIS)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS50 - 1);
 	else
@@ -9858,19 +9858,19 @@ Bool D3DMaterialObjectInvisibleChunk(d3d_render_chunk_new *pChunk)
 	// layer-ordering is saved in pChunk->zBias
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_DEPTHBIAS, F2DW((float)pChunk->zBias * -0.00001f));
 
-	if (GetDrawingEffect(pChunk->drawingflags) == DRAWFX_TRANSLUCENT25)
+	if (pChunk->drawingflags == DRAWFX_TRANSLUCENT25)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS25 - 1);
-	else if (GetDrawingEffect(pChunk->drawingflags) == DRAWFX_TRANSLUCENT50)
+	else if (pChunk->drawingflags == DRAWFX_TRANSLUCENT50)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS50 - 1);
-	else if (GetDrawingEffect(pChunk->drawingflags) == DRAWFX_TRANSLUCENT75)
+	else if (pChunk->drawingflags == DRAWFX_TRANSLUCENT75)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS75 - 1);
-	else if (GetDrawingEffect(pChunk->drawingflags) == DRAWFX_DITHERTRANS)
+	else if (pChunk->drawingflags == DRAWFX_DITHERTRANS)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       1);
-	else if (GetDrawingEffect(pChunk->drawingflags) == DRAWFX_DITHERINVIS)
+	else if (pChunk->drawingflags == DRAWFX_DITHERINVIS)
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF,
                                       D3DRENDER_TRANS50 - 1);
    

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -156,15 +156,15 @@ void				D3DRenderResizeDisplay(int left, int top, int right, int bottom);
 void				D3DRenderEnableToggle(void);
 int					D3DRenderIsEnabled(void);
 LPDIRECT3DTEXTURE9	D3DRenderTextureCreateFromBGF(PDIB pDib, BYTE xLat0, BYTE xLat1,
-												  unsigned int effect);
+												  BYTE effect);
 LPDIRECT3DTEXTURE9	D3DRenderTextureCreateFromBGFSwizzled(PDIB pDib, BYTE xLat0, BYTE xLat1,
-												  unsigned int effect);
-void				D3DRenderPaletteSet(UINT xlatID0, UINT xlatID1, unsigned int flags);
+												  BYTE effect);
+void				D3DRenderPaletteSet(UINT xlatID0, UINT xlatID1, BYTE flags);
 int					D3DRenderObjectGetLight(BSPnode *tree, room_contents_node *pRNode);
 void				D3DRenderBackgroundSet(ID background);
 void				D3DRenderBackgroundSet2(ID background);
 d3d_render_packet_new *D3DRenderPacketFindMatch(d3d_render_pool_new *pPool, LPDIRECT3DTEXTURE9 pTexture,
-												PDIB pDib, BYTE xLat0, BYTE xLat1, int effect);
+												PDIB pDib, BYTE xLat0, BYTE xLat1, BYTE effect);
 d3d_render_packet_new *D3DRenderPacketNew(d3d_render_pool_new *pPool);
 d3d_render_chunk_new *D3DRenderChunkNew(d3d_render_packet_new *pPacket);
 void				D3DRenderPoolReset(d3d_render_pool_new *pPool, void *pMaterialFunc);

--- a/clientd3d/dialog.c
+++ b/clientd3d/dialog.c
@@ -229,7 +229,7 @@ BOOL CALLBACK DescDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lParam)
 			(int)FONT_TITLES, info->name);
 		SetDlgItemText(hDlg, IDC_DESCNAME, info->name);
 		hdc = GetDC(hDlg);
-		SetTextColor(hdc,GetPlayerNameColor(info->obj->flags,info->name));
+		SetTextColor(hdc,GetPlayerNameColor(info->obj,info->name));
 		ReleaseDC(hDlg,hdc);
 		
 		// Item Description.
@@ -404,7 +404,7 @@ BOOL CALLBACK DescDialogProc(HWND hDlg, UINT message, UINT wParam, LONG lParam)
 		   SetTextColor(lpdis->hDC, NAME_COLOR_NORMAL_BG);
 		   DrawText(lpdis->hDC, str, strlen(str), &lpdis->rcItem, DT_LEFT | DT_VCENTER | DT_NOPREFIX);
 		   OffsetRect(&lpdis->rcItem, -1, -1);
-		   SetTextColor(lpdis->hDC, GetPlayerNameColor(info->obj->flags,info->name));
+		   SetTextColor(lpdis->hDC, GetPlayerNameColor(info->obj, info->name));
 		   DrawText(lpdis->hDC, str, strlen(str), &lpdis->rcItem, DT_LEFT | DT_VCENTER | DT_NOPREFIX);
 		   
 		   break;

--- a/clientd3d/draw3d.h
+++ b/clientd3d/draw3d.h
@@ -87,6 +87,7 @@ typedef struct {
    list_type overlays;         /* Bitmaps to draw over object */
    BYTE light;                 /* Strength of sector light at object */
    int  flags;                 /* Object flags, including moveon type */
+   int  minimapflags;          /* Minimap dot color flags */
    int  height;                /* Height to draw object (FINENESS units) */   
    int  center;                /* Screen column of center of object */
    int  depth;                 /* Depth under ground to draw object (FINENESS units) */

--- a/clientd3d/draw3d.h
+++ b/clientd3d/draw3d.h
@@ -87,7 +87,7 @@ typedef struct {
    list_type overlays;         /* Bitmaps to draw over object */
    BYTE light;                 /* Strength of sector light at object */
    int  flags;                 // Boolean object flags.
-   BYTE drawingflags;          // Object flags for drawing effects (invisibility, lighting type etc.)
+   BYTE drawingtype;          // Object flags for drawing effects (invisibility, lighting type etc.)
    int  minimapflags;          /* Minimap dot color flags */
    unsigned int  namecolor;    /* Player name color flags */
    object_type objecttype;     /* Enum of object type (i.e. outlaw, murderer, NPC) */

--- a/clientd3d/draw3d.h
+++ b/clientd3d/draw3d.h
@@ -89,7 +89,7 @@ typedef struct {
    int  flags;                 /* Object flags, including moveon type */
    int  minimapflags;          /* Minimap dot color flags */
    unsigned int  namecolor;    /* Player name color flags */
-   BYTE playertype;            /* Enum of player type (i.e. outlaw, innocent) */
+   object_type objecttype;     /* Enum of object type (i.e. outlaw, murderer, NPC) */
    int  height;                /* Height to draw object (FINENESS units) */
    int  center;                /* Screen column of center of object */
    int  depth;                 /* Depth under ground to draw object (FINENESS units) */

--- a/clientd3d/draw3d.h
+++ b/clientd3d/draw3d.h
@@ -88,7 +88,9 @@ typedef struct {
    BYTE light;                 /* Strength of sector light at object */
    int  flags;                 /* Object flags, including moveon type */
    int  minimapflags;          /* Minimap dot color flags */
-   int  height;                /* Height to draw object (FINENESS units) */   
+   unsigned int  namecolor;    /* Player name color flags */
+   BYTE playertype;            /* Enum of player type (i.e. outlaw, innocent) */
+   int  height;                /* Height to draw object (FINENESS units) */
    int  center;                /* Screen column of center of object */
    int  depth;                 /* Depth under ground to draw object (FINENESS units) */
    BYTE translation;           /* Color translation type */

--- a/clientd3d/draw3d.h
+++ b/clientd3d/draw3d.h
@@ -90,6 +90,7 @@ typedef struct {
    int  minimapflags;          /* Minimap dot color flags */
    unsigned int  namecolor;    /* Player name color flags */
    object_type objecttype;     /* Enum of object type (i.e. outlaw, murderer, NPC) */
+   moveon_type moveontype;     /* MoveOn type of the object */
    int  height;                /* Height to draw object (FINENESS units) */
    int  center;                /* Screen column of center of object */
    int  depth;                 /* Depth under ground to draw object (FINENESS units) */

--- a/clientd3d/draw3d.h
+++ b/clientd3d/draw3d.h
@@ -86,7 +86,8 @@ typedef struct {
    int  group;                 /* Bitmap group to use to display object */
    list_type overlays;         /* Bitmaps to draw over object */
    BYTE light;                 /* Strength of sector light at object */
-   int  flags;                 /* Object flags, including moveon type */
+   int  flags;                 // Boolean object flags.
+   BYTE drawingflags;          // Object flags for drawing effects (invisibility, lighting type etc.)
    int  minimapflags;          /* Minimap dot color flags */
    unsigned int  namecolor;    /* Player name color flags */
    object_type objecttype;     /* Enum of object type (i.e. outlaw, murderer, NPC) */

--- a/clientd3d/drawbmp.c
+++ b/clientd3d/drawbmp.c
@@ -31,10 +31,10 @@ extern HPALETTE hPal;
 extern BYTE light_palettes[NUM_PALETTES][NUM_COLORS];
 
 /* local function prototypes */
-static void DrawStretchedBitmap(PDIB pdib, RECT rect, int inc, BYTE translation, BYTE secondtranslation, BYTE flags);
+static void DrawStretchedBitmap(PDIB pdib, RECT rect, int inc, BYTE translation, BYTE secondtranslation, int flags, BYTE drawingtype);
 static Bool ComputeObjectBoundingBox(PDIB pdib, list_type overlays, Bool include_object, RECT *max_rect, int angle);
 static void DrawOverlays(PDIB pdib_obj, RECT *obj_rect, list_type overlays, 
-						 int inc, Bool underlays, BYTE secondtranslation, BYTE flags, int angle);
+						 int inc, Bool underlays, BYTE secondtranslation, int flags, BYTE drawingtype, int angle);
 static void OffscreenBitCopy(HDC hdc, int dest_x, int dest_y, int width, int height,
 							 BYTE *bits, int source_x, int source_y, int source_width, int options);
 /************************************************************************/
@@ -190,14 +190,14 @@ void DrawObjectIcon(HDC hdc, ID icon, int group, Bool draw_obj, AREA *area, HBRU
 	
 	// Draw underlays
 	//if (obj->overlays != NULL)
-	//DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, True, obj->secondtranslation, obj->drawingtype);
+	//DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, True, obj->secondtranslation, obj->flags, obj->drawingtype);
 	
 	if (draw_obj)
-		DrawStretchedBitmap(pdib, obj_rect, inc, 0, 0, 0);
+		DrawStretchedBitmap(pdib, obj_rect, inc, 0, 0, 0, 0);
 	
 	// Draw overlays
 	//if (obj->overlays != NULL)
-	//DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, False, obj->secondtranslation, obj->drawingtype);
+	//DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, False, obj->secondtranslation, obj->flags, obj->drawingtype);
 	
 	if (!copy) 
 		return;
@@ -279,14 +279,14 @@ void DrawObject(HDC hdc, object_node *obj, int group, Bool draw_obj, AREA *area,
 	
 	// Draw underlays
 	if (obj->overlays != NULL)
-		DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, True, obj->secondtranslation, obj->drawingtype, angle);
+		DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, True, obj->secondtranslation, obj->flags, obj->drawingtype, angle);
 	
 	if (draw_obj)
-		DrawStretchedBitmap(pdib, obj_rect, inc, obj->translation, obj->secondtranslation, obj->drawingtype);
+		DrawStretchedBitmap(pdib, obj_rect, inc, obj->translation, obj->secondtranslation, obj->flags, obj->drawingtype);
 	
 	// Draw overlays
 	if (obj->overlays != NULL)
-		DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, False, obj->secondtranslation, obj->drawingtype, angle);
+		DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, False, obj->secondtranslation, obj->flags, obj->drawingtype, angle);
 	
 	if (!copy) 
 		return;
@@ -304,10 +304,11 @@ void DrawObject(HDC hdc, object_node *obj, int group, Bool draw_obj, AREA *area,
 *   inc tells how far to step on pdib_obj per pixel of obj_rect (fixed point).
 *   If underlays is True, draw only those overlays which should be drawn
 *     before the object is drawn.
-*   flags is a set of object flags, specifying any special drawing effects.
+*   flags is a set of object flags used for OF_FLASHING etc. drawingtype is
+*   an enum of types such as DRAWFX_INVISIBLE, etc.
 */
 void DrawOverlays(PDIB pdib_obj, RECT *obj_rect, list_type overlays, 
-				  int inc, Bool underlays, BYTE secondtranslation, BYTE flags, int angle)
+				  int inc, Bool underlays, BYTE secondtranslation, int flags, BYTE drawingtype, int angle)
 {
 	RECT rect;
 	list_type l;
@@ -389,10 +390,10 @@ void DrawOverlays(PDIB pdib_obj, RECT *obj_rect, list_type overlays,
 			if (overlay->effect)
 			{
 				BYTE effect = overlay->effect;
-				DrawStretchedBitmap(pdib_ov, rect, inc * shrink / obj_shrink, overlay->translation, secondtranslation, flags | effect);
+				DrawStretchedBitmap(pdib_ov, rect, inc * shrink / obj_shrink, overlay->translation, secondtranslation, flags, drawingtype | effect);
 			}
 			else
-				DrawStretchedBitmap(pdib_ov, rect, inc * shrink / obj_shrink, overlay->translation, secondtranslation, flags);
+				DrawStretchedBitmap(pdib_ov, rect, inc * shrink / obj_shrink, overlay->translation, secondtranslation, flags, drawingtype);
 		}
 	}
 }
@@ -403,7 +404,7 @@ void DrawOverlays(PDIB pdib_obj, RECT *obj_rect, list_type overlays,
 *   translation gives the palette translation type.
 *   flags is a set of object flags, used to specify special drawing effects
 */
-void DrawStretchedBitmap(PDIB pdib, RECT rect, int inc, BYTE translation, BYTE secondtranslation, BYTE flags)
+void DrawStretchedBitmap(PDIB pdib, RECT rect, int inc, BYTE translation, BYTE secondtranslation, int flags, BYTE drawingtype)
 {
 	int bitmap_width;
 	BYTE *obj_bits, *offscreen_ptr, *object_ptr, *end_ptr, index;
@@ -420,7 +421,12 @@ void DrawStretchedBitmap(PDIB pdib, RECT rect, int inc, BYTE translation, BYTE s
 	obj_bits = DibPtr(pdib);
 	
 	y = 0;
-	d.drawingtype = flags;
+	d.flags = flags;
+	d.drawingtype = drawingtype;
+	d.minimapflags  = 0;
+	d.namecolor = 0;
+	d.objecttype = OT_NONE;
+	d.moveontype = OF_MOVEON_YES;
 	d.translation = translation;
 	d.secondtranslation = secondtranslation;
 	// Dummy palette for use with special effects--draws at max brightness
@@ -434,7 +440,7 @@ void DrawStretchedBitmap(PDIB pdib, RECT rect, int inc, BYTE translation, BYTE s
 		// NOTE: Could make effect cases faster by making separate loops without palette indirection
 		
 		// Handle common case of no effects specially here
-		if (translation == 0 && flags == 0)
+		if (translation == 0 && drawingtype == 0)
 		{
 			for (j = rect.left; j < rect.right; j++)
 			{
@@ -451,8 +457,8 @@ void DrawStretchedBitmap(PDIB pdib, RECT rect, int inc, BYTE translation, BYTE s
 			DrawingLoop loop;
 			BYTE effect;
 			
-			// Take effect from palette translation or object flags
-			effect = flags;
+			// Take effect from palette translation or object drawingtype
+			effect = drawingtype;
 			if (effect == 0)
 				effect = DRAWFX_TRANSLATE;
 			
@@ -460,7 +466,7 @@ void DrawStretchedBitmap(PDIB pdib, RECT rect, int inc, BYTE translation, BYTE s
 			
 			if (loop == NULL)
 			{
-				//debug(("DrawStretchedBitmap got unknown effect index %d\n", flags));
+				//debug(("DrawStretchedBitmap got unknown effect index %d\n", drawingtype));
 			}
 			else
 			{

--- a/clientd3d/drawbmp.c
+++ b/clientd3d/drawbmp.c
@@ -425,7 +425,7 @@ void DrawStretchedBitmap(PDIB pdib, RECT rect, int inc, BYTE translation, BYTE s
 	d.minimapflags  = 0;
 	d.namecolor = 0;
 	d.objecttype = OT_NONE;
-	d.moveontype = OF_MOVEON_YES;
+	d.moveontype = MOVEON_YES;
 	d.translation = translation;
 	d.secondtranslation = secondtranslation;
 	// Dummy palette for use with special effects--draws at max brightness

--- a/clientd3d/drawbmp.c
+++ b/clientd3d/drawbmp.c
@@ -190,14 +190,14 @@ void DrawObjectIcon(HDC hdc, ID icon, int group, Bool draw_obj, AREA *area, HBRU
 	
 	// Draw underlays
 	//if (obj->overlays != NULL)
-	//DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, True, obj->secondtranslation, obj->drawingflags);
+	//DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, True, obj->secondtranslation, obj->drawingtype);
 	
 	if (draw_obj)
 		DrawStretchedBitmap(pdib, obj_rect, inc, 0, 0, 0);
 	
 	// Draw overlays
 	//if (obj->overlays != NULL)
-	//DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, False, obj->secondtranslation, obj->drawingflags);
+	//DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, False, obj->secondtranslation, obj->drawingtype);
 	
 	if (!copy) 
 		return;
@@ -279,14 +279,14 @@ void DrawObject(HDC hdc, object_node *obj, int group, Bool draw_obj, AREA *area,
 	
 	// Draw underlays
 	if (obj->overlays != NULL)
-		DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, True, obj->secondtranslation, obj->drawingflags, angle);
+		DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, True, obj->secondtranslation, obj->drawingtype, angle);
 	
 	if (draw_obj)
-		DrawStretchedBitmap(pdib, obj_rect, inc, obj->translation, obj->secondtranslation, obj->drawingflags);
+		DrawStretchedBitmap(pdib, obj_rect, inc, obj->translation, obj->secondtranslation, obj->drawingtype);
 	
 	// Draw overlays
 	if (obj->overlays != NULL)
-		DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, False, obj->secondtranslation, obj->drawingflags, angle);
+		DrawOverlays(pdib, &obj_rect, *(obj->overlays), inc, False, obj->secondtranslation, obj->drawingtype, angle);
 	
 	if (!copy) 
 		return;
@@ -420,7 +420,7 @@ void DrawStretchedBitmap(PDIB pdib, RECT rect, int inc, BYTE translation, BYTE s
 	obj_bits = DibPtr(pdib);
 	
 	y = 0;
-	d.drawingflags = flags;
+	d.drawingtype = flags;
 	d.translation = translation;
 	d.secondtranslation = secondtranslation;
 	// Dummy palette for use with special effects--draws at max brightness

--- a/clientd3d/drawbmp.c
+++ b/clientd3d/drawbmp.c
@@ -434,7 +434,7 @@ void DrawStretchedBitmap(PDIB pdib, RECT rect, int inc, BYTE translation, BYTE s
 		// NOTE: Could make effect cases faster by making separate loops without palette indirection
 		
 		// Handle common case of no effects specially here
-		if (translation == 0 && GetDrawingEffect(flags) == 0)
+		if (translation == 0 && flags == 0)
 		{
 			for (j = rect.left; j < rect.right; j++)
 			{
@@ -452,15 +452,15 @@ void DrawStretchedBitmap(PDIB pdib, RECT rect, int inc, BYTE translation, BYTE s
 			BYTE effect;
 			
 			// Take effect from palette translation or object flags
-			effect = GetDrawingEffectIndex(flags);
+			effect = flags;
 			if (effect == 0)
-				effect = GetDrawingEffectIndex(DRAWFX_TRANSLATE);
+				effect = DRAWFX_TRANSLATE;
 			
 			loop = drawing_loops[effect];
 			
 			if (loop == NULL)
 			{
-				//debug(("DrawStretchedBitmap got unknown effect index %d\n", GetDrawingEffectIndex(flags)));
+				//debug(("DrawStretchedBitmap got unknown effect index %d\n", flags));
 			}
 			else
 			{

--- a/clientd3d/drawbmp.c
+++ b/clientd3d/drawbmp.c
@@ -388,12 +388,11 @@ void DrawOverlays(PDIB pdib_obj, RECT *obj_rect, list_type overlays,
 				DIVUP(((DibHeight(pdib_ov) * obj_shrink / shrink) << FIX_DECIMAL), inc);
 			
 			if (overlay->effect)
-			{
-				BYTE effect = overlay->effect;
-				DrawStretchedBitmap(pdib_ov, rect, inc * shrink / obj_shrink, overlay->translation, secondtranslation, flags, drawingtype | effect);
-			}
+				DrawStretchedBitmap(pdib_ov, rect, inc * shrink / obj_shrink,
+					overlay->translation, secondtranslation, flags, overlay->effect);
 			else
-				DrawStretchedBitmap(pdib_ov, rect, inc * shrink / obj_shrink, overlay->translation, secondtranslation, flags, drawingtype);
+				DrawStretchedBitmap(pdib_ov, rect, inc * shrink / obj_shrink,
+					overlay->translation, secondtranslation, flags, drawingtype);
 		}
 	}
 }

--- a/clientd3d/drawbsp.c
+++ b/clientd3d/drawbsp.c
@@ -419,7 +419,7 @@ static void AddObjects(room_type *room)
       dx = r->motion.x - viewer_x;
       dy = r->motion.y - viewer_y;
       dist = GetDistance(dx,dy);
-      if (dist <= 0 || (dist < MIN_DISTANCE && ObjectMoveonType(r->obj) == OF_MOVEON_YES))
+      if (dist <= 0 || (dist < MIN_DISTANCE && r->obj.moveontype == OF_MOVEON_YES))
 	continue;
       
       /* compute angle that object is viewed at */

--- a/clientd3d/drawbsp.c
+++ b/clientd3d/drawbsp.c
@@ -452,6 +452,11 @@ static void AddObjects(room_type *room)
       d->draw.group    = r->obj.animate->group;
       d->draw.overlays = *(r->obj.overlays);
       d->draw.flags    = r->obj.flags;
+      d->draw.drawingtype  = r->obj.drawingtype;
+      d->draw.minimapflags  = r->obj.minimapflags;
+      d->draw.namecolor = r->obj.namecolor;
+      d->draw.objecttype = r->obj.objecttype;
+      d->draw.moveontype = r->obj.moveontype;
       d->draw.translation = r->obj.translation;
       d->draw.secondtranslation = r->obj.secondtranslation;
       d->draw.obj      = r;
@@ -577,6 +582,11 @@ static void AddObjects(room_type *room)
       d->draw.overlays = NULL;
       d->draw.draw     = True;
       d->draw.flags    = 0;
+      d->draw.drawingtype  = DRAWFX_DRAW_PLAIN;
+      d->draw.minimapflags  = 0;
+      d->draw.namecolor = 0;
+      d->draw.objecttype = OT_NONE;
+      d->draw.moveontype = OF_MOVEON_YES;
       d->draw.height   = proj->motion.z;
       d->draw.translation = proj->translation;
       d->draw.secondtranslation = 0;

--- a/clientd3d/drawbsp.c
+++ b/clientd3d/drawbsp.c
@@ -419,7 +419,7 @@ static void AddObjects(room_type *room)
       dx = r->motion.x - viewer_x;
       dy = r->motion.y - viewer_y;
       dist = GetDistance(dx,dy);
-      if (dist <= 0 || (dist < MIN_DISTANCE && r->obj.moveontype == OF_MOVEON_YES))
+      if (dist <= 0 || (dist < MIN_DISTANCE && r->obj.moveontype == MOVEON_YES))
 	continue;
       
       /* compute angle that object is viewed at */
@@ -586,7 +586,7 @@ static void AddObjects(room_type *room)
       d->draw.minimapflags  = 0;
       d->draw.namecolor = 0;
       d->draw.objecttype = OT_NONE;
-      d->draw.moveontype = OF_MOVEON_YES;
+      d->draw.moveontype = MOVEON_YES;
       d->draw.height   = proj->motion.z;
       d->draw.translation = proj->translation;
       d->draw.secondtranslation = 0;

--- a/clientd3d/game.c
+++ b/clientd3d/game.c
@@ -500,7 +500,7 @@ void ChangeObject(object_node *new_obj, BYTE translation, BYTE effect, Animate *
 
       // If object was user's selected target, and target became invisible, clear selection.
       if(GetUserTargetID() == r->obj.id
-            && (GetDrawingEffect(r->obj.drawingflags) == DRAWFX_INVISIBLE))
+            && (r->obj.drawingflags == DRAWFX_INVISIBLE))
          SetUserTargetID(INVALID_ID);
 
       // Object may have changed its effects such as OF_HANGING.

--- a/clientd3d/game.c
+++ b/clientd3d/game.c
@@ -500,7 +500,7 @@ void ChangeObject(object_node *new_obj, BYTE translation, BYTE effect, Animate *
 
       // If object was user's selected target, and target became invisible, clear selection.
       if(GetUserTargetID() == r->obj.id
-            && (r->obj.drawingflags == DRAWFX_INVISIBLE))
+            && (r->obj.drawingtype == DRAWFX_INVISIBLE))
          SetUserTargetID(INVALID_ID);
 
       // Object may have changed its effects such as OF_HANGING.

--- a/clientd3d/game.c
+++ b/clientd3d/game.c
@@ -499,8 +499,9 @@ void ChangeObject(object_node *new_obj, BYTE translation, BYTE effect, Animate *
       r->obj.overlays = &r->obj.normal_overlays;
 
       // If object was user's selected target, and target became invisible, clear selection.
-      if(GetUserTargetID() == r->obj.id && (GetDrawingEffect(r->obj.flags) == OF_INVISIBLE))
-	 SetUserTargetID(INVALID_ID);
+      if(GetUserTargetID() == r->obj.id
+            && (GetDrawingEffect(r->obj.drawingflags) == DRAWFX_INVISIBLE))
+         SetUserTargetID(INVALID_ID);
 
       // Object may have changed its effects such as OF_HANGING.
       RoomObjectSetHeight(r);

--- a/clientd3d/gameuser.c
+++ b/clientd3d/gameuser.c
@@ -56,7 +56,7 @@ void UserAttack(int action)
    last_attack_time = now;
 
    /* Get objects at mouse position */
-   object_list = GetObjects3D(x, y, 0, OF_ATTACKABLE, 0);
+   object_list = GetObjects3D(x, y, 0, OF_ATTACKABLE, 0, 0, 0);
    if (object_list == NULL)
       return;
 
@@ -101,7 +101,7 @@ void UserAttackClosest(int action)
 	}
 	
    object_list = GetObjects3D(NO_COORD_CHECK, NO_COORD_CHECK, 
-			      CLOSE_DISTANCE, OF_ATTACKABLE, 0);
+			      CLOSE_DISTANCE, OF_ATTACKABLE, 0, 0, 0);
    if (object_list == NULL)
       return;
 
@@ -115,7 +115,7 @@ void UserPickup(void)
    list_type square_list, sel_list, l;
 
    if ((square_list = GetObjects3D(NO_COORD_CHECK, NO_COORD_CHECK,
-				   CLOSE_DISTANCE, OF_GETTABLE, 0)) == NULL)
+				   CLOSE_DISTANCE, OF_GETTABLE, 0, 0, 0)) == NULL)
        return;
 
    sel_list = DisplayLookList(hMain, GetString(hInst, IDS_GET), 
@@ -163,7 +163,7 @@ void UserLook(void)
    room_contents_node *r;
 
    if ((square_list = GetObjects3D(NO_COORD_CHECK, NO_COORD_CHECK,
-				   0, 0, OF_NOEXAMINE | OF_INVISIBLE)) == NULL)
+				   0, 0, OF_NOEXAMINE, 0, DRAWFX_INVISIBLE)) == NULL)
       return;
    
    sel_list = DisplayLookList(hMain, GetString(hInst, IDS_LOOK), square_list, LD_SINGLEAUTO);
@@ -223,7 +223,7 @@ void UserLookMouseSquare(void)
 //      return;
 //   }
 
-   objects = GetObjects3D(x, y, 0, 0, OF_INVISIBLE);
+   objects = GetObjects3D(x, y, 0, 0, 0, 0, DRAWFX_INVISIBLE);
    if (objects == NULL)
       return;
 
@@ -259,7 +259,7 @@ void UserActivate(void)
    object_node *obj;
 
    if ((square_list = GetObjects3D(NO_COORD_CHECK, NO_COORD_CHECK,
-				   CLOSE_DISTANCE, OF_ACTIVATABLE | OF_CONTAINER, OF_PLAYER)) == NULL)
+				   CLOSE_DISTANCE, OF_ACTIVATABLE | OF_CONTAINER, OF_PLAYER, 0, 0)) == NULL)
       return;
    
    sel_list = DisplayLookList(hMain, GetString(hInst, IDS_ACTIVATE), square_list, LD_SINGLEAUTO);
@@ -290,7 +290,7 @@ void UserActivateMouse(void)
    if (!MouseToRoom(&x, &y))
       return;
 
-   objects = GetObjects3D(x, y, CLOSE_DISTANCE, OF_ACTIVATABLE | OF_CONTAINER, OF_PLAYER);
+   objects = GetObjects3D(x, y, CLOSE_DISTANCE, OF_ACTIVATABLE | OF_CONTAINER, OF_PLAYER, 0, 0);
    if (objects == NULL)
       return;
 
@@ -335,7 +335,7 @@ void UserPut(void)
 
    /* If there are no containers around, don't ask for object to put */
    square_list = GetObjects3D(NO_COORD_CHECK, NO_COORD_CHECK,
-			      CLOSE_DISTANCE, OF_CONTAINER, 0);
+			      CLOSE_DISTANCE, OF_CONTAINER, 0, 0, 0);
    if (square_list == NULL)
       return;
    
@@ -439,7 +439,7 @@ void UserMakeOffer(void)
       return;
 
    recipients = GetObjects3D(NO_COORD_CHECK, NO_COORD_CHECK,
-			     CLOSE_DISTANCE, OF_OFFERABLE, OF_INVISIBLE);
+			     CLOSE_DISTANCE, OF_OFFERABLE, 0, 0, DRAWFX_INVISIBLE);
 
    if (recipients == NULL)
    {
@@ -483,7 +483,7 @@ void UserBuy(void)
 
    // Get object to buy from
    sellers = GetObjects3D(NO_COORD_CHECK, NO_COORD_CHECK,
-			  CLOSE_DISTANCE, OF_BUYABLE, 0);
+			  CLOSE_DISTANCE, OF_BUYABLE, 0, 0, 0);
 
    if (sellers == NULL)
    {
@@ -528,7 +528,7 @@ void UserDeposit(void)
       return;
 
    recipients = GetObjects3D(NO_COORD_CHECK, NO_COORD_CHECK,
-			     CLOSE_DISTANCE, OF_OFFERABLE, 0);
+			     CLOSE_DISTANCE, OF_OFFERABLE, 0, 0, 0);
 
    if (recipients == NULL)
    {
@@ -573,7 +573,7 @@ void UserWithdraw(void)
 
    // Get object to buy from
    bankers = GetObjects3D(NO_COORD_CHECK, NO_COORD_CHECK,
-			  CLOSE_DISTANCE, OF_BUYABLE, 0);
+			  CLOSE_DISTANCE, OF_BUYABLE, 0, 0, 0);
 
    if (bankers == NULL)
    {
@@ -683,7 +683,7 @@ void UserTargetNextOrPrevious(Bool bTargetNext)
 
 	//	Get list of visible objects.
 	//	xxx use something like OF_ATTACKABLE?
-	object_list = GetObjects3D(NO_COORD_CHECK, NO_COORD_CHECK, 0, OF_ATTACKABLE, OF_INVISIBLE);
+	object_list = GetObjects3D(NO_COORD_CHECK, NO_COORD_CHECK, 0, OF_ATTACKABLE, 0, 0, DRAWFX_INVISIBLE);
 	
 	//	There doesn't seem to be a "list_find_item()"-like proc that returns position of an item in a list,
 	//	so I'll just iterate through the list myself.

--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -453,7 +453,7 @@ void UserStartDrag(void)
    if (!MouseToRoom(&x, &y))
       return;
 
-   objects = GetObjects3D(x, y, CLOSE_DISTANCE, OF_GETTABLE | OF_CONTAINER, 0);
+   objects = GetObjects3D(x, y, CLOSE_DISTANCE, OF_GETTABLE | OF_CONTAINER, 0, 0, 0);
    if (objects == NULL)
       return;
 

--- a/clientd3d/lagbox.c
+++ b/clientd3d/lagbox.c
@@ -114,7 +114,7 @@ BOOL Lagbox_Create()
 	pobjLagbox->minimapflags = 0;
 	pobjLagbox->namecolor = NC_OUTLAW;
 	pobjLagbox->objecttype = OT_NONE;
-	pobjLagbox->moveontype = OF_MOVEON_YES;
+	pobjLagbox->moveontype = MOVEON_YES;
 	dwLagboxLatency = s_adwLatencyMetric[0];
 
 	hwndLagbox = CreateWindow("button", "", WS_CHILD | BS_OWNERDRAW, 

--- a/clientd3d/lagbox.c
+++ b/clientd3d/lagbox.c
@@ -297,7 +297,8 @@ void Lagbox_Command(HWND hWnd, int id, HWND hwndCtrl, UINT uNotify)
 	lagbox = *pobjLagbox;
 	lagbox.animate = &lagbox.normal_animate;
 	lagbox.overlays = &lagbox.normal_overlays;
-	lagbox.flags |= OF_PLAYER | PF_OUTLAW;
+	lagbox.flags |= OF_PLAYER;
+	lagbox.namecolor = NC_OUTLAW;
 
 	Lagbox_OnTooltipCallback(hWnd, &ttt);
 

--- a/clientd3d/lagbox.c
+++ b/clientd3d/lagbox.c
@@ -109,7 +109,7 @@ BOOL Lagbox_Create()
 	pobjLagbox->normal_animate.group = 1;
 	pobjLagbox->normal_animate.group_low = 1;
 	pobjLagbox->normal_animate.group_high = 1;
-	pobjLagbox->drawingflags = DRAWFX_DITHERTRANS;
+	pobjLagbox->drawingtype = DRAWFX_DITHERTRANS;
 
 	dwLagboxLatency = s_adwLatencyMetric[0];
 

--- a/clientd3d/lagbox.c
+++ b/clientd3d/lagbox.c
@@ -110,7 +110,11 @@ BOOL Lagbox_Create()
 	pobjLagbox->normal_animate.group_low = 1;
 	pobjLagbox->normal_animate.group_high = 1;
 	pobjLagbox->drawingtype = DRAWFX_DITHERTRANS;
-
+	pobjLagbox->flags = OF_PLAYER;
+	pobjLagbox->minimapflags = 0;
+	pobjLagbox->namecolor = NC_OUTLAW;
+	pobjLagbox->objecttype = OT_NONE;
+	pobjLagbox->moveontype = OF_MOVEON_YES;
 	dwLagboxLatency = s_adwLatencyMetric[0];
 
 	hwndLagbox = CreateWindow("button", "", WS_CHILD | BS_OWNERDRAW, 

--- a/clientd3d/lagbox.c
+++ b/clientd3d/lagbox.c
@@ -109,7 +109,7 @@ BOOL Lagbox_Create()
 	pobjLagbox->normal_animate.group = 1;
 	pobjLagbox->normal_animate.group_low = 1;
 	pobjLagbox->normal_animate.group_high = 1;
-	pobjLagbox->flags = OF_DITHERTRANS;
+	pobjLagbox->drawingflags = DRAWFX_DITHERTRANS;
 
 	dwLagboxLatency = s_adwLatencyMetric[0];
 

--- a/clientd3d/map.c
+++ b/clientd3d/map.c
@@ -384,7 +384,7 @@ void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
       // Skip ourselves, invisible objects and anything with
       // minimapflags of 0.
       if ((r->obj.id == player.id)
-         || (GetDrawingEffect(r->obj.drawingflags) == DRAWFX_INVISIBLE)
+         || (r->obj.drawingflags == DRAWFX_INVISIBLE)
          || (r->obj.minimapflags == MM_NONE))
          continue;
 

--- a/clientd3d/map.c
+++ b/clientd3d/map.c
@@ -382,8 +382,9 @@ void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
       room_contents_node *r = (room_contents_node *) (l->data);
 
       // Skip ourselves, invisible objects and anything with
-      // minimapflags of 0, except if it's another player.
-      if ((r->obj.id == player.id) || (GetDrawingEffect(r->obj.flags) == OF_INVISIBLE)
+      // minimapflags of 0.
+      if ((r->obj.id == player.id)
+         || (GetDrawingEffect(r->obj.drawingflags) == DRAWFX_INVISIBLE)
          || (r->obj.minimapflags == MM_NONE))
          continue;
 

--- a/clientd3d/map.c
+++ b/clientd3d/map.c
@@ -28,12 +28,14 @@
 #define MAP_PLAYER_FRONT_COLOR  PALETTERGB(0, 0, 0)      // Pixel at front of player
 #define MAP_OBJECT_COLOR        PALETTERGB(255, 0, 0)    // Red
 #define MAP_MINION_COLOR        PALETTERGB(0,200,0)      // Green
-#define MAP_MINION_OTH_COLOR    PALETTERGB(70,5,100)     // Purple
-#define MAP_FRIEND_COLOR        PALETTERGB(0, 255, 0)    // Bright Green
+#define MAP_MINION_OTH_COLOR    PALETTERGB(70,5,130)     // Purple
+#define MAP_FRIEND_COLOR        PALETTERGB(0, 255, 120)  // Green with blue tint
 #define MAP_ENEMY_COLOR         PALETTERGB(255, 0, 0)    // Red
 #define MAP_GUILDMATE_COLOR     PALETTERGB(255, 255, 0)  // Yellow
+#define MAP_BUILDGRP_COLOR      PALETTERGB(0, 255, 0)    // Bright Green
+#define MAP_NPC_COLOR           PALETTERGB(0, 0, 0)      // Black
 
-#define MAP_OBJECT_RADIUS (FINENESS / 6)  // Radius of circle drawn for an object
+#define MAP_OBJECT_RADIUS (FINENESS / 4)  // Radius of circle drawn for an object
 
 #define MAP_ZOOM_INCREMENT 0.1       // Amount to change zoom factor per user command
 #define MAP_ZOOM_DELAY     100       // # of milliseconds between zooming in by INCREMENT
@@ -42,9 +44,9 @@
 
 #define MAP_OBJECT_DISTANCE (7 * FINENESS) // Draw all object closer than this to player
 
-static HBRUSH hObjectBrush, hPlayerBrush, hNullBrush, hMinionBrush, hMinionOtherBrush;
+static HBRUSH hObjectBrush, hPlayerBrush, hNullBrush, hMinionBrush, hMinionOtherBrush, hNpcBrush;
 static HPEN hWallPen, hPlayerPen, hObjectPen, hMinionPen, hMinionOtherPen;
-static HPEN hFriendPen, hEnemyPen, hGuildmatePen;
+static HPEN hFriendPen, hEnemyPen, hGuildmatePen, hBuilderPen, hNpcPen;
 
 static float zoom;              // Factor to zoom in on map
 
@@ -135,7 +137,10 @@ void MapInitialize(void)
    hGuildmatePen = CreatePen(PS_SOLID, MAP_PLAYER_THICKNESS, MAP_GUILDMATE_COLOR);
    hMinionPen = CreatePen(PS_SOLID, MAP_OBJECT_THICKNESS, MAP_MINION_COLOR);
    hMinionOtherPen = CreatePen(PS_SOLID, MAP_OBJECT_THICKNESS, MAP_MINION_OTH_COLOR);
+   hBuilderPen = CreatePen(PS_SOLID, MAP_OBJECT_THICKNESS, MAP_BUILDGRP_COLOR);
+   hNpcPen = CreatePen(PS_SOLID, MAP_OBJECT_THICKNESS, MAP_NPC_COLOR);
 
+   hNpcBrush = CreateSolidBrush(MAP_NPC_COLOR);
    hMinionOtherBrush = CreateSolidBrush(MAP_MINION_OTH_COLOR);
    hMinionBrush = CreateSolidBrush(MAP_MINION_COLOR);
    hObjectBrush = CreateSolidBrush(MAP_OBJECT_COLOR);
@@ -171,11 +176,14 @@ void MapClose(void)
    DeleteObject(hGuildmatePen);
    DeleteObject(hMinionPen);
    DeleteObject(hMinionOtherPen);
+   DeleteObject(hBuilderPen);
+   DeleteObject(hNpcPen);
    DeleteObject(hMinionOtherBrush);
    DeleteObject(hMinionBrush);
    DeleteObject(hObjectBrush);
    DeleteObject(hPlayerBrush);
    DeleteObject(hNullBrush);
+   DeleteObject(hNpcBrush);
 
    if (pMapWalls)
       SafeFree(pMapWalls);
@@ -207,8 +215,6 @@ void MapDraw( HDC hdc, BYTE *bits, AREA *area, room_type *room, int width, Bool 
    else
       DrawWindowBackgroundMem(&map_bkgnd, bits, &rect, width, (int)( player.x * scaleMiniMap ), (int)( player.y * scaleMiniMap ) );
 
-
-   
       if (config.drawmap)
       {
 	 HPEN hOldPen = (HPEN) SelectObject(hdc, hWallPen);
@@ -361,8 +367,6 @@ void MapDrawWall(HDC hdc, int x, int y, float scale, WallData *wall)
 /*
  * MapDrawObjects:  Draw a dot for each object in list, skipping the player.
  *   (x, y) is the upper-left corner of the drawing area on hdc.
- * Note 2014-09-04: Should we be using a Switch for this, since we're
- * expanding the amount of possible dots?
  */
 void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
 {
@@ -376,18 +380,20 @@ void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
    for (l = objects; l != NULL; l = l->next)
    {
       room_contents_node *r = (room_contents_node *) (l->data);
-      
-      // Skip player and inanimate or invisible objects
-      if (r->obj.id == player.id || !(r->obj.flags & OF_ATTACKABLE) 
-	  || (GetDrawingEffect(r->obj.flags) == OF_INVISIBLE))
-	 continue;
+
+      // Skip ourselves, invisible objects and anything with
+      // minimapflags of 0, except if it's another player.
+      if ((r->obj.id == player.id) || (GetDrawingEffect(r->obj.flags) == OF_INVISIBLE)
+         || (r->obj.minimapflags == MM_NONE))
+         continue;
 
       // Only draw monsters that are visible, or within a certain range.
+      // Draw NPC dots no matter where they are.
       dx = (r->motion.x - player.x) >> 4;
       dy = (r->motion.y - player.y) >> 4;
       if (((dx * dx + dy * dy) > mapObjectDistanceShiftAndSquare) &&
           (!r->visible && !config.showUnseenMonsters) &&
-          !(r->obj.flags & OF_PLAYER)) 
+          !(r->obj.flags & OF_PLAYER) && !(r->obj.minimapflags & MM_NPC))
           continue;
 
       new_x = x + (r->motion.x * scale);
@@ -397,23 +403,32 @@ void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
       if (r->obj.flags & OF_PLAYER)
       {
          SelectObject(hdc, hPlayerBrush);
-         float ring_radius = 1.6f * radius;
+         float ring_radius;
 
-         if (r->obj.flags & OF_FRIEND)
+         // Builder group?
+         if (r->obj.minimapflags & MM_BUILDER_GROUP)
          {
-            if ((r->obj.flags & OF_ENEMY) || (r->obj.flags & OF_GUILDMATE))
-               ring_radius = 2.4f * radius;
+            ring_radius = 2.6f * radius;
+            SelectObject(hdc, hBuilderPen);
+            Ellipse(hdc, (int) (new_x - ring_radius),
+                     (int) (new_y - ring_radius),
+                     (int) (new_x + ring_radius),
+                     (int) (new_y + ring_radius));
+         }
 
+         ring_radius = 1.6f * radius;
+         // Friend?
+         if (r->obj.minimapflags & MM_FRIEND)
+         {
             SelectObject(hdc, hFriendPen);
             Ellipse(hdc, (int) (new_x - ring_radius),
                      (int) (new_y - ring_radius),
                      (int) (new_x + ring_radius),
                      (int) (new_y + ring_radius));
-            ring_radius = 1.6f * radius;
          }
 
          // Enemy?
-         if (r->obj.flags & OF_ENEMY)
+         if (r->obj.minimapflags & MM_ENEMY)
          {
             SelectObject(hdc, hEnemyPen);
             Ellipse(hdc, (int) (new_x - ring_radius),
@@ -423,7 +438,7 @@ void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
          }
 
          // Guildmate?
-         if (r->obj.flags & OF_GUILDMATE)
+         if (r->obj.minimapflags & MM_GUILDMATE)
          {
              SelectObject(hdc, hGuildmatePen);
              Ellipse(hdc, (int) (new_x - ring_radius),
@@ -433,33 +448,43 @@ void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
          }
       }
 
-      /* Draw middle of player dot in a different color. If
-      / a monster is a minion then color it appropriately,
-      / otherwise it gets the standard red dot. */
-      if (r->obj.flags & OF_PLAYER)
+      /* Draw middle of player dot in a different color. If a monster
+         is a minion or NPC then color it appropriately, otherwise it
+         gets the standard red dot. */
+      if (r->obj.minimapflags & MM_PLAYER)
       {
-          SelectObject(hdc, hPlayerPen);
-          SelectObject(hdc, hPlayerBrush);
+         SelectObject(hdc, hPlayerPen);
+         SelectObject(hdc, hPlayerBrush);
       }
-      else if ((r->obj.flags & OF_MINION_SELF) == OF_MINION_SELF)
+      else if (r->obj.minimapflags & MM_MINION_SELF)
       {
-          SelectObject(hdc, hMinionPen);
-          SelectObject(hdc, hMinionBrush);
+         SelectObject(hdc, hMinionPen);
+         SelectObject(hdc, hMinionBrush);
       }
-      else if ((r->obj.flags & OF_MINION_OTHER) == OF_MINION_OTHER)
+      else if (r->obj.minimapflags & MM_MINION_OTHER)
       {
-          SelectObject(hdc, hMinionOtherPen);
-          SelectObject(hdc, hMinionOtherBrush);
+         SelectObject(hdc, hMinionOtherPen);
+         SelectObject(hdc, hMinionOtherBrush);
+      }
+      else if (r->obj.minimapflags & MM_MONSTER)
+      {
+         SelectObject(hdc, hObjectPen);
+         SelectObject(hdc, hObjectBrush);
+      }
+      else if (r->obj.minimapflags & MM_NPC)
+      {
+         SelectObject(hdc, hNpcPen);
+         SelectObject(hdc, hNpcBrush);
       }
       else
       {
-          SelectObject(hdc, hObjectPen);
-          SelectObject(hdc, hObjectBrush);
+         // No dots for anything else, yet.
+         return;
       }
 
       // Draw a circle at the object's position
-      Ellipse(hdc, (int) (new_x - radius), (int) (new_y - radius), 
-	      (int) (new_x + radius), (int) (new_y + radius));
+      Ellipse(hdc, (int) (new_x - radius), (int) (new_y - radius),
+         (int) (new_x + radius), (int) (new_y + radius));
 
    }
 }

--- a/clientd3d/map.c
+++ b/clientd3d/map.c
@@ -384,7 +384,7 @@ void MapDrawObjects(HDC hdc, list_type objects, int x, int y, float scale)
       // Skip ourselves, invisible objects and anything with
       // minimapflags of 0.
       if ((r->obj.id == player.id)
-         || (r->obj.drawingflags == DRAWFX_INVISIBLE)
+         || (r->obj.drawingtype == DRAWFX_INVISIBLE)
          || (r->obj.minimapflags == MM_NONE))
          continue;
 

--- a/clientd3d/move.c
+++ b/clientd3d/move.c
@@ -655,7 +655,7 @@ int MoveObjectAllowed(room_type *room, int old_x, int old_y, int *new_x, int *ne
       dx = abs(r->motion.x - *new_x);
       dy = abs(r->motion.y - *new_y);
       
-      switch (ObjectMoveonType(r->obj))
+      switch (r->obj.moveontype)
       {
       case OF_MOVEON_NOTIFY:
          if ((dx > MIN_HOTPLATE_DIST) || (dy > MIN_HOTPLATE_DIST))

--- a/clientd3d/move.c
+++ b/clientd3d/move.c
@@ -657,7 +657,7 @@ int MoveObjectAllowed(room_type *room, int old_x, int old_y, int *new_x, int *ne
       
       switch (r->obj.moveontype)
       {
-      case OF_MOVEON_NOTIFY:
+      case MOVEON_NOTIFY:
          if ((dx > MIN_HOTPLATE_DIST) || (dy > MIN_HOTPLATE_DIST))
          {
             if ((int)r->obj.id == idLastObjNotify)
@@ -681,7 +681,7 @@ int MoveObjectAllowed(room_type *room, int old_x, int old_y, int *new_x, int *ne
          }
          break;
 
-      case OF_MOVEON_NO:
+      case MOVEON_NO:
          if (dx > MIN_NOMOVEON || dy > MIN_NOMOVEON ||
              (dx * dx + dy * dy) > MIN_NOMOVEON * MIN_NOMOVEON)
             continue;
@@ -716,7 +716,7 @@ int MoveObjectAllowed(room_type *room, int old_x, int old_y, int *new_x, int *ne
          return MOVE_BLOCKED;
          break;
          
-      case OF_MOVEON_TELEPORTER:
+      case MOVEON_TELEPORTER:
          if (dx > MIN_NOMOVEON || dy > MIN_NOMOVEON ||
              (dx * dx + dy * dy) > MIN_NOMOVEON * MIN_NOMOVEON)
             continue;

--- a/clientd3d/objdraw.c
+++ b/clientd3d/objdraw.c
@@ -45,7 +45,7 @@ DrawingLoop drawing_loops[NUM_DRAW_EFFECTS] = {
 };
 
 /************************************************************************/
-#define INVISIBLE_MAGNITUDE 3   // Size of distortion for invisibility effect
+#define INVISIBLE_MAGNITUDE 1   // Size of distortion for invisibility effect
 void DrawObjectInvisible(ObjectRowData *d)
 {
 	BYTE *copy_ptr;
@@ -60,26 +60,8 @@ void DrawObjectInvisible(ObjectRowData *d)
 	xinc = d->xinc;
 	row_bits = d->obj_bits;
 	copy_ptr = start;
-	if (rand() % 2 == 0)
-	{
-		if (d->ysize > 2 * INVISIBLE_MAGNITUDE)
-			if (d->row + INVISIBLE_MAGNITUDE >= d->ysize)
-				copy_ptr -= INVISIBLE_MAGNITUDE * d->xsize;
-			else copy_ptr += INVISIBLE_MAGNITUDE * d->xsize;
-			while (start <= end)
-			{
-				/* Don't draw transparent pixels */
-				index = *(row_bits + (x >> FIX_DECIMAL));
-				if (index != TRANSPARENT_INDEX)
-					*start = *(copy_ptr + INVISIBLE_MAGNITUDE);
-				
-				/* Move to next column of screen */
-				start++;
-				copy_ptr++;
-				x += xinc;
-			}
-	}
-	else
+
+	if (rand() % 8 == 0)
 	{
 		if (d->ysize > 2 * INVISIBLE_MAGNITUDE)
 			if (d->row <= INVISIBLE_MAGNITUDE)
@@ -91,6 +73,25 @@ void DrawObjectInvisible(ObjectRowData *d)
 				index = *(row_bits + (x >> FIX_DECIMAL));
 				if (index != TRANSPARENT_INDEX)
 					*start = *(copy_ptr - INVISIBLE_MAGNITUDE);
+				
+				/* Move to next column of screen */
+				start++;
+				copy_ptr++;
+				x += xinc;
+			}
+	}
+	else
+	{
+		if (d->ysize > 2 * INVISIBLE_MAGNITUDE)
+			if (d->row + INVISIBLE_MAGNITUDE >= d->ysize)
+				copy_ptr -= INVISIBLE_MAGNITUDE * d->xsize;
+			else copy_ptr += INVISIBLE_MAGNITUDE * d->xsize;
+			while (start <= end)
+			{
+				/* Don't draw transparent pixels */
+				index = *(row_bits + (x >> FIX_DECIMAL));
+				if (index != TRANSPARENT_INDEX)
+					*start = *(copy_ptr + INVISIBLE_MAGNITUDE);
 				
 				/* Move to next column of screen */
 				start++;

--- a/clientd3d/objdraw.c
+++ b/clientd3d/objdraw.c
@@ -119,7 +119,7 @@ void DrawObjectTranslucent(ObjectRowData *d)
 	xinc = d->xinc;
 	row_bits = d->obj_bits;
 	palette = d->palette;
-	effect = d->drawingflags;
+	effect = d->drawingtype;
 
 	switch( effect ) {
 		case DRAWFX_TRANSLUCENT25:

--- a/clientd3d/objdraw.c
+++ b/clientd3d/objdraw.c
@@ -108,7 +108,7 @@ void DrawObjectTranslucent(ObjectRowData *d)
 
 	bixlat* pBiXlat = &_blend75;
 	BYTE index;
-	int effect;
+	BYTE effect;
 	register BYTE *start, *end;
 	int x, xinc;
 	BYTE *palette, *row_bits;
@@ -119,13 +119,13 @@ void DrawObjectTranslucent(ObjectRowData *d)
 	xinc = d->xinc;
 	row_bits = d->obj_bits;
 	palette = d->palette;
-	effect = GetDrawingEffect(d->flags);// this is a macro
+	effect = GetDrawingEffect(d->drawingflags);// this is a macro
 
 	switch( effect ) {
-		case OF_TRANSLUCENT25:
+		case DRAWFX_TRANSLUCENT25:
 			pBiXlat = &_blend25;
 			break;
-		case OF_TRANSLUCENT50:
+		case DRAWFX_TRANSLUCENT50:
 			pBiXlat = &_blend50;
 			break;
 		default:

--- a/clientd3d/objdraw.c
+++ b/clientd3d/objdraw.c
@@ -119,7 +119,7 @@ void DrawObjectTranslucent(ObjectRowData *d)
 	xinc = d->xinc;
 	row_bits = d->obj_bits;
 	palette = d->palette;
-	effect = GetDrawingEffect(d->drawingflags);// this is a macro
+	effect = d->drawingflags;
 
 	switch( effect ) {
 		case DRAWFX_TRANSLUCENT25:

--- a/clientd3d/objdraw.h
+++ b/clientd3d/objdraw.h
@@ -15,7 +15,9 @@
 // Structure passed to inner loops
 typedef struct {
    int   flags;             // Object flags
-   int   minimapflags;      /* Minimap dot color flags */
+   int   minimapflags;      // Minimap dot color flags
+   unsigned int namecolor;  // Player name color flags
+   BYTE  playertype;        // Enum of player type (i.e. outlaw, innocent)
    BYTE  translation;       // Palette translation to use
    BYTE  secondtranslation; // Another palette translation to use
    BYTE *start_ptr;         // Points to start of row to draw in

--- a/clientd3d/objdraw.h
+++ b/clientd3d/objdraw.h
@@ -14,22 +14,23 @@
 
 // Structure passed to inner loops
 typedef struct {
-   int   flags;             // Object flags
-   int   minimapflags;      // Minimap dot color flags
-   unsigned int namecolor;  // Player name color flags
-   object_type objecttype;  // Enum of object type (i.e. outlaw, murderer, NPC)
-   moveon_type moveontype;  // MoveOn type of the object
-   BYTE  translation;       // Palette translation to use
-   BYTE  secondtranslation; // Another palette translation to use
-   BYTE *start_ptr;         // Points to start of row to draw in
-   BYTE *end_ptr;           // Points to last pixel to draw in
-   BYTE *obj_bits;          // Points to current row of bitmap to draw
-   int   row;               // Row of frame buffer we're drawing into
-   int   x;                 // The x coordinate on the offscreen buffer, in fixed point
-   int   xinc;              // The x increment in the object bitmap per screen pixel, in fixed point
-   BYTE *palette;           // Palette to indirect through; provides light level
-   int   xsize;             // x size of offscreen buffer in pixels
-   int   ysize;             // y size of offscreen buffer in pixels
+   int          flags;             // Boolean object flags.
+   BYTE         drawingflags;      // Object flags for drawing effects (invisibility, lighting type etc.)
+   int          minimapflags;      // Minimap dot color flags
+   unsigned int namecolor;         // Player name color flags
+   object_type  objecttype;        // Enum of object type (i.e. outlaw, murderer, NPC)
+   moveon_type  moveontype;        // MoveOn type of the object
+   BYTE         translation;       // Palette translation to use
+   BYTE         secondtranslation; // Another palette translation to use
+   BYTE         *start_ptr;        // Points to start of row to draw in
+   BYTE         *end_ptr;          // Points to last pixel to draw in
+   BYTE         *obj_bits;         // Points to current row of bitmap to draw
+   int          row;               // Row of frame buffer we're drawing into
+   int          x;                 // The x coordinate on the offscreen buffer, in fixed point
+   int          xinc;              // The x increment in the object bitmap per screen pixel, in fixed point
+   BYTE         *palette;          // Palette to indirect through; provides light level
+   int          xsize;             // x size of offscreen buffer in pixels
+   int          ysize;             // y size of offscreen buffer in pixels
 } ObjectRowData;
 
 typedef void (*DrawingLoop)(ObjectRowData *d);

--- a/clientd3d/objdraw.h
+++ b/clientd3d/objdraw.h
@@ -15,6 +15,7 @@
 // Structure passed to inner loops
 typedef struct {
    int   flags;             // Object flags
+   int   minimapflags;      /* Minimap dot color flags */
    BYTE  translation;       // Palette translation to use
    BYTE  secondtranslation; // Another palette translation to use
    BYTE *start_ptr;         // Points to start of row to draw in

--- a/clientd3d/objdraw.h
+++ b/clientd3d/objdraw.h
@@ -17,7 +17,7 @@ typedef struct {
    int   flags;             // Object flags
    int   minimapflags;      // Minimap dot color flags
    unsigned int namecolor;  // Player name color flags
-   BYTE  playertype;        // Enum of player type (i.e. outlaw, innocent)
+   object_type objecttype;  // Enum of object type (i.e. outlaw, murderer, NPC)
    BYTE  translation;       // Palette translation to use
    BYTE  secondtranslation; // Another palette translation to use
    BYTE *start_ptr;         // Points to start of row to draw in

--- a/clientd3d/objdraw.h
+++ b/clientd3d/objdraw.h
@@ -18,6 +18,7 @@ typedef struct {
    int   minimapflags;      // Minimap dot color flags
    unsigned int namecolor;  // Player name color flags
    object_type objecttype;  // Enum of object type (i.e. outlaw, murderer, NPC)
+   moveon_type moveontype;  // MoveOn type of the object
    BYTE  translation;       // Palette translation to use
    BYTE  secondtranslation; // Another palette translation to use
    BYTE *start_ptr;         // Points to start of row to draw in

--- a/clientd3d/objdraw.h
+++ b/clientd3d/objdraw.h
@@ -15,7 +15,7 @@
 // Structure passed to inner loops
 typedef struct {
    int          flags;             // Boolean object flags.
-   BYTE         drawingflags;      // Object flags for drawing effects (invisibility, lighting type etc.)
+   BYTE         drawingtype;      // Object flags for drawing effects (invisibility, lighting type etc.)
    int          minimapflags;      // Minimap dot color flags
    unsigned int namecolor;         // Player name color flags
    object_type  objecttype;        // Enum of object type (i.e. outlaw, murderer, NPC)

--- a/clientd3d/object.c
+++ b/clientd3d/object.c
@@ -93,6 +93,7 @@ object_node *ObjectCopy(object_node *obj)
    temp->minimapflags  = obj->minimapflags;
    temp->namecolor = obj->namecolor;
    temp->objecttype = obj->objecttype;
+   temp->moveontype = obj->moveontype;
    temp->amount = obj->amount;
    temp->temp_amount = obj->temp_amount;
    temp->translation = obj->translation;

--- a/clientd3d/object.c
+++ b/clientd3d/object.c
@@ -90,6 +90,7 @@ object_node *ObjectCopy(object_node *obj)
    temp->name_res = obj->name_res;
    temp->icon_res = obj->icon_res;
    temp->flags  = obj->flags;
+   temp->minimapflags  = obj->minimapflags;
    temp->amount = obj->amount;
    temp->temp_amount = obj->temp_amount;
    temp->translation = obj->translation;

--- a/clientd3d/object.c
+++ b/clientd3d/object.c
@@ -92,7 +92,7 @@ object_node *ObjectCopy(object_node *obj)
    temp->flags  = obj->flags;
    temp->minimapflags  = obj->minimapflags;
    temp->namecolor = obj->namecolor;
-   temp->playertype = obj->playertype;
+   temp->objecttype = obj->objecttype;
    temp->amount = obj->amount;
    temp->temp_amount = obj->temp_amount;
    temp->translation = obj->translation;

--- a/clientd3d/object.c
+++ b/clientd3d/object.c
@@ -90,7 +90,7 @@ object_node *ObjectCopy(object_node *obj)
    temp->name_res = obj->name_res;
    temp->icon_res = obj->icon_res;
    temp->flags  = obj->flags;
-   temp->drawingflags  = obj->drawingflags;
+   temp->drawingtype  = obj->drawingtype;
    temp->minimapflags  = obj->minimapflags;
    temp->namecolor = obj->namecolor;
    temp->objecttype = obj->objecttype;

--- a/clientd3d/object.c
+++ b/clientd3d/object.c
@@ -91,6 +91,8 @@ object_node *ObjectCopy(object_node *obj)
    temp->icon_res = obj->icon_res;
    temp->flags  = obj->flags;
    temp->minimapflags  = obj->minimapflags;
+   temp->namecolor = obj->namecolor;
+   temp->playertype = obj->playertype;
    temp->amount = obj->amount;
    temp->temp_amount = obj->temp_amount;
    temp->translation = obj->translation;

--- a/clientd3d/object.c
+++ b/clientd3d/object.c
@@ -90,6 +90,7 @@ object_node *ObjectCopy(object_node *obj)
    temp->name_res = obj->name_res;
    temp->icon_res = obj->icon_res;
    temp->flags  = obj->flags;
+   temp->drawingflags  = obj->drawingflags;
    temp->minimapflags  = obj->minimapflags;
    temp->namecolor = obj->namecolor;
    temp->objecttype = obj->objecttype;

--- a/clientd3d/object.h
+++ b/clientd3d/object.h
@@ -23,9 +23,6 @@ typedef DWORD ID;  /* Server id #s */
 #define GetObjTag(id) ( ((id) & 0xf0000000) >> 28)
 #define IsNumberObj(id) (GetObjTag(id) == CLIENT_TAG_NUMBER)
 
-// Object flag values and macros
-#define ObjectMoveonType(obj)    ((obj).moveontype)
-
 #define MAX_CHARNAME 30   // Maximum length of character name
 #define MAX_DESCRIPTION 1000  /* Maximum length of character description */
 

--- a/clientd3d/object.h
+++ b/clientd3d/object.h
@@ -81,7 +81,7 @@ typedef struct {
    int          flags;               /* Flags describing various properties of objects */
    int          minimapflags;        // Flags used to draw the right color/icon on the minimap.
    unsigned int namecolor;           // Player name color flags
-   BYTE         playertype;          // Enum of player type (i.e. outlaw, innocent)
+   object_type  objecttype;          /* Enum of object type (i.e. outlaw, murderer, NPC) */
    BYTE         translation;         // Palette translation information
    Animate      *animate;            /* Pointer to current animation (normal or motion animation) */
    list_type    *overlays;           /* Pointer to current overlays (normal or motion animation) */

--- a/clientd3d/object.h
+++ b/clientd3d/object.h
@@ -80,6 +80,8 @@ typedef struct {
    DWORD        temp_amount;         /* Scratch field used when user is selecting amount of object */
    int          flags;               /* Flags describing various properties of objects */
    int          minimapflags;        // Flags used to draw the right color/icon on the minimap.
+   unsigned int namecolor;           // Player name color flags
+   BYTE         playertype;          // Enum of player type (i.e. outlaw, innocent)
    BYTE         translation;         // Palette translation information
    Animate      *animate;            /* Pointer to current animation (normal or motion animation) */
    list_type    *overlays;           /* Pointer to current overlays (normal or motion animation) */

--- a/clientd3d/object.h
+++ b/clientd3d/object.h
@@ -79,7 +79,7 @@ typedef struct {
                                         this field gives amount of object */
    DWORD        temp_amount;         /* Scratch field used when user is selecting amount of object */
    int          flags;               // Boolean object flags.
-   BYTE         drawingflags;        // Object flags for drawing effects (invisibility, lighting type etc.)
+   BYTE         drawingtype;        // Object flags for drawing effects (invisibility, lighting type etc.)
    int          minimapflags;        // Flags used to draw the right color/icon on the minimap.
    unsigned int namecolor;           // Player name color flags
    object_type  objecttype;          /* Enum of object type (i.e. outlaw, murderer, NPC) */

--- a/clientd3d/object.h
+++ b/clientd3d/object.h
@@ -72,27 +72,28 @@ typedef struct
 } d_lighting;
 
 typedef struct {
-   ID        id;
-   ID        icon_res;
-   ID        name_res;
-   DWORD     amount;              /* If top bits of id signify CLIENT_TAG_NUMBER, then
-		                     this field gives amount of object */
-   DWORD     temp_amount;         /* Scratch field used when user is selecting amount of object */
-   int       flags;               /* Flags describing various properties of objects */
-   BYTE      translation;         // Palette translation information
-   Animate   *animate;            /* Pointer to current animation (normal or motion animation) */
-   list_type *overlays;           /* Pointer to current overlays (normal or motion animation) */
-   Animate   normal_animate;      /* Holds normal (non-motion) animation info */
-   list_type normal_overlays;     /* Bitmaps to be overlaid on this object when drawn */
-   BYTE      normal_translation;  // Palette translation when not moving
-   BYTE      secondtranslation;   // Overriding, additional second translation.
-   WORD	     bounceTime;
-   WORD	     phaseTime;
-   int	     boundingHeight;
-   int	     boundingWidth;
-   int	     lightAdjust;	  // For flicker and flash
-   BYTE	     effect;		  // Display effect
-   d_lighting	dLighting;			// new lighting flags for d3d client
+   ID           id;
+   ID           icon_res;
+   ID           name_res;
+   DWORD        amount;              /* If top bits of id signify CLIENT_TAG_NUMBER, then
+                                        this field gives amount of object */
+   DWORD        temp_amount;         /* Scratch field used when user is selecting amount of object */
+   int          flags;               /* Flags describing various properties of objects */
+   int          minimapflags;        // Flags used to draw the right color/icon on the minimap.
+   BYTE         translation;         // Palette translation information
+   Animate      *animate;            /* Pointer to current animation (normal or motion animation) */
+   list_type    *overlays;           /* Pointer to current overlays (normal or motion animation) */
+   Animate      normal_animate;      /* Holds normal (non-motion) animation info */
+   list_type    normal_overlays;     /* Bitmaps to be overlaid on this object when drawn */
+   BYTE         normal_translation;  // Palette translation when not moving
+   BYTE         secondtranslation;   // Overriding, additional second translation.
+   WORD         bounceTime;          //
+   WORD         phaseTime;           //
+   int          boundingHeight;      //
+   int          boundingWidth;       //
+   int          lightAdjust;         // For flicker and flash
+   BYTE         effect;              // Display effect
+   d_lighting   dLighting;           // new lighting flags for d3d client
 } object_node;
 
 typedef struct {

--- a/clientd3d/object.h
+++ b/clientd3d/object.h
@@ -24,7 +24,7 @@ typedef DWORD ID;  /* Server id #s */
 #define IsNumberObj(id) (GetObjTag(id) == CLIENT_TAG_NUMBER)
 
 // Object flag values and macros
-#define ObjectMoveonType(obj)    ((obj).flags & OF_NOMOVEON_MASK)
+#define ObjectMoveonType(obj)    ((obj).moveontype)
 
 #define MAX_CHARNAME 30   // Maximum length of character name
 #define MAX_DESCRIPTION 1000  /* Maximum length of character description */
@@ -82,6 +82,7 @@ typedef struct {
    int          minimapflags;        // Flags used to draw the right color/icon on the minimap.
    unsigned int namecolor;           // Player name color flags
    object_type  objecttype;          /* Enum of object type (i.e. outlaw, murderer, NPC) */
+   moveon_type moveontype;           // MoveOn type of the object
    BYTE         translation;         // Palette translation information
    Animate      *animate;            /* Pointer to current animation (normal or motion animation) */
    list_type    *overlays;           /* Pointer to current overlays (normal or motion animation) */

--- a/clientd3d/object.h
+++ b/clientd3d/object.h
@@ -78,11 +78,12 @@ typedef struct {
    DWORD        amount;              /* If top bits of id signify CLIENT_TAG_NUMBER, then
                                         this field gives amount of object */
    DWORD        temp_amount;         /* Scratch field used when user is selecting amount of object */
-   int          flags;               /* Flags describing various properties of objects */
+   int          flags;               // Boolean object flags.
+   BYTE         drawingflags;        // Object flags for drawing effects (invisibility, lighting type etc.)
    int          minimapflags;        // Flags used to draw the right color/icon on the minimap.
    unsigned int namecolor;           // Player name color flags
    object_type  objecttype;          /* Enum of object type (i.e. outlaw, murderer, NPC) */
-   moveon_type moveontype;           // MoveOn type of the object
+   moveon_type  moveontype;          // MoveOn type of the object
    BYTE         translation;         // Palette translation information
    Animate      *animate;            /* Pointer to current animation (normal or motion animation) */
    list_type    *overlays;           /* Pointer to current overlays (normal or motion animation) */

--- a/clientd3d/object3d.c
+++ b/clientd3d/object3d.c
@@ -879,7 +879,7 @@ void DrawObjectDecorations(DrawnObject *object)
    y = range->top_row - s.cy - 2;
 
    // Give a shadowed look to be visible on all color backgrounds
-   fg_color = GetPlayerNameColor(r->obj.flags,name);
+   fg_color = GetPlayerNameColor(&r->obj,name);
    bg_color = NAME_COLOR_NORMAL_BG;
 
    // Some names never grow darker, they use PALETTEINDEX().

--- a/clientd3d/object3d.c
+++ b/clientd3d/object3d.c
@@ -110,7 +110,7 @@ BOOL DrawObject3D(DrawnObject *object, ViewCone *clip)
 	dos.light  = object->light;
 	dos.draw   = object->draw;
 	dos.cone   = clip;
-	dos.drawingflags  = object->drawingflags;
+	dos.drawingtype  = object->drawingtype;
 	dos.translation = object->translation;
 	dos.secondtranslation = object->secondtranslation;
 
@@ -328,7 +328,7 @@ Bool DrawObjectBitmap( DrawObjectInfo *dos, AREA *obj_area, Bool bTargetSelectEf
    //palette = GetLightPalette(dos->distance, rand() % 60 + 1, FINENESS);
 
    d.palette = palette;
-   d.drawingflags = dos->drawingflags | (dos->effect);
+   d.drawingtype = dos->drawingtype | (dos->effect);
    d.translation = dos->translation;
    d.secondtranslation = dos->secondtranslation;
    rowTimesMAXX = starty * MAXX;
@@ -393,7 +393,7 @@ Bool DrawObjectBitmap( DrawObjectInfo *dos, AREA *obj_area, Bool bTargetSelectEf
 
 
       // Handle common case of no effects specially here
-      if (d.translation == 0 && d.drawingflags == 0)
+      if (d.translation == 0 && d.drawingtype == 0)
       {	 // Draw normally
 #if 1
 	 while (screen_ptr <= end_screen_ptr)
@@ -539,13 +539,13 @@ END_TRANS_BLIT:
 	 DrawingLoop loop;
 
 	 // Take effect from palette translation or object flags
-	 effect = d.drawingflags;
+	 effect = d.drawingtype;
 	 if (effect == 0)
 	    effect = DRAWFX_TRANSLATE;
 
 	 loop = drawing_loops[effect];
 	 if (loop == NULL)
-	    debug(("DrawObjectBitmap got unknown effect index %d\n", d.drawingflags));
+	    debug(("DrawObjectBitmap got unknown effect index %d\n", d.drawingtype));
 	 else
 	 {
 	    d.start_ptr = screen_ptr;
@@ -862,7 +862,7 @@ void DrawObjectDecorations(DrawnObject *object)
    if (r == NULL)
       return;
 
-   if (!(r->obj.flags & OF_PLAYER) || (r->obj.drawingflags == DRAWFX_INVISIBLE))
+   if (!(r->obj.flags & OF_PLAYER) || (r->obj.drawingtype == DRAWFX_INVISIBLE))
       return;
 
    // Draw player name

--- a/clientd3d/object3d.c
+++ b/clientd3d/object3d.c
@@ -334,7 +334,7 @@ Bool DrawObjectBitmap( DrawObjectInfo *dos, AREA *obj_area, Bool bTargetSelectEf
 
    d.palette = palette;
    d.flags  = dos->flags;
-   d.drawingtype = dos->drawingtype; // had | dos->effect here
+   d.drawingtype = dos->drawingtype | dos->effect;
    d.minimapflags  = dos->minimapflags;
    d.namecolor = dos->namecolor;
    d.objecttype = dos->objecttype;

--- a/clientd3d/object3d.c
+++ b/clientd3d/object3d.c
@@ -393,7 +393,7 @@ Bool DrawObjectBitmap( DrawObjectInfo *dos, AREA *obj_area, Bool bTargetSelectEf
 
 
       // Handle common case of no effects specially here
-      if (d.translation == 0 && GetDrawingEffect(d.drawingflags) == 0)
+      if (d.translation == 0 && d.drawingflags == 0)
       {	 // Draw normally
 #if 1
 	 while (screen_ptr <= end_screen_ptr)
@@ -539,13 +539,13 @@ END_TRANS_BLIT:
 	 DrawingLoop loop;
 
 	 // Take effect from palette translation or object flags
-	 effect = GetDrawingEffectIndex(d.drawingflags);
+	 effect = d.drawingflags;
 	 if (effect == 0)
-	    effect = GetDrawingEffectIndex(DRAWFX_TRANSLATE);
+	    effect = DRAWFX_TRANSLATE;
 
 	 loop = drawing_loops[effect];
 	 if (loop == NULL)
-	    debug(("DrawObjectBitmap got unknown effect index %d\n", GetDrawingEffectIndex(d.drawingflags)));
+	    debug(("DrawObjectBitmap got unknown effect index %d\n", d.drawingflags));
 	 else
 	 {
 	    d.start_ptr = screen_ptr;
@@ -862,7 +862,7 @@ void DrawObjectDecorations(DrawnObject *object)
    if (r == NULL)
       return;
 
-   if (!(r->obj.flags & OF_PLAYER) || (GetDrawingEffect(r->obj.drawingflags) == DRAWFX_INVISIBLE))
+   if (!(r->obj.flags & OF_PLAYER) || (r->obj.drawingflags == DRAWFX_INVISIBLE))
       return;
 
    // Draw player name

--- a/clientd3d/object3d.c
+++ b/clientd3d/object3d.c
@@ -333,7 +333,12 @@ Bool DrawObjectBitmap( DrawObjectInfo *dos, AREA *obj_area, Bool bTargetSelectEf
    //palette = GetLightPalette(dos->distance, rand() % 60 + 1, FINENESS);
 
    d.palette = palette;
-   d.drawingtype = dos->drawingtype | (dos->effect);
+   d.flags  = dos->flags;
+   d.drawingtype = dos->drawingtype; // had | dos->effect here
+   d.minimapflags  = dos->minimapflags;
+   d.namecolor = dos->namecolor;
+   d.objecttype = dos->objecttype;
+   d.moveontype = dos->moveontype;
    d.translation = dos->translation;
    d.secondtranslation = dos->secondtranslation;
    rowTimesMAXX = starty * MAXX;

--- a/clientd3d/object3d.c
+++ b/clientd3d/object3d.c
@@ -110,7 +110,7 @@ BOOL DrawObject3D(DrawnObject *object, ViewCone *clip)
 	dos.light  = object->light;
 	dos.draw   = object->draw;
 	dos.cone   = clip;
-	dos.flags  = object->flags;
+	dos.drawingflags  = object->drawingflags;
 	dos.translation = object->translation;
 	dos.secondtranslation = object->secondtranslation;
 
@@ -255,7 +255,7 @@ Bool DrawObjectBitmap( DrawObjectInfo *dos, AREA *obj_area, Bool bTargetSelectEf
    long col, row, rowTimesMAXX;
    long lefttop,righttop,leftbot,rightbot;
    ViewCone *c;
-   int effect;
+   BYTE effect;
    ObjectRowData d;
 
 //	Bool	bClipHaloLeft;
@@ -328,7 +328,7 @@ Bool DrawObjectBitmap( DrawObjectInfo *dos, AREA *obj_area, Bool bTargetSelectEf
    //palette = GetLightPalette(dos->distance, rand() % 60 + 1, FINENESS);
 
    d.palette = palette;
-   d.flags = dos->flags | (dos->effect << 20);
+   d.drawingflags = dos->drawingflags | (dos->effect);
    d.translation = dos->translation;
    d.secondtranslation = dos->secondtranslation;
    rowTimesMAXX = starty * MAXX;
@@ -393,7 +393,7 @@ Bool DrawObjectBitmap( DrawObjectInfo *dos, AREA *obj_area, Bool bTargetSelectEf
 
 
       // Handle common case of no effects specially here
-      if (d.translation == 0 && GetDrawingEffect(d.flags) == 0)
+      if (d.translation == 0 && GetDrawingEffect(d.drawingflags) == 0)
       {	 // Draw normally
 #if 1
 	 while (screen_ptr <= end_screen_ptr)
@@ -539,13 +539,13 @@ END_TRANS_BLIT:
 	 DrawingLoop loop;
 
 	 // Take effect from palette translation or object flags
-	 effect = GetDrawingEffectIndex(d.flags);
+	 effect = GetDrawingEffectIndex(d.drawingflags);
 	 if (effect == 0)
-	    effect = GetDrawingEffectIndex(OF_TRANSLATE);
+	    effect = GetDrawingEffectIndex(DRAWFX_TRANSLATE);
 
 	 loop = drawing_loops[effect];
 	 if (loop == NULL)
-	    debug(("DrawObjectBitmap got unknown effect index %d\n", GetDrawingEffectIndex(d.flags)));
+	    debug(("DrawObjectBitmap got unknown effect index %d\n", GetDrawingEffectIndex(d.drawingflags)));
 	 else
 	 {
 	    d.start_ptr = screen_ptr;
@@ -862,7 +862,7 @@ void DrawObjectDecorations(DrawnObject *object)
    if (r == NULL)
       return;
 
-   if (!(r->obj.flags & OF_PLAYER) || (GetDrawingEffect(r->obj.flags) == OF_INVISIBLE))
+   if (!(r->obj.flags & OF_PLAYER) || (GetDrawingEffect(r->obj.drawingflags) == DRAWFX_INVISIBLE))
       return;
 
    // Draw player name

--- a/clientd3d/object3d.c
+++ b/clientd3d/object3d.c
@@ -110,7 +110,12 @@ BOOL DrawObject3D(DrawnObject *object, ViewCone *clip)
 	dos.light  = object->light;
 	dos.draw   = object->draw;
 	dos.cone   = clip;
+	dos.flags = object->flags;
 	dos.drawingtype  = object->drawingtype;
+	dos.minimapflags  = object->minimapflags;
+	dos.namecolor = object->namecolor;
+	dos.objecttype = object->objecttype;
+	dos.moveontype = object->moveontype;
 	dos.translation = object->translation;
 	dos.secondtranslation = object->secondtranslation;
 

--- a/clientd3d/object3d.h
+++ b/clientd3d/object3d.h
@@ -47,7 +47,7 @@ typedef struct {
    int       flags;             // Object flags for special options (invisibility, etc.)
    int       minimapflags;      // Flag field for minimap dot drawing
    unsigned int namecolor;      /* Player name color flags */
-   BYTE         playertype;     /* Enum of player type (i.e. outlaw, innocent) */
+   object_type objecttype;      /* Enum of object type (i.e. outlaw, murderer, NPC) */
    int       cutoff;            // Last screen row in which to draw object (to cut off at ground level)
    BYTE      translation;       // Color translation type, 0 = none
    BYTE      secondtranslation; // Overriding second translation for all overlays.

--- a/clientd3d/object3d.h
+++ b/clientd3d/object3d.h
@@ -45,7 +45,7 @@ typedef struct {
    Bool         draw;              // True if object should actually be drawn (False = just compute location)
    ViewCone     *cone;             // Cone in which to draw object
    int          flags;             // Boolean object flags.
-   BYTE         drawingflags;      // Object flags for drawing effects (invisibility, lighting type etc.)
+   BYTE         drawingtype;      // Object flags for drawing effects (invisibility, lighting type etc.)
    int          minimapflags;      // Flag field for minimap dot drawing
    unsigned int namecolor;         /* Player name color flags */
    object_type  objecttype;        /* Enum of object type (i.e. outlaw, murderer, NPC) */

--- a/clientd3d/object3d.h
+++ b/clientd3d/object3d.h
@@ -48,6 +48,7 @@ typedef struct {
    int       minimapflags;      // Flag field for minimap dot drawing
    unsigned int namecolor;      /* Player name color flags */
    object_type objecttype;      /* Enum of object type (i.e. outlaw, murderer, NPC) */
+   moveon_type moveontype;      // MoveOn type of the object
    int       cutoff;            // Last screen row in which to draw object (to cut off at ground level)
    BYTE      translation;       // Color translation type, 0 = none
    BYTE      secondtranslation; // Overriding second translation for all overlays.

--- a/clientd3d/object3d.h
+++ b/clientd3d/object3d.h
@@ -39,21 +39,22 @@ typedef struct {
 
 // Options to DrawObjectBitmap
 typedef struct {
-   PDIB      pdib;              // Object bitmap
-   int       distance;          // Distance to object in FINENESS units
-   BYTE      light;             // Light level to draw object
-   Bool      draw;              // True if object should actually be drawn (False = just compute location)
-   ViewCone *cone;              // Cone in which to draw object
-   int       flags;             // Object flags for special options (invisibility, etc.)
-   int       minimapflags;      // Flag field for minimap dot drawing
-   unsigned int namecolor;      /* Player name color flags */
-   object_type objecttype;      /* Enum of object type (i.e. outlaw, murderer, NPC) */
-   moveon_type moveontype;      // MoveOn type of the object
-   int       cutoff;            // Last screen row in which to draw object (to cut off at ground level)
-   BYTE      translation;       // Color translation type, 0 = none
-   BYTE      secondtranslation; // Overriding second translation for all overlays.
-   BYTE      effect;
-   room_contents_node *obj;     // Pointer to room_contents_node for object
+   PDIB         pdib;              // Object bitmap
+   int          distance;          // Distance to object in FINENESS units
+   BYTE         light;             // Light level to draw object
+   Bool         draw;              // True if object should actually be drawn (False = just compute location)
+   ViewCone     *cone;             // Cone in which to draw object
+   int          flags;             // Boolean object flags.
+   BYTE         drawingflags;      // Object flags for drawing effects (invisibility, lighting type etc.)
+   int          minimapflags;      // Flag field for minimap dot drawing
+   unsigned int namecolor;         /* Player name color flags */
+   object_type  objecttype;        /* Enum of object type (i.e. outlaw, murderer, NPC) */
+   moveon_type  moveontype;        // MoveOn type of the object
+   int          cutoff;            // Last screen row in which to draw object (to cut off at ground level)
+   BYTE         translation;       // Color translation type, 0 = none
+   BYTE         secondtranslation; // Overriding second translation for all overlays.
+   BYTE         effect;
+   room_contents_node *obj;         // Pointer to room_contents_node for object
 } DrawObjectInfo;
 
 #define NAME_COLOR_NORMAL_BG   PALETTERGB(0, 0, 0)

--- a/clientd3d/object3d.h
+++ b/clientd3d/object3d.h
@@ -39,18 +39,20 @@ typedef struct {
 
 // Options to DrawObjectBitmap
 typedef struct {
-   PDIB      pdib;       // Object bitmap
-   int       distance;   // Distance to object in FINENESS units
-   BYTE      light;      // Light level to draw object
-   Bool      draw;       // True if object should actually be drawn (False = just compute location)
-   ViewCone *cone;       // Cone in which to draw object
-   int       flags;      // Object flags for special options (invisibility, etc.)
-   int       minimapflags;      // Object flags for special options (invisibility, etc.)
-   int       cutoff;     // Last screen row in which to draw object (to cut off at ground level)
-   BYTE      translation;// Color translation type, 0 = none
+   PDIB      pdib;              // Object bitmap
+   int       distance;          // Distance to object in FINENESS units
+   BYTE      light;             // Light level to draw object
+   Bool      draw;              // True if object should actually be drawn (False = just compute location)
+   ViewCone *cone;              // Cone in which to draw object
+   int       flags;             // Object flags for special options (invisibility, etc.)
+   int       minimapflags;      // Flag field for minimap dot drawing
+   unsigned int namecolor;      /* Player name color flags */
+   BYTE         playertype;     /* Enum of player type (i.e. outlaw, innocent) */
+   int       cutoff;            // Last screen row in which to draw object (to cut off at ground level)
+   BYTE      translation;       // Color translation type, 0 = none
    BYTE      secondtranslation; // Overriding second translation for all overlays.
-   BYTE	     effect;
-   room_contents_node *obj;    // Pointer to room_contents_node for object
+   BYTE      effect;
+   room_contents_node *obj;     // Pointer to room_contents_node for object
 } DrawObjectInfo;
 
 #define NAME_COLOR_NORMAL_BG   PALETTERGB(0, 0, 0)

--- a/clientd3d/object3d.h
+++ b/clientd3d/object3d.h
@@ -45,6 +45,7 @@ typedef struct {
    Bool      draw;       // True if object should actually be drawn (False = just compute location)
    ViewCone *cone;       // Cone in which to draw object
    int       flags;      // Object flags for special options (invisibility, etc.)
+   int       minimapflags;      // Object flags for special options (invisibility, etc.)
    int       cutoff;     // Last screen row in which to draw object (to cut off at ground level)
    BYTE      translation;// Color translation type, 0 = none
    BYTE      secondtranslation; // Overriding second translation for all overlays.

--- a/clientd3d/overlay.c
+++ b/clientd3d/overlay.c
@@ -209,7 +209,7 @@ void DrawPlayerOverlayBitmap(PDIB pdib, AREA *obj_area, BYTE translation,
    dos.minimapflags  = 0;
    dos.namecolor = 0;
    dos.objecttype = OT_NONE;
-   dos.moveontype = OF_MOVEON_YES;
+   dos.moveontype = MOVEON_YES;
    dos.cone     = &c;
    dos.distance = 1;
    dos.cutoff   = MAXY;

--- a/clientd3d/overlay.c
+++ b/clientd3d/overlay.c
@@ -18,9 +18,9 @@ extern player_info player;
 
 /* local function prototypes */
 Bool ComputePlayerOverlayArea(PDIB pdib, char hotspot, AREA *obj_area);
-static void DrawPlayerOverlayBitmap(PDIB pdib, AREA *obj_area, BYTE translation, BYTE secondtranslation, int flags);
+static void DrawPlayerOverlayBitmap(PDIB pdib, AREA *obj_area, BYTE translation, BYTE secondtranslation, int flags, BYTE drawingtype);
 static void DrawPlayerOverlayOverlays(PDIB pdib_obj, AREA *obj_area, list_type overlays,
-			       Bool underlays, BYTE secondtranslation, int flags);
+			       Bool underlays, BYTE secondtranslation, int flags, BYTE drawingtype);
 /************************************************************************/
 void SetPlayerOverlay(char hotspot, object_node *poverlay)
 {
@@ -80,12 +80,20 @@ void DrawPlayerOverlays(void)
    list_type overlays;
    room_contents_node *r;
    int flags;
+   BYTE drawingtype;
 
    // Get player's object flags for special drawing effects
    r = GetRoomObjectById(player.id);
    if (r == NULL)
+   {
       flags = 0;
-   else flags = r->obj.flags;
+      drawingtype = 0;
+   }
+   else
+   {
+      flags = r->obj.flags;
+      drawingtype = r->obj.drawingtype;
+   }
    
    for (i=0; i < NUM_PLAYER_OVERLAYS; i++)
    {
@@ -105,13 +113,13 @@ void DrawPlayerOverlays(void)
       // Draw underlays
       overlays = *(obj->overlays);
       if (overlays != NULL)
-	 DrawPlayerOverlayOverlays(pdib, &obj_area, overlays, True, obj->secondtranslation, flags | (obj->effect << 20));
+	 DrawPlayerOverlayOverlays(pdib, &obj_area, overlays, True, obj->secondtranslation, flags, drawingtype | obj->effect);
 
-      DrawPlayerOverlayBitmap(pdib, &obj_area, obj->translation, obj->secondtranslation, flags | (obj->effect << 20));
+      DrawPlayerOverlayBitmap(pdib, &obj_area, obj->translation, obj->secondtranslation, flags, drawingtype | obj->effect);
 
       // Draw overlays
       if (overlays != NULL)
-	 DrawPlayerOverlayOverlays(pdib, &obj_area, overlays, False, obj->secondtranslation, flags | (obj->effect << 20));
+	 DrawPlayerOverlayOverlays(pdib, &obj_area, overlays, False, obj->secondtranslation, flags, drawingtype | obj->effect);
    }
 }
 /************************************************************************/
@@ -123,7 +131,7 @@ void DrawPlayerOverlays(void)
  *   flags gives the object flags for special drawing effects.
  */
 void DrawPlayerOverlayOverlays(PDIB pdib_obj, AREA *obj_area, list_type overlays, Bool underlays,
-			       BYTE secondtranslation, int flags)
+			       BYTE secondtranslation, int flags, BYTE drawingtype)
 {
    list_type l;
    AREA overlay_area;
@@ -164,7 +172,7 @@ void DrawPlayerOverlayOverlays(PDIB pdib_obj, AREA *obj_area, list_type overlays
 	 // Scale offset, and place on base bitmap
 	 overlay_area.x = overlay_area.x / OVERLAY_FACTOR + obj_area->x;
 	 overlay_area.y = overlay_area.y / OVERLAY_FACTOR + obj_area->y;
-	 DrawPlayerOverlayBitmap(pdib_ov, &overlay_area, overlay->translation, secondtranslation, flags | (overlay->effect << 20));
+	 DrawPlayerOverlayBitmap(pdib_ov, &overlay_area, overlay->translation, secondtranslation, flags, drawingtype | overlay->effect);
       }
    }
 }
@@ -175,7 +183,8 @@ void DrawPlayerOverlayOverlays(PDIB pdib_obj, AREA *obj_area, list_type overlays
  *   translation gives the palette translation type.
  *   flags gives the object flags for special drawing effects.
  */
-void DrawPlayerOverlayBitmap(PDIB pdib, AREA *obj_area, BYTE translation, BYTE secondtranslation, int flags)
+void DrawPlayerOverlayBitmap(PDIB pdib, AREA *obj_area, BYTE translation,
+                           BYTE secondtranslation, int flags, BYTE drawingtype)
 {
    room_contents_node *pPlayer;
    DrawObjectInfo dos;
@@ -196,6 +205,11 @@ void DrawPlayerOverlayBitmap(PDIB pdib, AREA *obj_area, BYTE translation, BYTE s
    dos.light    = KOD_LIGHT_LEVELS - 1;
    dos.draw     = True;
    dos.flags    = flags;
+   dos.drawingtype  = drawingtype;
+   dos.minimapflags  = 0;
+   dos.namecolor = 0;
+   dos.objecttype = OT_NONE;
+   dos.moveontype = OF_MOVEON_YES;
    dos.cone     = &c;
    dos.distance = 1;
    dos.cutoff   = MAXY;

--- a/clientd3d/ownerdrw.c
+++ b/clientd3d/ownerdrw.c
@@ -437,7 +437,7 @@ void DrawOwnerListItem(const DRAWITEMSTRUCT *lpdis, Bool selected, Bool combo)
    if (style & OD_COLORTEXT)
    {
    	// get the color we'd prefer for this particular obj
-   	crColorText = GetPlayerWhoNameColor(obj->flags,NULL);
+   	crColorText = GetPlayerWhoNameColor(obj,NULL);
    	
 	// draw a black halo around the text just to ensure it is visible
 	SetTextColor(lpdis->hDC, RGB(0, 0, 0));

--- a/clientd3d/select.c
+++ b/clientd3d/select.c
@@ -43,7 +43,7 @@ void UserSelect(ID target)
       SetFocus(hMain);
       
       /* See if user clicked on an object--even if not, go back to normal mode */
-      square_list = GetObjects3D(x, y, 0, 0, OF_NOEXAMINE);
+      square_list = GetObjects3D(x, y, 0, 0, OF_NOEXAMINE, 0, 0);
       
       GameSetState(GAME_PLAY);
       

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -328,7 +328,8 @@ void ExtractObject(char **ptr, object_node *item)
       item->amount = 0;
    Extract(ptr, &item->icon_res, SIZE_ID);
    Extract(ptr, &item->name_res, SIZE_ID);
-   Extract(ptr, &item->flags, 4); // includes drawfx_mask bits
+   Extract(ptr, &item->flags, 4);
+   Extract(ptr, &item->drawingflags, 1);
    Extract(ptr, &item->minimapflags, 4);
    Extract(ptr, &item->namecolor, 4);
 
@@ -371,7 +372,8 @@ void ExtractObjectNoLight(char **ptr, object_node *item)
       item->amount = 0;
    Extract(ptr, &item->icon_res, SIZE_ID);
    Extract(ptr, &item->name_res, SIZE_ID);
-   Extract(ptr, &item->flags, 4); // includes drawfx_mask bits
+   Extract(ptr, &item->flags, 4);
+   Extract(ptr, &item->drawingflags, 1);
    Extract(ptr, &item->minimapflags, 4);
    Extract(ptr, &item->namecolor, 4);
 
@@ -1162,9 +1164,12 @@ Bool HandlePlayers(char *ptr,long len)
       ChangeResource(obj->name_res, name);
 
       Extract(&ptr, &obj->flags, SIZE_VALUE);
+      len -= SIZE_VALUE;
+      Extract(&ptr, &obj->drawingflags, SIZE_TYPE);
+      len -= SIZE_TYPE;
       Extract(&ptr, &obj->minimapflags, SIZE_VALUE);
       Extract(&ptr, &obj->namecolor, SIZE_VALUE);
-      len -= 3 * SIZE_VALUE;
+      len -= 2 * SIZE_VALUE;
 
       BYTE temptype = 0;
       Extract(&ptr, &temptype, SIZE_TYPE);
@@ -1203,9 +1208,12 @@ Bool HandleAddPlayer(char *ptr,long len)
    ChangeResource(obj->name_res, name);
 
    Extract(&ptr, &obj->flags, SIZE_VALUE);
+   len -= SIZE_VALUE;
+   Extract(&ptr, &obj->drawingflags, SIZE_TYPE);
+   len -= SIZE_TYPE;
    Extract(&ptr, &obj->minimapflags, SIZE_VALUE);
    Extract(&ptr, &obj->namecolor, SIZE_VALUE);
-   len -= 3 * SIZE_VALUE;
+   len -= 2 * SIZE_VALUE;
 
    BYTE temptype = 0;
    Extract(&ptr, &temptype, SIZE_TYPE);

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -329,7 +329,7 @@ void ExtractObject(char **ptr, object_node *item)
    Extract(ptr, &item->icon_res, SIZE_ID);
    Extract(ptr, &item->name_res, SIZE_ID);
    Extract(ptr, &item->flags, 4);
-   Extract(ptr, &item->drawingflags, 1);
+   Extract(ptr, &item->drawingtype, 1);
    Extract(ptr, &item->minimapflags, 4);
    Extract(ptr, &item->namecolor, 4);
 
@@ -373,7 +373,7 @@ void ExtractObjectNoLight(char **ptr, object_node *item)
    Extract(ptr, &item->icon_res, SIZE_ID);
    Extract(ptr, &item->name_res, SIZE_ID);
    Extract(ptr, &item->flags, 4);
-   Extract(ptr, &item->drawingflags, 1);
+   Extract(ptr, &item->drawingtype, 1);
    Extract(ptr, &item->minimapflags, 4);
    Extract(ptr, &item->namecolor, 4);
 
@@ -1165,7 +1165,7 @@ Bool HandlePlayers(char *ptr,long len)
 
       Extract(&ptr, &obj->flags, SIZE_VALUE);
       len -= SIZE_VALUE;
-      Extract(&ptr, &obj->drawingflags, SIZE_TYPE);
+      Extract(&ptr, &obj->drawingtype, SIZE_TYPE);
       len -= SIZE_TYPE;
       Extract(&ptr, &obj->minimapflags, SIZE_VALUE);
       Extract(&ptr, &obj->namecolor, SIZE_VALUE);
@@ -1209,7 +1209,7 @@ Bool HandleAddPlayer(char *ptr,long len)
 
    Extract(&ptr, &obj->flags, SIZE_VALUE);
    len -= SIZE_VALUE;
-   Extract(&ptr, &obj->drawingflags, SIZE_TYPE);
+   Extract(&ptr, &obj->drawingtype, SIZE_TYPE);
    len -= SIZE_TYPE;
    Extract(&ptr, &obj->minimapflags, SIZE_VALUE);
    Extract(&ptr, &obj->namecolor, SIZE_VALUE);

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -336,6 +336,10 @@ void ExtractObject(char **ptr, object_node *item)
    Extract(ptr, &temptype, 1);
    item->objecttype = (object_type)temptype;
 
+   BYTE tempmovetype = 0;
+   Extract(ptr, &tempmovetype, 1);
+   item->moveontype = (moveon_type)tempmovetype;
+
    ExtractDLighting(ptr, &item->dLighting);
 
    ExtractPaletteTranslation(ptr,&item->translation,&item->effect);
@@ -374,6 +378,10 @@ void ExtractObjectNoLight(char **ptr, object_node *item)
    BYTE temptype = 0;
    Extract(ptr, &temptype, 1);
    item->objecttype = (object_type)temptype;
+
+   BYTE tempmovetype = 0;
+   Extract(ptr, &tempmovetype, 1);
+   item->moveontype = (moveon_type)tempmovetype;
 
    ExtractPaletteTranslation(ptr,&item->translation,&item->effect);
    item->normal_translation = item->translation;
@@ -1161,7 +1169,11 @@ Bool HandlePlayers(char *ptr,long len)
       BYTE temptype = 0;
       Extract(&ptr, &temptype, SIZE_TYPE);
       obj->objecttype = (object_type)temptype;
-      len -= SIZE_TYPE;
+
+      BYTE movetemptype = 0;
+      Extract(&ptr, &movetemptype, SIZE_TYPE);
+      obj->moveontype = (moveon_type)movetemptype;
+      len -= 2 * SIZE_TYPE;
 
       list = list_add_item(list, obj);
    }
@@ -1181,7 +1193,6 @@ Bool HandleAddPlayer(char *ptr,long len)
    object_node *obj;
    char *start = ptr;
    char name[MAXNAME + 1];
-   BYTE temptype = 0;
 
    obj = ObjectGetBlank();
    Extract(&ptr, &obj->id, SIZE_ID);
@@ -1196,9 +1207,14 @@ Bool HandleAddPlayer(char *ptr,long len)
    Extract(&ptr, &obj->namecolor, SIZE_VALUE);
    len -= 3 * SIZE_VALUE;
 
+   BYTE temptype = 0;
    Extract(&ptr, &temptype, SIZE_TYPE);
    obj->objecttype = (object_type)temptype;
-   len -= SIZE_TYPE;
+
+   BYTE movetemptype = 0;
+   Extract(&ptr, &movetemptype, SIZE_TYPE);
+   obj->moveontype = (moveon_type)movetemptype;
+   len -= 2 * SIZE_TYPE;
 
    if (len != 0)
    {

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -320,7 +320,7 @@ void ExtractDLighting(char **ptr, d_lighting *dLighting)
  *   ptr appropriately.  Place data in given object node.
  */
 void ExtractObject(char **ptr, object_node *item)
-{  
+{
    Extract(ptr, &item->id, SIZE_ID);
    if (IsNumberObj(item->id))
       Extract(ptr, &item->amount, SIZE_AMOUNT);
@@ -330,6 +330,8 @@ void ExtractObject(char **ptr, object_node *item)
    Extract(ptr, &item->name_res, SIZE_ID);
    Extract(ptr, &item->flags, 4); // includes drawfx_mask bits
    Extract(ptr, &item->minimapflags, 4);
+   Extract(ptr, &item->namecolor, 4);
+   Extract(ptr, &item->playertype, 1);
 
    ExtractDLighting(ptr, &item->dLighting);
 
@@ -1143,7 +1145,11 @@ Bool HandlePlayers(char *ptr,long len)
       ChangeResource(obj->name_res, name);
 
       Extract(&ptr, &obj->flags, SIZE_VALUE);
-      len -= SIZE_VALUE;
+      Extract(&ptr, &obj->namecolor, SIZE_VALUE);
+      len -= 2 * SIZE_VALUE;
+
+      Extract(&ptr, &obj->playertype, SIZE_TYPE);
+      len -= SIZE_TYPE;
 
       list = list_add_item(list, obj);
    }
@@ -1173,7 +1179,11 @@ Bool HandleAddPlayer(char *ptr,long len)
    ChangeResource(obj->name_res, name);
 
    Extract(&ptr, &obj->flags, SIZE_VALUE);
-   len -= SIZE_VALUE;
+   Extract(&ptr, &obj->namecolor, SIZE_VALUE);
+   len -= 2 * SIZE_VALUE;
+
+   Extract(&ptr, &obj->playertype, SIZE_TYPE);
+   len -= SIZE_TYPE;
 
    if (len != 0)
    {

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -331,7 +331,10 @@ void ExtractObject(char **ptr, object_node *item)
    Extract(ptr, &item->flags, 4); // includes drawfx_mask bits
    Extract(ptr, &item->minimapflags, 4);
    Extract(ptr, &item->namecolor, 4);
-   Extract(ptr, &item->playertype, 1);
+
+   BYTE temptype = 0;
+   Extract(ptr, &temptype, 1);
+   item->objecttype = (object_type)temptype;
 
    ExtractDLighting(ptr, &item->dLighting);
 
@@ -365,6 +368,12 @@ void ExtractObjectNoLight(char **ptr, object_node *item)
    Extract(ptr, &item->icon_res, SIZE_ID);
    Extract(ptr, &item->name_res, SIZE_ID);
    Extract(ptr, &item->flags, 4); // includes drawfx_mask bits
+   Extract(ptr, &item->minimapflags, 4);
+   Extract(ptr, &item->namecolor, 4);
+
+   BYTE temptype = 0;
+   Extract(ptr, &temptype, 1);
+   item->objecttype = (object_type)temptype;
 
    ExtractPaletteTranslation(ptr,&item->translation,&item->effect);
    item->normal_translation = item->translation;
@@ -1145,10 +1154,13 @@ Bool HandlePlayers(char *ptr,long len)
       ChangeResource(obj->name_res, name);
 
       Extract(&ptr, &obj->flags, SIZE_VALUE);
+      Extract(&ptr, &obj->minimapflags, SIZE_VALUE);
       Extract(&ptr, &obj->namecolor, SIZE_VALUE);
-      len -= 2 * SIZE_VALUE;
+      len -= 3 * SIZE_VALUE;
 
-      Extract(&ptr, &obj->playertype, SIZE_TYPE);
+      BYTE temptype = 0;
+      Extract(&ptr, &temptype, SIZE_TYPE);
+      obj->objecttype = (object_type)temptype;
       len -= SIZE_TYPE;
 
       list = list_add_item(list, obj);
@@ -1169,6 +1181,7 @@ Bool HandleAddPlayer(char *ptr,long len)
    object_node *obj;
    char *start = ptr;
    char name[MAXNAME + 1];
+   BYTE temptype = 0;
 
    obj = ObjectGetBlank();
    Extract(&ptr, &obj->id, SIZE_ID);
@@ -1179,10 +1192,12 @@ Bool HandleAddPlayer(char *ptr,long len)
    ChangeResource(obj->name_res, name);
 
    Extract(&ptr, &obj->flags, SIZE_VALUE);
+   Extract(&ptr, &obj->minimapflags, SIZE_VALUE);
    Extract(&ptr, &obj->namecolor, SIZE_VALUE);
-   len -= 2 * SIZE_VALUE;
+   len -= 3 * SIZE_VALUE;
 
-   Extract(&ptr, &obj->playertype, SIZE_TYPE);
+   Extract(&ptr, &temptype, SIZE_TYPE);
+   obj->objecttype = (object_type)temptype;
    len -= SIZE_TYPE;
 
    if (len != 0)

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -337,9 +337,8 @@ void ExtractObject(char **ptr, object_node *item)
    Extract(ptr, &temptype, 1);
    item->objecttype = (object_type)temptype;
 
-   BYTE tempmovetype = 0;
-   Extract(ptr, &tempmovetype, 1);
-   item->moveontype = (moveon_type)tempmovetype;
+   Extract(ptr, &temptype, 1);
+   item->moveontype = (moveon_type)temptype;
 
    ExtractDLighting(ptr, &item->dLighting);
 
@@ -381,9 +380,8 @@ void ExtractObjectNoLight(char **ptr, object_node *item)
    Extract(ptr, &temptype, 1);
    item->objecttype = (object_type)temptype;
 
-   BYTE tempmovetype = 0;
-   Extract(ptr, &tempmovetype, 1);
-   item->moveontype = (moveon_type)tempmovetype;
+   Extract(ptr, &temptype, 1);
+   item->moveontype = (moveon_type)temptype;
 
    ExtractPaletteTranslation(ptr,&item->translation,&item->effect);
    item->normal_translation = item->translation;
@@ -1175,9 +1173,8 @@ Bool HandlePlayers(char *ptr,long len)
       Extract(&ptr, &temptype, SIZE_TYPE);
       obj->objecttype = (object_type)temptype;
 
-      BYTE movetemptype = 0;
-      Extract(&ptr, &movetemptype, SIZE_TYPE);
-      obj->moveontype = (moveon_type)movetemptype;
+      Extract(&ptr, &temptype, SIZE_TYPE);
+      obj->moveontype = (moveon_type)temptype;
       len -= 2 * SIZE_TYPE;
 
       list = list_add_item(list, obj);
@@ -1219,9 +1216,8 @@ Bool HandleAddPlayer(char *ptr,long len)
    Extract(&ptr, &temptype, SIZE_TYPE);
    obj->objecttype = (object_type)temptype;
 
-   BYTE movetemptype = 0;
-   Extract(&ptr, &movetemptype, SIZE_TYPE);
-   obj->moveontype = (moveon_type)movetemptype;
+   Extract(&ptr, &temptype, SIZE_TYPE);
+   obj->moveontype = (moveon_type)temptype;
    len -= 2 * SIZE_TYPE;
 
    if (len != 0)

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -329,6 +329,7 @@ void ExtractObject(char **ptr, object_node *item)
    Extract(ptr, &item->icon_res, SIZE_ID);
    Extract(ptr, &item->name_res, SIZE_ID);
    Extract(ptr, &item->flags, 4); // includes drawfx_mask bits
+   Extract(ptr, &item->minimapflags, 4);
 
    ExtractDLighting(ptr, &item->dLighting);
 
@@ -1170,7 +1171,7 @@ Bool HandleAddPlayer(char *ptr,long len)
 
    len = ExtractString(&ptr, len, name, MAXNAME);
    ChangeResource(obj->name_res, name);
-   
+
    Extract(&ptr, &obj->flags, SIZE_VALUE);
    len -= SIZE_VALUE;
 

--- a/include/proto.h
+++ b/include/proto.h
@@ -385,6 +385,7 @@ enum {
    DRAWFX_DITHERTRANS   = 0x08,    // Dither (with two translates) 50% of pixels
    DRAWFX_DOUBLETRANS   = 0x09,    // Translate twice each pixel, plus lighting
    DRAWFX_SECONDTRANS   = 0x0A,    // Ignore per-overlay xlat and use only secondary xlat
+   DRAWFX_DITHERGREY    = 0x0B,    // Haze (dither with transparency) 50% of pixels, greyscale other 50%
 };
 
 // Minimap dot color bitfield. Now separate from object flags.

--- a/include/proto.h
+++ b/include/proto.h
@@ -366,16 +366,6 @@ enum {
 #define OF_APPLYABLE     0x00001000    // Set if object can be applied to another object
 #define OF_SAFETY        0x00002000    // Set if player has safety on (self only)
 
-// Player name colors
-#define PF_KILLER        0x00004000    // Set if object is a killer (must also have OF_PLAYER)
-#define PF_OUTLAW        0x00008000    // Set if object is an outlaw (must also have OF_PLAYER)
-#define PF_DM            0x0000C000    // Set if object is a DM player
-#define PF_CREATOR       0x00010000    // Set if object is a creator player
-#define PF_SUPER         0x00014000    // Set if object is a "super DM"
-#define PF_MODERATOR     0x00018000    // Set if object is a "moderator"
-#define PF_EVENTCHAR     0x0001C000    // Set if object is an event character
-#define OF_PLAYER_MASK   0x0001C000    // Mask to get player flag bits
-
 #define OF_FLICKERING    0x00020000    // For players or objects if holding a flickering light.
 #define OF_FLASHING      0x00040000    // For players or objects if flashing with light.
 #define OF_BOUNCING      0x00060000    // If both flags on then object is bouncing
@@ -396,6 +386,10 @@ enum {
 #define OF_EFFECT_MASK   0x00F00000    // Mask to get object drawing effect bits
 #define NUM_DRAW_EFFECTS 16            // # of possible object drawing effects
 
+#define GetDrawingEffect(flags) ((flags) & OF_EFFECT_MASK)
+#define GetDrawingEffectIndex(flags) (((flags) & OF_EFFECT_MASK) >> 20)
+#define GetItemFlags(flags)   ((flags))
+
 // Minimap dot color bitfield. Now separate from object flags.
 #define MM_NONE          0x00000000    // No dot (default for all objects)
 #define MM_PLAYER        0x00000001    // Standard blue player dot
@@ -408,17 +402,36 @@ enum {
 #define MM_MINION_OTHER  0x00000080    // Set if monster is other's minion
 #define MM_MINION_SELF   0x00000100    // Set if a monster is our minion
 
-#define GetPlayerFlags(flags)   ((flags) & OF_PLAYER_MASK)
-#define GetDrawingEffect(flags) ((flags) & OF_EFFECT_MASK)
-#define GetDrawingEffectIndex(flags) (((flags) & OF_EFFECT_MASK) >> 20)
-#define GetItemFlags(flags)   ((flags))
+// Player names now sent as RGB values. Defining them here
+#define NC_PLAYER        0xFFFFFF   // Default, white name.
+#define NC_SHADOW        0x000000   // Set if name should be drawn black.
+#define NC_KILLER        0xFF0000   // Set if object is a killer.
+#define NC_OUTLAW        0xFC9E00   // Set if object is an outlaw.
+#define NC_DM            0x00FFFF   // Set if object is a DM player.
+#define NC_CREATOR       0xFFFF00   // Set if object is a creator player.
+#define NC_SUPER         0x00FF00   // Set if object is a "super DM".
+#define NC_MODERATOR     0x0078FF   // Set if object is a "moderator".
+#define NC_EVENTCHAR     0xFF00FF   // Set if object is an event character.
+#define NC_DAENKS        0xB300B3   // Purple name color for Daenks.
+#define NC_COLOR_MAX     0xFFFFFF   // Max color, defined for clarity.
+
+/* Enum of player types. */
+enum {
+   PF_KILLER       = 1,   // Set if object is a killer.
+   PF_OUTLAW       = 2,   // Set if object is an outlaw.
+   PF_DM           = 3,   // Set if object is a DM player.
+   PF_CREATOR      = 4,   // Set if object is a creator player.
+   PF_SUPER        = 5,   // Set if object is a "super DM".
+   PF_MODERATOR    = 6,   // Set if object is a "moderator".
+   PF_EVENTCHAR    = 7,   // Set if object is an event character.
+};
 
 /* How objects allow or disallow motion onto their square */
 enum {
    OF_MOVEON_YES        = 0,   // Can always move on object
    OF_MOVEON_NO         = 1,   // Can never move on object
    OF_MOVEON_TELEPORTER = 2,   // Can move on object, but then kod will move you elsewhere
-   OF_MOVEON_NOTIFY	= 3,
+   OF_MOVEON_NOTIFY     = 3,
 };
 
 /* Effect codes */

--- a/include/proto.h
+++ b/include/proto.h
@@ -365,29 +365,35 @@ enum {
 #define OF_APPLYABLE     0x00001000    // Set if object can be applied to another object
 #define OF_SAFETY        0x00002000    // Set if player has safety on (self only)
 
-#define OF_FLICKERING    0x00020000    // For players or objects if holding a flickering light.
-#define OF_FLASHING      0x00040000    // For players or objects if flashing with light.
-#define OF_BOUNCING      0x00060000    // If both flags on then object is bouncing
+#define OF_FLICKERING    0x00010000    // For players or objects if holding a flickering light.
+#define OF_FLASHING      0x00020000    // For players or objects if flashing with light.
+#define OF_BOUNCING      0x00040000    // If both flags on then object is bouncing
 #define OF_PHASING       0x00080000    // For players or objects if phasing translucent/solid.
-
-// Object drawing effects
-#define OF_DRAW_PLAIN    0x00000000    // No special drawing effects
-#define OF_TRANSLUCENT25 0x00100000    // Set if object should be drawn at 25% opacity
-#define OF_TRANSLUCENT50 0x00200000    // Set if object should be drawn at 50% opacity
-#define OF_TRANSLUCENT75 0x00300000    // Set if object should be drawn at 75% opacity
-#define OF_BLACK         0x00400000    // Set if object should be drawn all black
-#define OF_INVISIBLE     0x00500000    // Set if object should be drawn with invisibility effect
-#define OF_TRANSLATE     0x00600000    // Reserved (used internally by client)
-#define OF_DITHERINVIS   0x00700000    // Haze (dither with transparency) 50% of pixels
-#define OF_DITHERTRANS   0x00800000    // Dither (with two translates) 50% of pixels
-#define OF_DOUBLETRANS   0x00900000    // Translate twice each pixel, plus lighting
-#define OF_SECONDTRANS   0x00A00000    // Ignore per-overlay xlat and use only secondary xlat
-#define OF_EFFECT_MASK   0x00F00000    // Mask to get object drawing effect bits
-#define NUM_DRAW_EFFECTS 16            // # of possible object drawing effects
-
-#define GetDrawingEffect(flags) ((flags) & OF_EFFECT_MASK)
-#define GetDrawingEffectIndex(flags) (((flags) & OF_EFFECT_MASK) >> 20)
 #define GetItemFlags(flags)   ((flags))
+
+// Drawing effects. Separate from object flags.
+#define NUM_DRAW_EFFECTS 256       // # of object drawing effects.
+enum {
+   DRAWFX_DRAW_PLAIN    = 0x00,    // No special drawing effects
+   DRAWFX_TRANSLUCENT25 = 0x01,    // Set if object should be drawn at 25% opacity
+   DRAWFX_TRANSLUCENT50 = 0x02,    // Set if object should be drawn at 50% opacity
+   DRAWFX_TRANSLUCENT75 = 0x03,    // Set if object should be drawn at 75% opacity
+   DRAWFX_BLACK         = 0x04,    // Set if object should be drawn all black
+   DRAWFX_INVISIBLE     = 0x05,    // Set if object should be drawn with invisibility effect
+   DRAWFX_TRANSLATE     = 0x06,    // Reserved (used internally by client)
+   DRAWFX_DITHERINVIS   = 0x07,    // Haze (dither with transparency) 50% of pixels
+   DRAWFX_DITHERTRANS   = 0x08,    // Dither (with two translates) 50% of pixels
+   DRAWFX_DOUBLETRANS   = 0x09,    // Translate twice each pixel, plus lighting
+   DRAWFX_SECONDTRANS   = 0x0A,    // Ignore per-overlay xlat and use only secondary xlat
+   DRAWFX_EFFECT_MASK   = 0xFF,    // Mask to get object drawing effect bits
+};
+
+#define GetDrawingEffect(flags) ((flags) & DRAWFX_EFFECT_MASK)
+/* Bit shifts the drawing effects to the first bits, if not already there.
+ * Note the shift has been removed since the drawing effects now occupy the
+ * first byte now. If these constants are moved, replace the bit shift here
+ * and any place GetDrawingEffectIndex is used. */
+#define GetDrawingEffectIndex(flags) ((flags) & DRAWFX_EFFECT_MASK)
 
 // Minimap dot color bitfield. Now separate from object flags.
 #define MM_NONE          0x00000000    // No dot (default for all objects)
@@ -404,7 +410,7 @@ enum {
 /* Player name color sent as hex RGB value. Define constants
    for ease of use as needed. Requires OF_PLAYER boolean flag
    to be set to draw a name. */
-#define NC_PLAYER        0xFFFFFF   // Default, white name.
+#define NC_PLAYER        0xFFFFFF   // White name.
 #define NC_SHADOW        0x000000   // Set if name should be drawn black.
 #define NC_KILLER        0xFF0000   // Set if object is a killer.
 #define NC_OUTLAW        0xFC9E00   // Set if object is an outlaw.

--- a/include/proto.h
+++ b/include/proto.h
@@ -388,13 +388,6 @@ enum {
    DRAWFX_EFFECT_MASK   = 0xFF,    // Mask to get object drawing effect bits
 };
 
-#define GetDrawingEffect(flags) ((flags) & DRAWFX_EFFECT_MASK)
-/* Bit shifts the drawing effects to the first bits, if not already there.
- * Note the shift has been removed since the drawing effects now occupy the
- * first byte now. If these constants are moved, replace the bit shift here
- * and any place GetDrawingEffectIndex is used. */
-#define GetDrawingEffectIndex(flags) ((flags) & DRAWFX_EFFECT_MASK)
-
 // Minimap dot color bitfield. Now separate from object flags.
 #define MM_NONE          0x00000000    // No dot (default for all objects)
 #define MM_PLAYER        0x00000001    // Standard blue player dot

--- a/include/proto.h
+++ b/include/proto.h
@@ -352,7 +352,6 @@ enum {
 
 
 /* Object flag values and masks */
-#define OF_NOMOVEON_MASK 0x00000003
 #define OF_PLAYER        0x00000004    // Set if object is a player
 #define OF_ATTACKABLE    0x00000008    // Set if object is legal target for an attack
 #define OF_GETTABLE      0x00000010    // Set if player can try to pick up object
@@ -430,12 +429,12 @@ typedef enum {
 } object_type;
 
 /* How objects allow or disallow motion onto their square */
-enum {
+typedef enum {
    OF_MOVEON_YES        = 0,   // Can always move on object
    OF_MOVEON_NO         = 1,   // Can never move on object
    OF_MOVEON_TELEPORTER = 2,   // Can move on object, but then kod will move you elsewhere
    OF_MOVEON_NOTIFY     = 3,
-};
+} moveon_type;
 
 /* Effect codes */
 enum {

--- a/include/proto.h
+++ b/include/proto.h
@@ -428,10 +428,10 @@ typedef enum {
 
 /* How objects allow or disallow motion onto their square */
 typedef enum {
-   OF_MOVEON_YES        = 0,   // Can always move on object
-   OF_MOVEON_NO         = 1,   // Can never move on object
-   OF_MOVEON_TELEPORTER = 2,   // Can move on object, but then kod will move you elsewhere
-   OF_MOVEON_NOTIFY     = 3,
+   MOVEON_YES        = 0,   // Can always move on object
+   MOVEON_NO         = 1,   // Can never move on object
+   MOVEON_TELEPORTER = 2,   // Can move on object, but then kod will move you elsewhere
+   MOVEON_NOTIFY     = 3,
 } moveon_type;
 
 /* Effect codes */

--- a/include/proto.h
+++ b/include/proto.h
@@ -365,9 +365,9 @@ enum {
 #define OF_APPLYABLE     0x00001000    // Set if object can be applied to another object
 #define OF_SAFETY        0x00002000    // Set if player has safety on (self only)
 
-#define OF_FLICKERING    0x00010000    // For players or objects if holding a flickering light.
-#define OF_FLASHING      0x00020000    // For players or objects if flashing with light.
-#define OF_BOUNCING      0x00040000    // If both flags on then object is bouncing
+#define OF_BOUNCING      0x00010000    // If both flags on then object is bouncing
+#define OF_FLICKERING    0x00020000    // For players or objects if holding a flickering light.
+#define OF_FLASHING      0x00040000    // For players or objects if flashing with light.
 #define OF_PHASING       0x00080000    // For players or objects if phasing translucent/solid.
 #define GetItemFlags(flags)   ((flags))
 

--- a/include/proto.h
+++ b/include/proto.h
@@ -385,7 +385,6 @@ enum {
    DRAWFX_DITHERTRANS   = 0x08,    // Dither (with two translates) 50% of pixels
    DRAWFX_DOUBLETRANS   = 0x09,    // Translate twice each pixel, plus lighting
    DRAWFX_SECONDTRANS   = 0x0A,    // Ignore per-overlay xlat and use only secondary xlat
-   DRAWFX_EFFECT_MASK   = 0xFF,    // Mask to get object drawing effect bits
 };
 
 // Minimap dot color bitfield. Now separate from object flags.

--- a/include/proto.h
+++ b/include/proto.h
@@ -396,16 +396,18 @@ enum {
 #define OF_EFFECT_MASK   0x00F00000    // Mask to get object drawing effect bits
 #define NUM_DRAW_EFFECTS 16            // # of possible object drawing effects
 
-// Minimap dot colors
-#define OF_ENEMY         0x01000000    // Enemy player
-#define OF_FRIEND        0x02000000    // Friendly player
-#define OF_GUILDMATE     0x04000000    // Guildmate player
-#define OF_MINION        0x08000000    // Monster is a minion owned by a player
-#define OF_MINION_OTHER  0x09000000    // Set if monster is other's minion
-#define OF_MINION_SELF   0x0A000000    // Set if a monster is our minion
-#define OF_MINIMAP_MASK  0x0F000000    // Mask to get minimap drawing effects
+// Minimap dot color bitfield. Now separate from object flags.
+#define MM_NONE          0x00000000    // No dot (default for all objects)
+#define MM_PLAYER        0x00000001    // Standard blue player dot
+#define MM_ENEMY         0x00000002    // Enemy (halo or attackable) player
+#define MM_FRIEND        0x00000004    // Friendly (guild ally) player
+#define MM_GUILDMATE     0x00000008    // Guildmate player
+#define MM_BUILDER_GROUP 0x00000010    // Player is in same building group
+#define MM_MONSTER       0x00000020    // Default monster dot
+#define MM_NPC           0x00000040    // NPC
+#define MM_MINION_OTHER  0x00000080    // Set if monster is other's minion
+#define MM_MINION_SELF   0x00000100    // Set if a monster is our minion
 
-#define GetMinimapFlags(flags)  ((flags) & OF_MINIMAP_MASK)
 #define GetPlayerFlags(flags)   ((flags) & OF_PLAYER_MASK)
 #define GetDrawingEffect(flags) ((flags) & OF_EFFECT_MASK)
 #define GetDrawingEffectIndex(flags) (((flags) & OF_EFFECT_MASK) >> 20)

--- a/include/proto.h
+++ b/include/proto.h
@@ -402,7 +402,9 @@ enum {
 #define MM_MINION_OTHER  0x00000080    // Set if monster is other's minion
 #define MM_MINION_SELF   0x00000100    // Set if a monster is our minion
 
-// Player names now sent as RGB values. Defining them here
+/* Player name color sent as hex RGB value. Define constants
+   for ease of use as needed. Requires OF_PLAYER boolean flag
+   to be set to draw a name. */
 #define NC_PLAYER        0xFFFFFF   // Default, white name.
 #define NC_SHADOW        0x000000   // Set if name should be drawn black.
 #define NC_KILLER        0xFF0000   // Set if object is a killer.
@@ -415,16 +417,17 @@ enum {
 #define NC_DAENKS        0xB300B3   // Purple name color for Daenks.
 #define NC_COLOR_MAX     0xFFFFFF   // Max color, defined for clarity.
 
-/* Enum of player types. */
-enum {
-   PF_KILLER       = 1,   // Set if object is a killer.
-   PF_OUTLAW       = 2,   // Set if object is an outlaw.
-   PF_DM           = 3,   // Set if object is a DM player.
-   PF_CREATOR      = 4,   // Set if object is a creator player.
-   PF_SUPER        = 5,   // Set if object is a "super DM".
-   PF_MODERATOR    = 6,   // Set if object is a "moderator".
-   PF_EVENTCHAR    = 7,   // Set if object is an event character.
-};
+/* Enum of object types. */
+typedef enum {
+   OT_NONE         = 0,   // Default for most objects.
+   OT_KILLER       = 1,   // Set if object is a killer.
+   OT_OUTLAW       = 2,   // Set if object is an outlaw.
+   OT_DM           = 3,   // Set if object is a DM player.
+   OT_CREATOR      = 4,   // Set if object is a creator player.
+   OT_SUPER        = 5,   // Set if object is a "super DM".
+   OT_MODERATOR    = 6,   // Set if object is a "moderator".
+   OT_EVENTCHAR    = 7,   // Set if object is an event character.
+} object_type;
 
 /* How objects allow or disallow motion onto their square */
 enum {

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -105,13 +105,17 @@
    PLAYER_EVENT      = 0x1C000
 
    % What is the target, according to the viewer?  Used for special flagging.
-   PLAYER_IS_ENEMY      = 0x01000000
-   PLAYER_IS_FRIEND     = 0x02000000
-   PLAYER_IS_GUILDMATE  = 0x04000000
-   MINION_YES           = 0x08000000
-   MINION_OTHER         = 0x09000000
-   MINION_SELF          = 0x0A000000
-   MINIMAP_MASK         = 0x0F000000
+   % This is now its own bitfield separate from object flags.
+   MM_NONE                 = 0x00000000
+   MM_PLAYER               = 0x00000001
+   MM_PLAYER_IS_ENEMY      = 0x00000002
+   MM_PLAYER_IS_FRIEND     = 0x00000004
+   MM_PLAYER_IS_GUILDMATE  = 0x00000008
+   MM_BUILDER_GROUP        = 0x00000010
+   MM_MONSTER              = 0x00000020
+   MM_NPC                  = 0x00000040
+   MM_MINION_OTHER         = 0x00000080
+   MM_MINION_SELF          = 0x00000100
 
    %%% Projectile and Light flags
 

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -108,7 +108,8 @@
    MM_MINION_SELF          = 0x00000100
 
    % Player name color sent as hex RGB value. Define constants
-   % for ease of use as needed.
+   % for ease of use as needed. Requires OF_PLAYER boolean flag
+   % to be set to draw a name.
    NC_PLAYER       = 0xFFFFFF   % Default, white name.
    NC_SHADOW       = 0x000000   % Set if name should be drawn black.
    NC_KILLER       = 0xFF0000   % Set if object is a killer.
@@ -121,15 +122,15 @@
    NC_DAENKS       = 0xB300B3   % Purple name color for Daenks.
    NC_COLOR_MAX    = 0xFFFFFF   % Max color, defined for clarity.
 
-   % Player type enum. Even if the name color displayed changes, these
-   % should still report the correct player type.
-   PF_KILLER       = 1   % Set if object is a killer.
-   PF_OUTLAW       = 2   % Set if object is an outlaw.
-   PF_DM           = 3   % Set if object is a DM player.
-   PF_CREATOR      = 4   % Set if object is a creator player.
-   PF_SUPER        = 5   % Set if object is a "super DM".
-   PF_MODERATOR    = 6   % Set if object is a "moderator".
-   PF_EVENTCHAR    = 7   % Set if object is an event character.
+   % Object type enum. Used in the client for differentiating objects.
+   OT_NONE         = 0   % Default, no type set.
+   OT_KILLER       = 1   % Set if object is a killer.
+   OT_OUTLAW       = 2   % Set if object is an outlaw.
+   OT_DM           = 3   % Set if object is a DM player.
+   OT_CREATOR      = 4   % Set if object is a creator player.
+   OT_SUPER        = 5   % Set if object is a "super DM".
+   OT_MODERATOR    = 6   % Set if object is a "moderator".
+   OT_EVENTCHAR    = 7   % Set if object is an event character.
 
    %%% Projectile and Light flags
 

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -35,18 +35,19 @@
    HOUR = 3600
    MINUTE = 60
 
-   %%% Object type constants
+   %%% KOD Object type constants
 
    ACTIVE = 1
    PASSIVE = 2
 
-   %%% Object flags for client
-
-   % 0's are default value
+   % MoveOn type enum, now separate from object flags.
    MOVEON_YES        = 0
-   MOVEON_NO         = 0x00000001
-   MOVEON_TELEPORTER = 0x00000002
-   MOVEON_NOTIFY     = 0x00000003
+   MOVEON_NO         = 1
+   MOVEON_TELEPORTER = 2
+   MOVEON_NOTIFY     = 3
+
+   % Object flags for client.
+   % 0's are default value
    USER_NO           = 0
    USER_YES          = 0x00000004
    BATTLER_NO        = 0

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -47,31 +47,19 @@
    MOVEON_NOTIFY     = 3
 
    % Object flags for client.
-   % 0's are default value
-   USER_NO           = 0
-   USER_YES          = 0x00000004
-   BATTLER_NO        = 0
-   BATTLER_YES       = 0x00000008
-   GETTABLE_NO       = 0
-   GETTABLE_YES      = 0x00000010
+   OF_PLAYER         = 0x00000004
+   OF_ATTACKABLE     = 0x00000008
+   OF_GETTABLE       = 0x00000010
    % careful--only one's user is ALLOWED to put/get in.
-   CONTAINER_NO      = 0
-   CONTAINER_YES     = 0x00000020
-   LOOK_YES          = 0
-   LOOK_NO           = 0x00000040
-   ITEM_MAGIC_YES    = 0x00000080
-   ITEM_MAGIC_NO     = 0
-   HANGING_YES       = 0x00000100
-   OFFER_YES         = 0x00000200
-   OFFER_NO          = 0
-   BUY_YES           = 0x00000400
-   BUY_NO            = 0
-   ACTIVATE_YES      = 0x00000800
-   ACTIVATE_NO       = 0
-   APPLY_YES         = 0x00001000
-   APPLY_NO          = 0
-   SAFETY_YES        = 0x00002000
-   SAFETY_NO         = 0
+   OF_CONTAINER      = 0x00000020
+   OF_NOEXAMINE      = 0x00000040
+   OF_ITEM_MAGIC     = 0x00000080
+   OF_HANGING        = 0x00000100
+   OF_OFFERABLE      = 0x00000200
+   OF_BUYABLE        = 0x00000400
+   OF_ACTIVATABLE    = 0x00000800
+   OF_APPLYABLE      = 0x00001000
+   OF_SAFETY         = 0x00002000
 
    OF_BOUNCING       = 0x00010000
    OF_FLICKERING     = 0x00020000

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -73,27 +73,24 @@
    SAFETY_YES        = 0x00002000
    SAFETY_NO         = 0
 
-   % Visual effects
-   FLICKERING_YES    = 0x00020000
-   FLICKERING_NO     = 0
-   FLASHING_YES      = 0x00040000
-   FLASHING_NO       = 0
-   BOUNCE_YES        = 0x00060000
-   BOUNCE_NO         = 0
-   PHASING_YES       = 0x00080000
-   PHASING_NO        = 0
+   OF_FLICKERING     = 0x00010000
+   OF_FLASHING       = 0x00020000
+   OF_BOUNCING       = 0x00040000
+   OF_PHASING        = 0x00080000
 
-   DRAWFX_NO = 0
-   DRAWFX_TRANSLUCENT_25 = 0x100000
-   DRAWFX_TRANSLUCENT_50 = 0x200000
-   DRAWFX_TRANSLUCENT_75 = 0x300000
-   DRAWFX_BLACK          = 0x400000
-   DRAWFX_INVISIBLE      = 0x500000
-   DRAWFX_DITHERINVIS    = 0x700000
-   DRAWFX_DITHERTRANS    = 0x800000
-   DRAWFX_DOUBLETRANS    = 0x900000
-   DRAWFX_SECONDTRANS    = 0xA00000
-   DRAWFX_MASK           = 0xF00000
+   % Drawing effects flags, separate from the boolean object flags.
+   DRAWFX_NONE           = 0
+   DRAWFX_TRANSLUCENT_25 = 0x00000001
+   DRAWFX_TRANSLUCENT_50 = 0x00000002
+   DRAWFX_TRANSLUCENT_75 = 0x00000003
+   DRAWFX_BLACK          = 0x00000004
+   DRAWFX_INVISIBLE      = 0x00000005
+   DRAWFX_TRANSLATE      = 0x00000006 % This is reserved by client, do not use.
+   DRAWFX_DITHERINVIS    = 0x00000007
+   DRAWFX_DITHERTRANS    = 0x00000008
+   DRAWFX_DOUBLETRANS    = 0x00000009
+   DRAWFX_SECONDTRANS    = 0x0000000A
+   DRAWFX_MASK           = 0x000000FF % First byte reserved for drawing effects.
 
    % What is the target, according to the viewer?  Used for special flagging.
    % This is now its own bitfield separate from object flags.

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -73,9 +73,9 @@
    SAFETY_YES        = 0x00002000
    SAFETY_NO         = 0
 
-   OF_FLICKERING     = 0x00010000
-   OF_FLASHING       = 0x00020000
-   OF_BOUNCING       = 0x00040000
+   OF_BOUNCING       = 0x00010000
+   OF_FLICKERING     = 0x00020000
+   OF_FLASHING       = 0x00040000
    OF_PHASING        = 0x00080000
 
    % Drawing effects flags, separate from the boolean object flags.

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -94,16 +94,6 @@
    DRAWFX_SECONDTRANS    = 0xA00000
    DRAWFX_MASK           = 0xF00000
 
-   % Bits 0x4000, 0x8000, 0x10000 in total describe the player type
-   PLAYER_NO         = 0
-   PLAYER_PK         = 0x4000
-   PLAYER_OUTLAW     = 0x8000
-   PLAYER_DM         = 0xC000
-   PLAYER_CREATOR    = 0x10000
-   PLAYER_SUPER      = 0x14000
-   PLAYER_MODERATOR  = 0x18000
-   PLAYER_EVENT      = 0x1C000
-
    % What is the target, according to the viewer?  Used for special flagging.
    % This is now its own bitfield separate from object flags.
    MM_NONE                 = 0x00000000
@@ -116,6 +106,30 @@
    MM_NPC                  = 0x00000040
    MM_MINION_OTHER         = 0x00000080
    MM_MINION_SELF          = 0x00000100
+
+   % Player name color sent as hex RGB value. Define constants
+   % for ease of use as needed.
+   NC_PLAYER       = 0xFFFFFF   % Default, white name.
+   NC_SHADOW       = 0x000000   % Set if name should be drawn black.
+   NC_KILLER       = 0xFF0000   % Set if object is a killer.
+   NC_OUTLAW       = 0xFC9E00   % Set if object is an outlaw.
+   NC_DM           = 0x00FFFF   % Set if object is a DM player.
+   NC_CREATOR      = 0xFFFF00   % Set if object is a creator player.
+   NC_SUPER        = 0x00FF00   % Set if object is a "super DM".
+   NC_MODERATOR    = 0x0078FF   % Set if object is a "moderator".
+   NC_EVENTCHAR    = 0xFF00FF   % Set if object is an event character.
+   NC_DAENKS       = 0xB300B3   % Purple name color for Daenks.
+   NC_COLOR_MAX    = 0xFFFFFF   % Max color, defined for clarity.
+
+   % Player type enum. Even if the name color displayed changes, these
+   % should still report the correct player type.
+   PF_KILLER       = 1   % Set if object is a killer.
+   PF_OUTLAW       = 2   % Set if object is an outlaw.
+   PF_DM           = 3   % Set if object is a DM player.
+   PF_CREATOR      = 4   % Set if object is a creator player.
+   PF_SUPER        = 5   % Set if object is a "super DM".
+   PF_MODERATOR    = 6   % Set if object is a "moderator".
+   PF_EVENTCHAR    = 7   % Set if object is an event character.
 
    %%% Projectile and Light flags
 

--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -68,17 +68,18 @@
 
    % Drawing effects flags, separate from the boolean object flags.
    DRAWFX_NONE           = 0
-   DRAWFX_TRANSLUCENT_25 = 0x00000001
-   DRAWFX_TRANSLUCENT_50 = 0x00000002
-   DRAWFX_TRANSLUCENT_75 = 0x00000003
-   DRAWFX_BLACK          = 0x00000004
-   DRAWFX_INVISIBLE      = 0x00000005
-   DRAWFX_TRANSLATE      = 0x00000006 % This is reserved by client, do not use.
-   DRAWFX_DITHERINVIS    = 0x00000007
-   DRAWFX_DITHERTRANS    = 0x00000008
-   DRAWFX_DOUBLETRANS    = 0x00000009
-   DRAWFX_SECONDTRANS    = 0x0000000A
-   DRAWFX_MASK           = 0x000000FF % First byte reserved for drawing effects.
+   DRAWFX_TRANSLUCENT_25 = 0x01
+   DRAWFX_TRANSLUCENT_50 = 0x02
+   DRAWFX_TRANSLUCENT_75 = 0x03
+   DRAWFX_BLACK          = 0x04
+   DRAWFX_INVISIBLE      = 0x05
+   DRAWFX_TRANSLATE      = 0x06 % This is reserved by client, do not use.
+   DRAWFX_DITHERINVIS    = 0x07
+   DRAWFX_DITHERTRANS    = 0x08
+   DRAWFX_DOUBLETRANS    = 0x09
+   DRAWFX_SECONDTRANS    = 0x0A
+   DRAWFX_DITHERGREY     = 0x0B % Old logoff ghost greyscale effect.
+   DRAWFX_MASK           = 0xFF
 
    % What is the target, according to the viewer?  Used for special flagging.
    % This is now its own bitfield separate from object flags.

--- a/kod/object.kod
+++ b/kod/object.kod
@@ -74,7 +74,9 @@ classvars:
    vbSummoned = FALSE
 
    viGender = GENDER_NEUTER
+
    viObject_flags = 0
+   viMoveOn_type = 0
 
 properties:
 
@@ -730,6 +732,11 @@ messages:
    "Returns FALSE for most things."
    {
       return FALSE;
+   }
+
+   GetMoveOnType()
+   {
+      return viMoveOn_type;
    }
 
    GetObjectFlags()

--- a/kod/object.kod
+++ b/kod/object.kod
@@ -737,8 +737,8 @@ messages:
       return viObject_flags;
    }
 
-   GetPlayerType()
-   "This is an enum of player types. Returns 0 for most objects."
+   GetClientObjectType()
+   "This is an enum of object types. Returns 0 for most objects for now."
    {
       return 0;
    }

--- a/kod/object.kod
+++ b/kod/object.kod
@@ -746,7 +746,7 @@ messages:
       return viObject_flags | piDrawType;
    }
 
-   GetDrawingFlags()
+   GetDrawingEffects()
    "This returns any special drawing effect the object has. Default is "
    "no drawing effect."
    {

--- a/kod/object.kod
+++ b/kod/object.kod
@@ -85,6 +85,8 @@ properties:
    plObject_attributes = $
 
    piNameColor = 0
+   piDrawfx = 0
+   piDrawType = 0
 
 messages:
 
@@ -741,7 +743,22 @@ messages:
 
    GetObjectFlags()
    {
-      return viObject_flags;
+      return viObject_flags | piDrawType;
+   }
+
+   GetDrawingFlags()
+   "This returns any special drawing effect the object has. Default is "
+   "no drawing effect."
+   {
+      return piDrawfx;
+   }
+
+   GetDrawType()
+   "This returns any special drawing type the object has. Default is "
+   "no drawing type. Drawing types are phasing, flickering, flashing "
+   "and bouncing, stored separately from object flags and drawing effects."
+   {
+      return piDrawType;
    }
 
    GetClientObjectType()

--- a/kod/object.kod
+++ b/kod/object.kod
@@ -787,7 +787,7 @@ messages:
 
    SetNameColor(red=0,green=0,blue=0,rgb=$)
    "Can set the name color for any object. Currently, only objects "
-   "with USER_YES set to TRUE will display a name. Can change color "
+   "with OF_PLAYER set to TRUE will display a name. Can change color "
    "by red, green and blue value, or alternatively by rgb value."
    {
       if rgb <> $

--- a/kod/object.kod
+++ b/kod/object.kod
@@ -86,7 +86,7 @@ properties:
 
    piNameColor = 0
    piDrawfx = 0
-   piDrawType = 0
+   piDrawEffectFlag = 0
 
 messages:
 
@@ -743,7 +743,7 @@ messages:
 
    GetObjectFlags()
    {
-      return viObject_flags | piDrawType;
+      return viObject_flags | piDrawEffectFlag;
    }
 
    GetDrawingEffects()
@@ -758,7 +758,7 @@ messages:
    "no drawing type. Drawing types are phasing, flickering, flashing "
    "and bouncing, stored separately from object flags and drawing effects."
    {
-      return piDrawType;
+      return piDrawEffectFlag;
    }
 
    GetClientObjectType()

--- a/kod/object.kod
+++ b/kod/object.kod
@@ -59,8 +59,6 @@ resources:
    object_cap_lord = "Lord"
    object_cap_lady = "Lady"
 
-
-
 classvars:
    vrName = object_name_rsc
    vrIcon = object_icon_rsc
@@ -70,7 +68,7 @@ classvars:
    viDefinite = ARTICLE_THE
 
    viBulk = 0
-   viWeight = 0 
+   viWeight = 0
 
    viIllusion = FALSE
    vbSummoned = FALSE
@@ -81,8 +79,10 @@ classvars:
 properties:
 
    poOwner = $
-   
+
    plObject_attributes = $
+
+   piNameColor = 0
 
 messages:
 
@@ -735,6 +735,64 @@ messages:
    GetObjectFlags()
    {
       return viObject_flags;
+   }
+
+   GetPlayerType()
+   "This is an enum of player types. Returns 0 for most objects."
+   {
+      return 0;
+   }
+
+   GetPlayerNameColor(rgb=FALSE)
+   "Returns the name color property, or if sent rgb TRUE, returns "
+   "a list with the int RGB value of piNameColor."
+   {
+      local lColor;
+
+      if rgb
+      {
+         lColor = Cons((piNameColor & 0x0000FF), lColor); % Blue
+         lColor = Cons((piNameColor  & 0x00FF00) / 256, lColor); % Green
+         lColor = Cons((piNameColor & 0xFF0000) / 65536, lColor); % Red
+
+         return lColor;
+      }
+
+      return piNameColor;
+   }
+
+   SetNameColor(red=0,green=0,blue=0,rgb=$)
+   "Can set the name color for any object. Currently, only objects "
+   "with USER_YES set to TRUE will display a name. Can change color "
+   "by red, green and blue value, or alternatively by rgb value."
+   {
+      if rgb <> $
+         AND rgb >= 0
+         AND rgb <= NC_COLOR_MAX
+      {
+         piNameColor = rgb;
+         if poOwner <> $
+         {
+            Send(poOwner,@SomethingChanged,#what=self);
+         }
+
+         return TRUE;
+      }
+
+      if (red >= 0 AND red <= 255)
+         AND (green >= 0 AND green <= 255)
+         AND (blue >= 0 AND blue <= 255)
+      {
+         piNameColor = red * green * blue;
+         if poOwner <> $
+         {
+            Send(poOwner,@SomethingChanged,#what=self);
+         }
+
+         return TRUE;
+      }
+
+      return FALSE;
    }
 
    GetGender()

--- a/kod/object/active/flag.kod
+++ b/kod/object/active/flag.kod
@@ -74,7 +74,7 @@ classvars:
    vrIcon = flag_icon_rsc
    vrDesc = flag_desc_rsc
 
-   viObject_flags = ACTIVATE_YES
+   viObject_flags = OF_ACTIVATABLE
 
 properties:
 
@@ -749,10 +749,10 @@ messages:
    {
       if pbClaimable
       {
-         return (viObject_flags | ACTIVATE_YES);
+         return (viObject_flags | OF_ACTIVATABLE);
       }
 
-      return (viObject_flags & ~ACTIVATE_YES);
+      return (viObject_flags & ~OF_ACTIVATABLE);
    }
 
    NewOwner(what=$)

--- a/kod/object/active/holder/nomoveon.kod
+++ b/kod/object/active/holder/nomoveon.kod
@@ -16,7 +16,7 @@ constants:
 
 classvars:
 
-   viObject_flags = MOVEON_NO
+   viMoveOn_type = MOVEON_NO
 
 properties:
 

--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -134,7 +134,7 @@ resources:
 
 classvars:
 
-   viObject_flags = MOVEON_NO | BATTLER_YES
+   viObject_flags = BATTLER_YES
 
    viBattler_level = 50
 

--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -134,7 +134,7 @@ resources:
 
 classvars:
 
-   viObject_flags = BATTLER_YES
+   viObject_flags = OF_ATTACKABLE
 
    viBattler_level = 50
 

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -691,13 +691,6 @@ messages:
       return;
    }
 
-   %%% DrawFX
-
-   GetDrawFX()
-   {
-      return piDrawfx;
-   }
-
    %%% Enchantments of Monsters
 
    EnchantmentTimer(timer = $)
@@ -5894,8 +5887,6 @@ messages:
          iFlags = iFlags | OFFER_YES;
       }
 
-      iFlags = iFlags | piDrawfx;
-
       return iFlags;
    }
 
@@ -6344,12 +6335,12 @@ messages:
 
    IsInvisible()
    {
-      return (Send(self,@GetObjectFlags) & DRAWFX_INVISIBLE);
+      return (Send(self,@GetDrawingFlags) & DRAWFX_INVISIBLE);
    }
 
    IsShadowForm()
    {
-      return (Send(self,@GetObjectFlags) & DRAWFX_BLACK);
+      return (Send(self,@GetDrawingFlags) & DRAWFX_BLACK);
    }
 
    GetVaultNum()

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -6335,12 +6335,12 @@ messages:
 
    IsInvisible()
    {
-      return (Send(self,@GetDrawingFlags) & DRAWFX_INVISIBLE);
+      return (Send(self,@GetDrawingEffects) & DRAWFX_INVISIBLE);
    }
 
    IsShadowForm()
    {
-      return (Send(self,@GetDrawingFlags) & DRAWFX_BLACK);
+      return (Send(self,@GetDrawingEffects) & DRAWFX_BLACK);
    }
 
    GetVaultNum()

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -5873,18 +5873,18 @@ messages:
 
       if NOT (piBehavior & AI_NPC)
       {
-         iFlags = iFlags | BATTLER_YES;
+         iFlags = iFlags | OF_ATTACKABLE;
       }
 
       if Send(Self,@MobIsSeller)
       {
-         iFlags = iFlags | BUY_YES;
+         iFlags = iFlags | OF_BUYABLE;
       }
 
       if (viAttributes & MOB_BUYER)
          OR (viAttributes & MOB_RECEIVE)
       {
-         iFlags = iFlags | OFFER_YES;
+         iFlags = iFlags | OF_OFFERABLE;
       }
 
       return iFlags;

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -5876,7 +5876,7 @@ messages:
    {
       local iFlags;
 
-      iFlags = MOVEON_NO;
+      iFlags = 0;
 
       if NOT (piBehavior & AI_NPC)
       {

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -5869,7 +5869,7 @@ messages:
    {
       local iFlags;
 
-      iFlags = 0;
+      iFlags = viObject_flags | piDrawEffectFlag;
 
       if NOT (piBehavior & AI_NPC)
       {

--- a/kod/object/active/holder/nomoveon/battler/monster/BRAMBLE.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/BRAMBLE.kod
@@ -62,7 +62,6 @@ classvars:
    viDifficulty = 4 
    viKarma = 0
    viDefault_behavior = AI_NOFIGHT | AI_NOMOVE
-   viObject_flags = BATTLER_YES
    viCashmin = 0
    viCashmax = 0
    vrSound_hit = $

--- a/kod/object/active/holder/nomoveon/battler/monster/BRAMBLE.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/BRAMBLE.kod
@@ -56,7 +56,8 @@ classvars:
 
    viTreasure_type = TID_NONE
    viAttack_type = ATCK_WEAP_SLASH
-   viAttributes = MOB_NOMOVE | MOB_NOFIGHT | MOVEON_NOTIFY | MOB_NOQUEST
+   viAttributes = MOB_NOMOVE | MOB_NOFIGHT | MOB_NOQUEST
+   viMoveOn_type = MOVEON_NOTIFY
    viLevel = 25
    viDifficulty = 4 
    viKarma = 0

--- a/kod/object/active/holder/nomoveon/battler/monster/dangel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dangel.kod
@@ -83,7 +83,7 @@ classvars:
 properties:
 
    piAnimation = ANIM_NONE
-   piDrawfx = BOUNCE_YES
+   piDrawType = OF_BOUNCING
 
    piSpellPower = 99
    piMax_mana = 40
@@ -252,11 +252,6 @@ messages:
    Delete()
    {
       propagate;
-   }
-
-   GetObjectFlags()
-   {
-      return BOUNCE_YES | BATTLER_YES;
    }
 
    CanMorphTo()

--- a/kod/object/active/holder/nomoveon/battler/monster/dangel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dangel.kod
@@ -83,7 +83,7 @@ classvars:
 properties:
 
    piAnimation = ANIM_NONE
-   piDrawType = OF_BOUNCING
+   piDrawEffectFlag = OF_BOUNCING
 
    piSpellPower = 99
    piMax_mana = 40

--- a/kod/object/active/holder/nomoveon/battler/monster/dangel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dangel.kod
@@ -256,7 +256,7 @@ messages:
 
    GetObjectFlags()
    {
-      return MOVEON_NO | BOUNCE_YES | BATTLER_YES;
+      return BOUNCE_YES | BATTLER_YES;
    }
 
    CanMorphTo()

--- a/kod/object/active/holder/nomoveon/battler/monster/dfly.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dfly.kod
@@ -280,10 +280,10 @@ messages:
    {
       if piAnimation = ANIM_NONE
       {
-         return BATTLER_YES;
+         return OF_ATTACKABLE;
       }
 
-      return BATTLER_YES | OF_BOUNCING;
+      return OF_ATTACKABLE | OF_BOUNCING;
    }
 
    CanMorphTo()

--- a/kod/object/active/holder/nomoveon/battler/monster/dfly.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dfly.kod
@@ -87,8 +87,6 @@ properties:
    ptHover = $
    ptLand = $
 
-   piDrawfx = BOUNCE_YES
-
 messages:
 
    Constructed()
@@ -114,7 +112,7 @@ messages:
    DoSpit()
    {
       piAnimation = ANIM_ATTACK;
-      piDrawFX = piDrawFX | BOUNCE_YES;
+      piDrawType = piDrawType | OF_BOUNCING;
       Send(poOwner,@SomethingChanged,#what=self);
       Send(poOwner,@SomethingShot,#who=self,#target=poTarget,#projectile=self);
       piAnimation = ANIM_HOVER;
@@ -172,7 +170,7 @@ messages:
       if (poTarget = $) AND (piAnimation = ANIM_HOVER)
       {
          piAnimation = ANIM_NONE;
-         piDrawFX = (piDrawFX & (~BOUNCE_YES));
+         piDrawType = (piDrawType & (~OF_BOUNCING));
          Send(poOwner,@SomethingChanged,#what=self);
       }
 
@@ -285,7 +283,7 @@ messages:
          return BATTLER_YES;
       }
 
-      return BOUNCE_YES | BATTLER_YES;
+      return BATTLER_YES | OF_BOUNCING;
    }
 
    CanMorphTo()

--- a/kod/object/active/holder/nomoveon/battler/monster/dfly.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dfly.kod
@@ -282,10 +282,10 @@ messages:
    {
       if piAnimation = ANIM_NONE
       {
-         return MOVEON_NO | BATTLER_YES;
+         return BATTLER_YES;
       }
 
-      return MOVEON_NO | BOUNCE_YES | BATTLER_YES;
+      return BOUNCE_YES | BATTLER_YES;
    }
 
    CanMorphTo()

--- a/kod/object/active/holder/nomoveon/battler/monster/dfly.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dfly.kod
@@ -112,7 +112,7 @@ messages:
    DoSpit()
    {
       piAnimation = ANIM_ATTACK;
-      piDrawType = piDrawType | OF_BOUNCING;
+      piDrawEffectFlag = piDrawEffectFlag | OF_BOUNCING;
       Send(poOwner,@SomethingChanged,#what=self);
       Send(poOwner,@SomethingShot,#who=self,#target=poTarget,#projectile=self);
       piAnimation = ANIM_HOVER;
@@ -170,7 +170,7 @@ messages:
       if (poTarget = $) AND (piAnimation = ANIM_HOVER)
       {
          piAnimation = ANIM_NONE;
-         piDrawType = (piDrawType & (~OF_BOUNCING));
+         piDrawEffectFlag = (piDrawEffectFlag & (~OF_BOUNCING));
          Send(poOwner,@SomethingChanged,#what=self);
       }
 

--- a/kod/object/active/holder/nomoveon/battler/monster/dflypet.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dflypet.kod
@@ -88,8 +88,6 @@ properties:
    ptHover = $
    ptLand = $
 
-   piDrawfx = BOUNCE_YES
-
    piColor = PT_GRAY_TO_DGREEN
 
 messages:
@@ -117,7 +115,7 @@ messages:
    DoSpit()
    {
       piAnimation = ANIM_ATTACK;
-      piDrawFX = piDrawFX | BOUNCE_YES;
+      piDrawType = piDrawType | OF_BOUNCING;
       Send(poOwner,@SomethingChanged,#what=self);
       Send(poOwner,@SomethingShot,#who=self,#target=poTarget,
            #projectile = self);
@@ -170,7 +168,7 @@ messages:
       if (poTarget = $) AND (piAnimation = ANIM_HOVER)
       {
          piAnimation = ANIM_NONE;
-         piDrawFX = (piDrawFX & (~BOUNCE_YES));
+         piDrawType = (piDrawType & (~OF_BOUNCING));
          Send(poOwner,@SomethingChanged,#what=self);
       }
 
@@ -282,6 +280,11 @@ messages:
       propagate;
    }
 
+   CanMorphTo()
+   {
+      return FALSE;
+   }
+
    GetObjectFlags()
    {
       if piAnimation = ANIM_NONE
@@ -289,12 +292,7 @@ messages:
          return BATTLER_YES;
       }
 
-      return BOUNCE_YES | BATTLER_YES;
-   }
-
-   CanMorphTo()
-   {
-      return FALSE;
+      return BATTLER_YES | OF_BOUNCING;
    }
 
    SetColor(iColor=PT_GRAY_TO_DGREEN)

--- a/kod/object/active/holder/nomoveon/battler/monster/dflypet.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dflypet.kod
@@ -289,10 +289,10 @@ messages:
    {
       if piAnimation = ANIM_NONE
       {
-         return BATTLER_YES;
+         return OF_ATTACKABLE;
       }
 
-      return BATTLER_YES | OF_BOUNCING;
+      return OF_ATTACKABLE | OF_BOUNCING;
    }
 
    SetColor(iColor=PT_GRAY_TO_DGREEN)

--- a/kod/object/active/holder/nomoveon/battler/monster/dflypet.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dflypet.kod
@@ -115,7 +115,7 @@ messages:
    DoSpit()
    {
       piAnimation = ANIM_ATTACK;
-      piDrawType = piDrawType | OF_BOUNCING;
+      piDrawEffectFlag = piDrawEffectFlag | OF_BOUNCING;
       Send(poOwner,@SomethingChanged,#what=self);
       Send(poOwner,@SomethingShot,#who=self,#target=poTarget,
            #projectile = self);
@@ -168,7 +168,7 @@ messages:
       if (poTarget = $) AND (piAnimation = ANIM_HOVER)
       {
          piAnimation = ANIM_NONE;
-         piDrawType = (piDrawType & (~OF_BOUNCING));
+         piDrawEffectFlag = (piDrawEffectFlag & (~OF_BOUNCING));
          Send(poOwner,@SomethingChanged,#what=self);
       }
 

--- a/kod/object/active/holder/nomoveon/battler/monster/dflypet.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dflypet.kod
@@ -286,10 +286,10 @@ messages:
    {
       if piAnimation = ANIM_NONE
       {
-         return MOVEON_NO | BATTLER_YES;
+         return BATTLER_YES;
       }
 
-      return MOVEON_NO | BOUNCE_YES | BATTLER_YES;
+      return BOUNCE_YES | BATTLER_YES;
    }
 
    CanMorphTo()

--- a/kod/object/active/holder/nomoveon/battler/monster/dflyq.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dflyq.kod
@@ -132,7 +132,7 @@ messages:
    DoSpit()
    {
       piAnimation = ANIM_ATTACK;
-      piDrawType = piDrawType | OF_BOUNCING;
+      piDrawEffectFlag = piDrawEffectFlag | OF_BOUNCING;
       Send(poOwner,@SomethingChanged,#what=self);
       Send(poOwner,@SomethingShot,#who=self,#target=poTarget,#projectile = self);
       piAnimation = ANIM_HOVER;
@@ -189,7 +189,7 @@ messages:
       if (poTarget = $) AND (piAnimation = ANIM_HOVER)
       {
          piAnimation = ANIM_NONE;
-         piDrawType = (piDrawType & (~OF_BOUNCING));
+         piDrawEffectFlag = (piDrawEffectFlag & (~OF_BOUNCING));
          Send(poOwner,@SomethingChanged,#what=self);
       }
 

--- a/kod/object/active/holder/nomoveon/battler/monster/dflyq.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dflyq.kod
@@ -373,10 +373,10 @@ messages:
    {
       if piAnimation = ANIM_NONE
       {
-         return BATTLER_YES | OFFER_YES;
+         return OF_ATTACKABLE | OF_OFFERABLE;
       }
 
-      return BATTLER_YES | OFFER_YES | OF_BOUNCING;
+      return OF_ATTACKABLE | OF_OFFERABLE | OF_BOUNCING;
    }
 
    CanMorphTo()

--- a/kod/object/active/holder/nomoveon/battler/monster/dflyq.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dflyq.kod
@@ -365,10 +365,10 @@ messages:
    {
       if piAnimation = ANIM_NONE
       {
-         return MOVEON_NO | BATTLER_YES | OFFER_YES;
+         return BATTLER_YES | OFFER_YES;
       }
 
-      return MOVEON_NO | BOUNCE_YES | BATTLER_YES | OFFER_YES;
+      return BOUNCE_YES | BATTLER_YES | OFFER_YES;
    }
 
    TweakBehavior(mob = $)

--- a/kod/object/active/holder/nomoveon/battler/monster/dflyq.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dflyq.kod
@@ -132,7 +132,7 @@ messages:
    DoSpit()
    {
       piAnimation = ANIM_ATTACK;
-      piDrawFX = piDrawFX | BOUNCE_YES;
+      piDrawType = piDrawType | OF_BOUNCING;
       Send(poOwner,@SomethingChanged,#what=self);
       Send(poOwner,@SomethingShot,#who=self,#target=poTarget,#projectile = self);
       piAnimation = ANIM_HOVER;
@@ -189,8 +189,8 @@ messages:
       if (poTarget = $) AND (piAnimation = ANIM_HOVER)
       {
          piAnimation = ANIM_NONE;
-         piDrawFX = (piDrawFX & (~BOUNCE_YES));
-          Send(poOwner,@SomethingChanged,#what=self);
+         piDrawType = (piDrawType & (~OF_BOUNCING));
+         Send(poOwner,@SomethingChanged,#what=self);
       }
 
       return;
@@ -296,11 +296,6 @@ messages:
       propagate;
    }
 
-   GetDrawfx()
-   {
-      return piDrawfx;
-   }
-
    CanAcceptOffer()
    {
       return TRUE;
@@ -361,16 +356,6 @@ messages:
       return TRUE;
    }
 
-   GetObjectFlags()
-   {
-      if piAnimation = ANIM_NONE
-      {
-         return BATTLER_YES | OFFER_YES;
-      }
-
-      return BOUNCE_YES | BATTLER_YES | OFFER_YES;
-   }
-
    TweakBehavior(mob = $)
    {
       if poMaster <> $
@@ -382,6 +367,16 @@ messages:
       }
 
       return;
+   }
+
+   GetObjectFlags()
+   {
+      if piAnimation = ANIM_NONE
+      {
+         return BATTLER_YES | OFFER_YES;
+      }
+
+      return BATTLER_YES | OFFER_YES | OF_BOUNCING;
    }
 
    CanMorphTo()

--- a/kod/object/active/holder/nomoveon/battler/monster/evfairy.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/evfairy.kod
@@ -67,7 +67,7 @@ classvars:
 
 properties:
 
-   piDrawType = OF_BOUNCING
+   piDrawEffectFlag = OF_BOUNCING
    viKarma = -50
    piAnimation = ANIM_NONE
 

--- a/kod/object/active/holder/nomoveon/battler/monster/evfairy.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/evfairy.kod
@@ -178,7 +178,7 @@ messages:
 
    GetObjectFlags()
    {
-      return MOVEON_NO | BOUNCE_YES | BATTLER_YES;
+      return BOUNCE_YES | BATTLER_YES;
    }
 
    SendLightingInformation()

--- a/kod/object/active/holder/nomoveon/battler/monster/evfairy.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/evfairy.kod
@@ -67,7 +67,7 @@ classvars:
 
 properties:
 
-   piDrawfx = BOUNCE_YES
+   piDrawType = OF_BOUNCING
    viKarma = -50
    piAnimation = ANIM_NONE
 
@@ -174,11 +174,6 @@ messages:
       }
 
       propagate;
-   }
-
-   GetObjectFlags()
-   {
-      return BOUNCE_YES | BATTLER_YES;
    }
 
    SendLightingInformation()

--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -367,7 +367,7 @@ messages:
       vrIcon = Send(poOriginal,@GetPlayerIcon);
       vrName = Send(poOriginal,@GetTrueName);
       piGender = Send(poOriginal,@GetGender);
-      piDrawfx = Send(poOriginal,@GetDrawingFlags);
+      piDrawfx = Send(poOriginal,@GetDrawingEffects);
 
       return;
    }
@@ -382,14 +382,14 @@ messages:
       return Send(poOriginal,@GetObjectFlags);
    }
 
-   GetDrawingFlags()
+   GetDrawingEffects()
    {
       if poOriginal = $
       {
          return 0;
       }
 
-      return Send(poOriginal,@GetDrawingFlags);
+      return Send(poOriginal,@GetDrawingEffects);
    }
 
    GetPlayerNameColor()
@@ -509,7 +509,7 @@ messages:
             Send(self,@DoDance);
          }
 
-         piDrawfx = Send(poOriginal,@GetDrawingFlags);
+         piDrawfx = Send(poOriginal,@GetDrawingEffects);
       }
 
       propagate;

--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -367,7 +367,7 @@ messages:
       vrIcon = Send(poOriginal,@GetPlayerIcon);
       vrName = Send(poOriginal,@GetTrueName);
       piGender = Send(poOriginal,@GetGender);
-      piDrawfx = Send(poOriginal,@GetPlayerDrawfx);
+      piDrawfx = Send(poOriginal,@GetDrawingFlags);
 
       return;
    }
@@ -380,6 +380,16 @@ messages:
       }
 
       return Send(poOriginal,@GetObjectFlags);
+   }
+
+   GetDrawingFlags()
+   {
+      if poOriginal = $
+      {
+         return 0;
+      }
+
+      return Send(poOriginal,@GetDrawingFlags);
    }
 
    GetPlayerNameColor()
@@ -499,7 +509,7 @@ messages:
             Send(self,@DoDance);
          }
 
-         piDrawfx = Send(poOriginal,@GetPlayerDrawfx);
+         piDrawfx = Send(poOriginal,@GetDrawingFlags);
       }
 
       propagate;

--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -392,14 +392,14 @@ messages:
       return Send(poOriginal,@GetPlayerNameColor);
    }
 
-   GetPlayerType()
+   GetClientObjectType()
    {
       if poOriginal = $
       {
          return 0;
       }
 
-      return Send(poOriginal,@GetPlayerType);
+      return Send(poOriginal,@GetClientObjectType);
    }
 
    GetAttackRange()

--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -374,16 +374,32 @@ messages:
 
    GetObjectFlags()
    {
-      local iFlags;
-
       if poOriginal = $
       {
          return 0;
       }
 
-      iFlags = Send(poOriginal,@GetObjectFlags);
+      return Send(poOriginal,@GetObjectFlags);
+   }
 
-      return iFlags;
+   GetPlayerNameColor()
+   {
+      if poOriginal = $
+      {
+         return 0;
+      }
+
+      return Send(poOriginal,@GetPlayerNameColor);
+   }
+
+   GetPlayerType()
+   {
+      if poOriginal = $
+      {
+         return 0;
+      }
+
+      return Send(poOriginal,@GetPlayerType);
    }
 
    GetAttackRange()

--- a/kod/object/active/holder/nomoveon/battler/monster/fairy.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/fairy.kod
@@ -176,7 +176,7 @@ messages:
 
    GetObjectFlags()
    {
-      return MOVEON_NO | BOUNCE_YES | BATTLER_YES;
+      return BOUNCE_YES | BATTLER_YES;
    }
 
    SendLightingInformation()

--- a/kod/object/active/holder/nomoveon/battler/monster/fairy.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/fairy.kod
@@ -62,10 +62,10 @@ classvars:
    vrSound_miss = fairy_sound_miss
    vrSound_aware = fairy_sound_aware
    vrSound_death = fairy_sound_death
-   
+
 properties:
 
-   piDrawfx = BOUNCE_YES
+   piDrawType = OF_BOUNCING
    viKarma = 50
    piAnimation = ANIM_NONE
 
@@ -172,11 +172,6 @@ messages:
       }
 
       propagate;
-   }
-
-   GetObjectFlags()
-   {
-      return BOUNCE_YES | BATTLER_YES;
    }
 
    SendLightingInformation()

--- a/kod/object/active/holder/nomoveon/battler/monster/fairy.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/fairy.kod
@@ -65,7 +65,7 @@ classvars:
 
 properties:
 
-   piDrawType = OF_BOUNCING
+   piDrawEffectFlag = OF_BOUNCING
    viKarma = 50
    piAnimation = ANIM_NONE
 

--- a/kod/object/active/holder/nomoveon/battler/monster/ghost.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/ghost.kod
@@ -77,7 +77,7 @@ properties:
 
    piAnimation = ANIM_NONE
    piGroup = 1
-   piDrawType = OF_FLICKERING
+   piDrawEffectFlag = OF_FLICKERING
    piDrawfx = DRAWFX_TRANSLUCENT_75
    piMinDamage = 6
    piMaxDamage = 16

--- a/kod/object/active/holder/nomoveon/battler/monster/ghost.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/ghost.kod
@@ -77,7 +77,8 @@ properties:
 
    piAnimation = ANIM_NONE
    piGroup = 1
-   piDrawfx = DRAWFX_TRANSLUCENT_75 | FLICKERING_YES
+   piDrawType = OF_FLICKERING
+   piDrawfx = DRAWFX_TRANSLUCENT_75
    piMinDamage = 6
    piMaxDamage = 16
    vrDesc = ghost_desc_rsc

--- a/kod/object/active/holder/nomoveon/battler/monster/kriipa.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/kriipa.kod
@@ -103,22 +103,22 @@ messages:
 
    GetObjectFlags()
    {
-      if (piRoofState <> STATE_ONROOF)
+      if (piRoofState = STATE_ONROOF)
       {
-         return piDrawFX | BATTLER_YES;
+         return HANGING_YES | BATTLER_YES;
       }
 
-      return piDrawFX | HANGING_YES | BATTLER_YES;
+      propagate;
    }
 
    GetMoveOnType()
    {
-      if (piRoofState <> STATE_ONROOF)
+      if (piRoofState = STATE_ONROOF)
       {
-         propagate;
+         return MOVEON_YES;
       }
 
-      return MOVEON_YES;
+      propagate;
    }
 
    TryAttack()

--- a/kod/object/active/holder/nomoveon/battler/monster/kriipa.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/kriipa.kod
@@ -105,10 +105,20 @@ messages:
    {
       if (piRoofState <> STATE_ONROOF)
       {
-         return MOVEON_NO | piDrawFX | BATTLER_YES;
+         return piDrawFX | BATTLER_YES;
       }
 
       return piDrawFX | HANGING_YES | BATTLER_YES;
+   }
+
+   GetMoveOnType()
+   {
+      if (piRoofState <> STATE_ONROOF)
+      {
+         propagate;
+      }
+
+      return MOVEON_YES;
    }
 
    TryAttack()

--- a/kod/object/active/holder/nomoveon/battler/monster/kriipa.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/kriipa.kod
@@ -105,7 +105,7 @@ messages:
    {
       if (piRoofState = STATE_ONROOF)
       {
-         return HANGING_YES | BATTLER_YES;
+         return OF_HANGING | OF_ATTACKABLE;
       }
 
       propagate;

--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -348,13 +348,13 @@ messages:
       if IsClass(poOriginal,&Player)
       {
          vrIcon = Send(poOriginal,@GetPlayerIcon);
-         piDrawfx = Send(poOriginal,@GetPlayerDrawfx);
+         piDrawfx = Send(poOriginal,@GetDrawingFlags);
          vrName = Send(poOriginal,@GetTrueName);
       }
       else
       {
          vrIcon = Send(poOriginal,@GetIcon);
-         piDrawfx = Send(poOriginal,@GetDrawfx);
+         piDrawfx = Send(poOriginal,@GetDrawingFlags);
          vrName = Send(poOriginal,@GetName);
       }
 
@@ -371,6 +371,16 @@ messages:
       }
 
       return Send(poOriginal,@GetObjectFlags);
+   }
+
+   GetDrawingFlags()
+   {
+      if poOriginal = $
+      {
+         return 0;
+      }
+
+      return Send(poOriginal,@GetDrawingFlags);
    }
 
    GetPlayerNameColor()
@@ -478,7 +488,7 @@ messages:
       if (what = poOriginal)
          AND IsClass(poOriginal,&Player)
       {
-         piDrawfx = Send(poOriginal,@GetPlayerDrawfx);
+         piDrawfx = Send(poOriginal,@GetDrawingFlags);
 
          % Players report that if a character casts a lot of
          % reflections and then changes state, e.g. by putting on lots

--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -383,14 +383,14 @@ messages:
       return Send(poOriginal,@GetPlayerNameColor);
    }
 
-   GetPlayerType()
+   GetClientObjectType()
    {
       if poOriginal = $
       {
          return 0;
       }
 
-      return Send(poOriginal,@GetPlayerType);
+      return Send(poOriginal,@GetClientObjectType);
    }
 
    GetAttackRange()

--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -348,13 +348,13 @@ messages:
       if IsClass(poOriginal,&Player)
       {
          vrIcon = Send(poOriginal,@GetPlayerIcon);
-         piDrawfx = Send(poOriginal,@GetDrawingFlags);
+         piDrawfx = Send(poOriginal,@GetDrawingEffects);
          vrName = Send(poOriginal,@GetTrueName);
       }
       else
       {
          vrIcon = Send(poOriginal,@GetIcon);
-         piDrawfx = Send(poOriginal,@GetDrawingFlags);
+         piDrawfx = Send(poOriginal,@GetDrawingEffects);
          vrName = Send(poOriginal,@GetName);
       }
 
@@ -373,14 +373,14 @@ messages:
       return Send(poOriginal,@GetObjectFlags);
    }
 
-   GetDrawingFlags()
+   GetDrawingEffects()
    {
       if poOriginal = $
       {
          return 0;
       }
 
-      return Send(poOriginal,@GetDrawingFlags);
+      return Send(poOriginal,@GetDrawingEffects);
    }
 
    GetPlayerNameColor()
@@ -488,7 +488,7 @@ messages:
       if (what = poOriginal)
          AND IsClass(poOriginal,&Player)
       {
-         piDrawfx = Send(poOriginal,@GetDrawingFlags);
+         piDrawfx = Send(poOriginal,@GetDrawingEffects);
 
          % Players report that if a character casts a lot of
          % reflections and then changes state, e.g. by putting on lots

--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -365,16 +365,32 @@ messages:
 
    GetObjectFlags()
    {
-      local iFlags;
-
       if poOriginal = $
       {
          return 0;
       }
 
-      iFlags = Send(poOriginal,@GetObjectFlags);
+      return Send(poOriginal,@GetObjectFlags);
+   }
 
-      return iFlags;
+   GetPlayerNameColor()
+   {
+      if poOriginal = $
+      {
+         return 0;
+      }
+
+      return Send(poOriginal,@GetPlayerNameColor);
+   }
+
+   GetPlayerType()
+   {
+      if poOriginal = $
+      {
+         return 0;
+      }
+
+      return Send(poOriginal,@GetPlayerType);
    }
 
    GetAttackRange()

--- a/kod/object/active/holder/nomoveon/battler/monster/revenant.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/revenant.kod
@@ -74,6 +74,7 @@ properties:
    % our private data
 
    piAnimation = ANIM_NONE
+   piDrawFx = DRAWFX_INVISIBLE
 
    poRoom = $                %% The room we are scheduled to be created in.
    poHauntee = $             %% The player we are to hunt.
@@ -260,11 +261,6 @@ messages:
       % if no body animation
 
       propagate;
-   }
-
-   GetObjectFlags()
-   {
-      return BATTLER_YES | DRAWFX_INVISIBLE;
    }
 
    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/monster/specmum.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/specmum.kod
@@ -63,7 +63,7 @@ classvars:
 properties:
 
    piDrawfx = DRAWFX_TRANSLUCENT_50
-   piDrawType = OF_FLICKERING
+   piDrawEffectFlag = OF_FLICKERING
 
 messages:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/specmum.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/specmum.kod
@@ -62,7 +62,8 @@ classvars:
 
 properties:
 
-   piDrawfx = DRAWFX_TRANSLUCENT_50 | FLICKERING_YES
+   piDrawfx = DRAWFX_TRANSLUCENT_50
+   piDrawType = OF_FLICKERING
 
 messages:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/temples/kcrjmonk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/temples/kcrjmonk.kod
@@ -68,7 +68,7 @@ classvars:
 properties:
 
    pbIllusioned = TRUE
-   piDrawType = OF_BOUNCING
+   piDrawEffectFlag = OF_BOUNCING
 
    ptGoIllusioned = $
    ptWorthyTimer = $
@@ -78,7 +78,7 @@ messages:
 
    Constructed()
    {
-      piDrawType = OF_BOUNCING;
+      piDrawEffectFlag = OF_BOUNCING;
 
       propagate;
    }
@@ -150,7 +150,7 @@ messages:
 
       pbIllusioned = FALSE;
       piDrawfx = DRAWFX_NONE;
-      piDrawType = ~OF_BOUNCING;
+      piDrawEffectFlag = ~OF_BOUNCING;
       Send(poOwner,@SomethingChanged,#what=self);
 
       if ptGoIllusioned <> $
@@ -177,7 +177,7 @@ messages:
             #type=SAY_RESOURCE);
 
       pbIllusioned = TRUE;
-      piDrawType = OF_BOUNCING;
+      piDrawEffectFlag = OF_BOUNCING;
       Send(poOwner,@SomethingChanged,#what=self);
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/monster/temples/kcrjmonk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/temples/kcrjmonk.kod
@@ -68,7 +68,7 @@ classvars:
 properties:
 
    pbIllusioned = TRUE
-   piDrawfx = BOUNCE_YES
+   piDrawType = OF_BOUNCING
 
    ptGoIllusioned = $
    ptWorthyTimer = $
@@ -78,7 +78,7 @@ messages:
 
    Constructed()
    {
-      piDrawfx = BOUNCE_YES;
+      piDrawType = OF_BOUNCING;
 
       propagate;
    }
@@ -149,7 +149,8 @@ messages:
             #type=SAY_RESOURCE);
 
       pbIllusioned = FALSE;
-      piDrawfx = DRAWFX_NO;
+      piDrawfx = DRAWFX_NONE;
+      piDrawType = ~OF_BOUNCING;
       Send(poOwner,@SomethingChanged,#what=self);
 
       if ptGoIllusioned <> $
@@ -176,7 +177,7 @@ messages:
             #type=SAY_RESOURCE);
 
       pbIllusioned = TRUE;
-      piDrawfx = BOUNCE_YES;
+      piDrawType = OF_BOUNCING;
       Send(poOwner,@SomethingChanged,#what=self);
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/decoratr.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/decoratr.kod
@@ -164,7 +164,7 @@ classvars:
 
 properties:
 
-   piDrawType = OF_BOUNCING
+   piDrawEffectFlag = OF_BOUNCING
 
    piDialogTopic = TOPIC_NONE
    ptDialogTopicTimeout = $

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/decoratr.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/decoratr.kod
@@ -160,9 +160,11 @@ classvars:
    viOccupation = MOB_ROLE_SCHOLAR
    viDefinite = ARTICLE_THE
 
+   viObject_flags = OFFER_YES
+
 properties:
 
-   piDrawfx = BOUNCE_YES
+   piDrawType = OF_BOUNCING
 
    piDialogTopic = TOPIC_NONE
    ptDialogTopicTimeout = $
@@ -192,11 +194,6 @@ messages:
       AddPacket(1,ANIMATE_CYCLE, 4,100, 2,1, 2,2);
 
       return;
-   }
-
-   GetObjectFlags()
-   {
-      return BOUNCE_YES | OFFER_YES;
    }
 
    CanMorphTo()

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/decoratr.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/decoratr.kod
@@ -160,7 +160,7 @@ classvars:
    viOccupation = MOB_ROLE_SCHOLAR
    viDefinite = ARTICLE_THE
 
-   viObject_flags = OFFER_YES
+   viObject_flags = OF_OFFERABLE
 
 properties:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/ladyphen.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/ladyphen.kod
@@ -529,7 +529,7 @@ messages:
    {
       local iFlags;
 
-      iFlags = piDrawFX;
+      iFlags = 0;
 
       if piColor = COLOR_BLUE
       {

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/ladyphen.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/ladyphen.kod
@@ -553,7 +553,7 @@ messages:
       return iFlags;
    }
 
-   GetPlayerType()
+   GetClientObjectType()
    {
       local iFlags;
 
@@ -561,7 +561,7 @@ messages:
 
       if piColor = COLOR_BLUE
       {
-         iFlags = iFlags | PF_DM;
+         iFlags = iFlags | OT_DM;
       }
 
       return iFlags;

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/ladyphen.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/ladyphen.kod
@@ -533,7 +533,35 @@ messages:
 
       if piColor = COLOR_BLUE
       {
-         iFlags = iFlags | PLAYER_DM | USER_YES ;
+         iFlags = iFlags | USER_YES;
+      }
+
+      return iFlags;
+   }
+
+   GetPlayerNameColor()
+   {
+      local iFlags;
+
+      iFlags = 0;
+
+      if piColor = COLOR_BLUE
+      {
+         iFlags = iFlags | NC_DM;
+      }
+
+      return iFlags;
+   }
+
+   GetPlayerType()
+   {
+      local iFlags;
+
+      iFlags = 0;
+
+      if piColor = COLOR_BLUE
+      {
+         iFlags = iFlags | PF_DM;
       }
 
       return iFlags;

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/ladyphen.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/ladyphen.kod
@@ -529,7 +529,7 @@ messages:
    {
       local iFlags;
 
-      iFlags = 0;
+      iFlags = viObject_flags | piDrawEffectFlag;
 
       if piColor = COLOR_BLUE
       {

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/ladyphen.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/ladyphen.kod
@@ -533,7 +533,7 @@ messages:
 
       if piColor = COLOR_BLUE
       {
-         iFlags = iFlags | USER_YES;
+         iFlags = iFlags | OF_PLAYER;
       }
 
       return iFlags;

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -979,9 +979,6 @@ properties:
    % The user's string description, typed when created (and editable in game).
    psPlayerDescription = $
 
-   % Draw effects flags
-   piDrawFX = 0
-
    % graphics stuff
 
    prLegs = player_legs_a_rsc
@@ -9376,7 +9373,7 @@ messages:
          AddPacket(1,HS_SE);
          AddPacket(4,PWO_RIGHT_HAND);
          AddPacket(4,player_window_overlay_hand);
-         AddPacket(4,0, 4,0, 4,0, 4,0, 1,0, 1,0);
+         AddPacket(4,0, 4,0, 1,0, 4,0, 4,0, 1,0, 1,0);
          AddPacket(1,ANIMATE_ONCE, 4,175, 2,1, 2,3, 2,0);
          AddPacket(1,0);
 
@@ -9407,7 +9404,7 @@ messages:
          AddPacket(1,HS_SE);
          AddPacket(4,PWO_RIGHT_HAND);
          AddPacket(4,player_window_overlay_hand);
-         AddPacket(4,0, 4,0, 4,0, 4,0, 1,0, 1,0);
+         AddPacket(4,0, 4,0, 1,0, 4,0, 4,0, 1,0, 1,0);
          AddPacket(1,ANIMATE_ONCE,4,300,2,4,2,6,2,iGroup);
          AddPacket(1,1);
          AddPacket(4,player_window_overlay_glow, 1,HS_RIGHT_HAND,
@@ -9441,8 +9438,8 @@ messages:
          AddPacket(4,Send(what,@GetWindowOverlayID)); % supposedly "object id" in client
          AddPacket(4,Send(what,@GetWindowOverlay));
          AddPacket(4,Send(what,@GetName)); % useless field, used to make client parsing easier
-         % Flags, minimapflags, namecolor, playertype, moveon type.
-         AddPacket(4,0, 4,0, 4,0, 1,0, 1,0);
+         % Flags, drawing flags, minimapflags, namecolor, playertype, moveon type.
+         AddPacket(4,0, 1,0, 4,0, 4,0, 1,0, 1,0);
          Send(what,@SendWindowOverlayAnimation);
          Send(what,@SendWindowOverlayOverlays);
 
@@ -9611,16 +9608,10 @@ messages:
       return;
    }
 
-   GetPlayerDrawfx()
-   {
-      return piDrawfx;
-   }
-
    ResetPlayerDrawfx(drawfx = 0, SendSomethingChanged = TRUE)
    {
-      piDrawfx = piDrawfx & (FLICKERING_YES | PHASING_YES | FLASHING_YES);
-      piDrawfx = piDrawfx | drawfx;
-      
+      piDrawfx = piDrawfx & drawfx;
+
       if poOwner <> $ AND SendSomethingChanged
       {
          Send(poOwner,@SomethingChanged,#what=self);
@@ -11035,14 +11026,14 @@ messages:
 
    SetFlickerFlag()
    {
-      piDrawfx = piDrawfx | FLICKERING_YES;
+      piDrawType = piDrawType | OF_FLICKERING;
 
       return;
    }
 
    ClearFlickerFlag()
    {
-      piDrawfx = piDrawfx & (~FLICKERING_YES);
+      piDrawType = piDrawType & (~OF_FLICKERING);
 
       return;
    }
@@ -11051,14 +11042,14 @@ messages:
    {
       local i;
 
-      piDrawfx = piDrawfx & (~FLICKERING_YES);
+      piDrawType = piDrawType & (~OF_FLICKERING);
       for i in plUsing
       {
          if IsClass(i,&Torch)
             OR (IsClass(i,&Weapon) 
                AND Send(i,@HasAttribute,#ItemAtt=WA_GLOWING))
          {
-            piDrawfx = piDrawfx | FLICKERING_YES;
+            piDrawType = piDrawType | OF_FLICKERING;
 
             return;
          }
@@ -13527,7 +13518,7 @@ messages:
                if Nth(oLightObject,3) = self
                   AND NOT Send(Nth(oLightObject,1),@GetOldAreaEnchStyle)
                {
-                  if (piDrawFX & FLICKERING_YES)
+                  if (piDrawType & OF_FLICKERING)
                   {
                       iIntensity = Send(Nth(oLightObject,1),@GetLightIntensity);
                       iColor = Send(Nth(oLightObject,1),@GetLightColor);
@@ -13541,7 +13532,7 @@ messages:
             }
          }
 
-         if (piDrawFX & FLICKERING_YES)
+         if (piDrawType & OF_FLICKERING)
          {
             AddPacket(2,(LIGHT_FLAG_ON | LIGHT_FLAG_DYNAMIC));
             % 75 out of 255 intensity of light

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -11026,14 +11026,14 @@ messages:
 
    SetFlickerFlag()
    {
-      piDrawType = piDrawType | OF_FLICKERING;
+      piDrawEffectFlag = piDrawEffectFlag | OF_FLICKERING;
 
       return;
    }
 
    ClearFlickerFlag()
    {
-      piDrawType = piDrawType & (~OF_FLICKERING);
+      piDrawEffectFlag = piDrawEffectFlag & (~OF_FLICKERING);
 
       return;
    }
@@ -11042,14 +11042,14 @@ messages:
    {
       local i;
 
-      piDrawType = piDrawType & (~OF_FLICKERING);
+      piDrawEffectFlag = piDrawEffectFlag & (~OF_FLICKERING);
       for i in plUsing
       {
          if IsClass(i,&Torch)
             OR (IsClass(i,&Weapon) 
                AND Send(i,@HasAttribute,#ItemAtt=WA_GLOWING))
          {
-            piDrawType = piDrawType | OF_FLICKERING;
+            piDrawEffectFlag = piDrawEffectFlag | OF_FLICKERING;
 
             return;
          }
@@ -13518,7 +13518,7 @@ messages:
                if Nth(oLightObject,3) = self
                   AND NOT Send(Nth(oLightObject,1),@GetOldAreaEnchStyle)
                {
-                  if (piDrawType & OF_FLICKERING)
+                  if (piDrawEffectFlag & OF_FLICKERING)
                   {
                       iIntensity = Send(Nth(oLightObject,1),@GetLightIntensity);
                       iColor = Send(Nth(oLightObject,1),@GetLightColor);
@@ -13532,7 +13532,7 @@ messages:
             }
          }
 
-         if (piDrawType & OF_FLICKERING)
+         if (piDrawEffectFlag & OF_FLICKERING)
          {
             AddPacket(2,(LIGHT_FLAG_ON | LIGHT_FLAG_DYNAMIC));
             % 75 out of 255 intensity of light

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -9376,7 +9376,7 @@ messages:
          AddPacket(1,HS_SE);
          AddPacket(4,PWO_RIGHT_HAND);
          AddPacket(4,player_window_overlay_hand);
-         AddPacket(4,0, 4,0, 4,0, 4,0, 1,0);
+         AddPacket(4,0, 4,0, 4,0, 4,0, 1,0, 1,0);
          AddPacket(1,ANIMATE_ONCE, 4,175, 2,1, 2,3, 2,0);
          AddPacket(1,0);
 
@@ -9407,7 +9407,7 @@ messages:
          AddPacket(1,HS_SE);
          AddPacket(4,PWO_RIGHT_HAND);
          AddPacket(4,player_window_overlay_hand);
-         AddPacket(4,0, 4,0, 4,0, 4,0, 1,0);
+         AddPacket(4,0, 4,0, 4,0, 4,0, 1,0, 1,0);
          AddPacket(1,ANIMATE_ONCE,4,300,2,4,2,6,2,iGroup);
          AddPacket(1,1);
          AddPacket(4,player_window_overlay_glow, 1,HS_RIGHT_HAND,
@@ -9441,7 +9441,8 @@ messages:
          AddPacket(4,Send(what,@GetWindowOverlayID)); % supposedly "object id" in client
          AddPacket(4,Send(what,@GetWindowOverlay));
          AddPacket(4,Send(what,@GetName)); % useless field, used to make client parsing easier
-         AddPacket(4,0, 4,0, 4,0, 1,0); % Flags, minimapflags, namecolor, playertype.
+         % Flags, minimapflags, namecolor, playertype, moveon type.
+         AddPacket(4,0, 4,0, 4,0, 1,0, 1,0);
          Send(what,@SendWindowOverlayAnimation);
          Send(what,@SendWindowOverlayOverlays);
 

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -9376,7 +9376,7 @@ messages:
          AddPacket(1,HS_SE);
          AddPacket(4,PWO_RIGHT_HAND);
          AddPacket(4,player_window_overlay_hand);
-         AddPacket(4,0, 4,0);
+         AddPacket(4,0, 4,0, 4,0, 4,0, 1,0);
          AddPacket(1,ANIMATE_ONCE, 4,175, 2,1, 2,3, 2,0);
          AddPacket(1,0);
 
@@ -9407,7 +9407,7 @@ messages:
          AddPacket(1,HS_SE);
          AddPacket(4,PWO_RIGHT_HAND);
          AddPacket(4,player_window_overlay_hand);
-         AddPacket(4,0, 4,0);
+         AddPacket(4,0, 4,0, 4,0, 4,0, 1,0);
          AddPacket(1,ANIMATE_ONCE,4,300,2,4,2,6,2,iGroup);
          AddPacket(1,1);
          AddPacket(4,player_window_overlay_glow, 1,HS_RIGHT_HAND,
@@ -9441,7 +9441,7 @@ messages:
          AddPacket(4,Send(what,@GetWindowOverlayID)); % supposedly "object id" in client
          AddPacket(4,Send(what,@GetWindowOverlay));
          AddPacket(4,Send(what,@GetName)); % useless field, used to make client parsing easier
-         AddPacket(4,0);
+         AddPacket(4,0, 4,0, 4,0, 1,0); % Flags, minimapflags, namecolor, playertype.
          Send(what,@SendWindowOverlayAnimation);
          Send(what,@SendWindowOverlayOverlays);
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -928,8 +928,9 @@ messages:
          AddPacket(4,what,4,rName);
          AddPacket(STRING_RESOURCE,rName);
          AddPacket(4,Send(what,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
+         AddPacket(4,0); % minimapflags, don't need the value here.
          AddPacket(4,Send(what,@GetPlayerNameColor));
-         AddPacket(1,Send(what,@GetPlayerType));
+         AddPacket(1,Send(what,@GetClientObjectType));
          SendPacket(poSession);
 
          if IsClass(self,&Admin) AND IsClass(what,&Admin)
@@ -2413,7 +2414,7 @@ messages:
       AddPacket(4,iFlags);
       AddPacket(4,iMinimapFlags);
       AddPacket(4,iNameColorFlags);
-      AddPacket(1,Send(what,@GetPlayerType));
+      AddPacket(1,Send(what,@GetClientObjectType));
 
       % Send the lighting information.
       Send(what,@SendLightingInformation);
@@ -2621,8 +2622,9 @@ messages:
 
          AddPacket(4,i, 4,rName, STRING_RESOURCE,rName);
          AddPacket(4,Send(i,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
+         AddPacket(4,0); % minimapflags, don't need the value here.
          AddPacket(4,Send(i,@GetPlayerNameColor));
-         AddPacket(1,Send(i,@GetPlayerType));
+         AddPacket(1,Send(i,@GetClientObjectType));
       }
       
       SendPacket(poSession);
@@ -8304,7 +8306,7 @@ messages:
       return iFlags;
    }
 
-   GetPlayerType()
+   GetClientObjectType()
    {
       local iFlags;
 
@@ -8313,13 +8315,13 @@ messages:
       % Send the appropriate flag to draw the name.
       if piFlags & PFLAG_MURDERER
       {
-         iFlags = iFlags | PF_KILLER;
+         iFlags = iFlags | OT_KILLER;
       }
       else
       {
          if (piFlags & PFLAG_OUTLAW)
          {
-            iFlags = iFlags | PF_OUTLAW;
+            iFlags = iFlags | OT_OUTLAW;
          }
       }
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2336,7 +2336,7 @@ messages:
    "show_type is used to get the look or inventory animation and overlays "
    "instead of the normal animation and overlays."
    {
-      local iFlags, iEnemyKarma, iSelfKarma, oIllusion, oOtherGuild, oRoom;
+      local iFlags, iEnemyKarma, iSelfKarma, iMinimapFlags;
 
       % Send given object's id number, name, icon, and animation info
 
@@ -2396,70 +2396,18 @@ messages:
             iFlags = (iFlags & (~FLICKERING_YES));
             iFlags = (iFlags | FLASHING_YES);
          }
-
-         if IsClass(what,&Player)
-         {
-            oIllusion = Send(what,@GetIllusionForm);
-
-            if NOT Send(what,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
-               OR oIllusion = $
-               OR NOT IsClass(oIllusion,&Monster)
-            {
-               oOtherGuild = Send(what,@GetGuild);
-               if poGuild <> $ AND oOtherGuild <> $
-               {
-                  if poGuild = oOtherGuild
-                  {
-                     iFlags = (iFlags | PLAYER_IS_GUILDMATE);
-                  }
-
-                  if Send(poGuild,@IsAlly,#otherguild=oOtherGuild)
-                     AND Send(oOtherGuild,@IsAlly,#otherguild=poGuild)
-                  {
-                     iFlags = (iFlags | PLAYER_IS_FRIEND);
-                  }
-
-                  if Send(poGuild,@IsMutualEnemy,#otherguild=oOtherGuild)
-                  {
-                     iFlags = (iFlags | PLAYER_IS_ENEMY);
-                  }
-               }
-            }
-
-            If what <> self
-               AND NOT IsClass(self,&DM)
-               AND Send(self,@AllowPlayerAttack,#victim=what,#report=FALSE,#actual=FALSE)
-            {
-               iFlags = (iFlags | PLAYER_IS_ENEMY);
-            }
-         }
-
-         if IsClass(what,&Monster)
-            AND NOT (IsClass(what,&Reflection)
-               OR IsClass(what,&EvilTwin))
-            AND Send(what,@GetMaster) <> $
-         {
-            if (Send(what,@GetMaster) = self)
-            {
-               iFlags = (iFlags | MINION_SELF);
-            }
-            else
-            {
-               iFlags = (iFlags | MINION_OTHER);
-            }
-         }
       }
 
-      oRoom = poOwner;
-      if oRoom <> $
+      iMinimapFlags = Send(self,@BuildMinimapDotFlag,#what=what);
+      if iMinimapFlags = $
       {
-         if Send(oRoom,@AreGroupedHere,#who=self,#what=what)
-         {
-            iFlags = (iFlags | PLAYER_IS_FRIEND);
-         }
+         Debug("Got $ minimapflags for self ",self,Send(self,@GetTrueName),
+            " for object ",what,Send(what,@GetTrueName));
+         iMinimapFlags = 0;
       }
 
       AddPacket(4,iFlags);
+      AddPacket(4,iMinimapFlags);
 
       % Send the lighting information.
       Send(what,@SendLightingInformation);
@@ -2490,6 +2438,102 @@ messages:
       }
 
       return;
+   }
+
+   BuildMinimapDotFlag(what=$)
+   "This message builds the minimap dot flags for each object we can see, "
+   "which is then sent to our client for drawing objects on the map/minimap."
+   {
+      local iBehavior, iFlags, oIllusion, oOtherGuild;
+
+      if what = self
+         OR what = $
+         OR poOwner <> Send(what,@GetOwner)
+      {
+         return MM_NONE;
+      }
+
+      iFlags = MM_NONE;
+
+      if IsClass(what,&Player)
+      {
+         oIllusion = Send(what,@GetIllusionForm);
+
+         if NOT Send(what,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+            OR oIllusion = $
+            OR NOT IsClass(oIllusion,&Monster)
+         {
+            % Standard player blue dot.
+            iFlags = iFlags | MM_PLAYER;
+
+            oOtherGuild = Send(what,@GetGuild);
+            if poGuild <> $ AND oOtherGuild <> $
+            {
+               if poGuild = oOtherGuild
+               {
+                  iFlags = (iFlags | MM_PLAYER_IS_GUILDMATE);
+               }
+
+               if Send(poGuild,@IsAlly,#otherguild=oOtherGuild)
+                  AND Send(oOtherGuild,@IsAlly,#otherguild=poGuild)
+               {
+                  iFlags = (iFlags | MM_PLAYER_IS_FRIEND);
+               }
+
+               if Send(poGuild,@IsMutualEnemy,#otherguild=oOtherGuild)
+               {
+                  iFlags = (iFlags | MM_PLAYER_IS_ENEMY);
+               }
+            }
+         }
+
+         % Draw a red halo for any attackable player.
+         if NOT IsClass(self,&DM)
+            AND Send(self,@AllowPlayerAttack,#victim=what,
+                     #report=FALSE,#actual=FALSE)
+         {
+            iFlags = (iFlags | MM_PLAYER_IS_ENEMY);
+         }
+      }
+
+      if IsClass(what,&Monster)
+         AND NOT (IsClass(what,&Reflection)
+            OR IsClass(what,&EvilTwin))
+      {
+         if Send(what,@GetMaster) <> $
+         {
+            if (Send(what,@GetMaster) = self)
+            {
+               iFlags = (iFlags | MM_MINION_SELF);
+            }
+            else
+            {
+               iFlags = (iFlags | MM_MINION_OTHER);
+            }
+         }
+         else
+         {
+            % Draw dots for NPCs.
+            if Send(what,@GetBehavior) & AI_NPC
+            {
+               iFlags = (iFlags | MM_NPC);
+            }
+            else
+            {
+               iFlags = (iFlags | MM_MONSTER);
+            }
+         }
+      }
+
+      if poOwner <> $
+      {
+         if Send(poOwner,@AreGroupedHere,#who=self,#what=what)
+         {
+            iFlags = (iFlags | MM_BUILDER_GROUP);
+         }
+      }
+
+      return iFlags;
    }
 
    ToCliPlayer()

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -931,6 +931,7 @@ messages:
          AddPacket(4,0); % minimapflags, don't need the value here.
          AddPacket(4,Send(what,@GetPlayerNameColor));
          AddPacket(1,Send(what,@GetClientObjectType));
+         AddPacket(1,0); % MoveOn type, don't need it here.
          SendPacket(poSession);
 
          if IsClass(self,&Admin) AND IsClass(what,&Admin)
@@ -2339,7 +2340,7 @@ messages:
    "show_type is used to get the look or inventory animation and overlays "
    "instead of the normal animation and overlays."
    {
-      local iFlags, iEnemyKarma, iSelfKarma, iMinimapFlags, iNameColorFlags;
+      local iFlags, iEnemyKarma, iSelfKarma, iMinimapFlags;
 
       % Send given object's id number, name, icon, and animation info
 
@@ -2409,12 +2410,11 @@ messages:
          iMinimapFlags = 0;
       }
 
-      iNameColorFlags = Send(what,@GetPlayerNameColor);
-
       AddPacket(4,iFlags);
       AddPacket(4,iMinimapFlags);
-      AddPacket(4,iNameColorFlags);
+      AddPacket(4,Send(what,@GetPlayerNameColor));
       AddPacket(1,Send(what,@GetClientObjectType));
+      AddPacket(1,Send(what,@GetMoveOnType));
 
       % Send the lighting information.
       Send(what,@SendLightingInformation);
@@ -2461,6 +2461,12 @@ messages:
       }
 
       iFlags = MM_NONE;
+
+      if IsClass(what,&Reflection)
+         OR IsClass(what,&EvilTwin)
+      {
+         what = Send(what,@GetMaster);
+      }
 
       if IsClass(what,&Player)
       {
@@ -2625,6 +2631,7 @@ messages:
          AddPacket(4,0); % minimapflags, don't need the value here.
          AddPacket(4,Send(i,@GetPlayerNameColor));
          AddPacket(1,Send(i,@GetClientObjectType));
+         AddPacket(1,0); % MoveOn type, don't need it here.
       }
       
       SendPacket(poSession);
@@ -8220,11 +8227,31 @@ messages:
       return ret_val;
    }
 
+   GetMoveOnType()
+   {
+      local iFlags;
+
+      iFlags = MOVEON_NO;
+
+      if Send(self,@IsPhasedOut)
+      {
+         iFlags = (iFlags & ~MOVEON_NO);
+      }
+
+      % Angeled characters cannot block other players.
+      if NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+      {
+         iFlags = (iFlags & ~MOVEON_NO);
+      }
+
+      return iFlags;
+   }
+
    GetObjectFlags()
    {
       local iFlags, oIllusion;
 
-      iFlags = MOVEON_NO | BATTLER_YES | USER_YES | OFFER_YES;
+      iFlags = BATTLER_YES | USER_YES | OFFER_YES;
 
       if (piFlags & PFLAG_INVISIBLE)
       {
@@ -8232,7 +8259,7 @@ messages:
          iFlags = iFlags & (~DRAWFX_MASK);
          iFlags = iFlags | DRAWFX_INVISIBLE;
       }
-      
+
       if (piFlags & PFLAG_SAFETY)
       {
          iFlags = iFlags | SAFETY_YES;
@@ -8254,13 +8281,7 @@ messages:
       if Send(self,@IsPhasedOut)
       {
          iFlags = iFlags | LOOK_NO;
-         iFlags = (iFlags & ~MOVEON_NO & ~BATTLER_YES & ~OFFER_YES & ~USER_YES);
-      }
-      
-      % Angeled characters cannot block other players
-      if NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
-      {
-         iFlags = (iFlags & ~MOVEON_NO);
+         iFlags = (iFlags & ~BATTLER_YES & ~OFFER_YES & ~USER_YES);
       }
 
       return iFlags;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -8272,12 +8272,12 @@ messages:
    {
       local iFlags, oIllusion;
 
-      iFlags = BATTLER_YES | USER_YES | OFFER_YES;
+      iFlags = OF_ATTACKABLE | OF_PLAYER | OF_OFFERABLE;
 
 
       if (piFlags & PFLAG_SAFETY)
       {
-         iFlags = iFlags | SAFETY_YES;
+         iFlags = iFlags | OF_SAFETY;
       }
 
       oIllusion = Send(self,@GetIllusionForm);
@@ -8287,13 +8287,13 @@ messages:
          AND oIllusion <> $
          AND IsClass(oIllusion,&Monster)
       {
-         iFlags = (iFlags & ~USER_YES & ~OFFER_YES);
+         iFlags = (iFlags & ~OF_PLAYER & ~OF_OFFERABLE);
       }
       
       if Send(self,@IsPhasedOut)
       {
-         iFlags = iFlags | LOOK_NO;
-         iFlags = (iFlags & ~BATTLER_YES & ~OFFER_YES & ~USER_YES);
+         iFlags = iFlags | OF_NOEXAMINE;
+         iFlags = (iFlags & ~OF_ATTACKABLE & ~OF_OFFERABLE & ~OF_PLAYER);
       }
 
       % Get the flashing/flickering/phasing/bouncing flags.

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -8297,7 +8297,7 @@ messages:
       }
 
       % Get the flashing/flickering/phasing/bouncing flags.
-      iFlags = iFlags | piDrawType;
+      iFlags = iFlags | piDrawEffectFlag;
 
       return iFlags;
    }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -370,7 +370,7 @@ properties:
    vrName = user_name_rsc
 
    piHomeroom
-   
+
    piLastSafeRoom = $
 
    plNew_mail = $
@@ -928,6 +928,8 @@ messages:
          AddPacket(4,what,4,rName);
          AddPacket(STRING_RESOURCE,rName);
          AddPacket(4,Send(what,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
+         AddPacket(4,Send(what,@GetPlayerNameColor));
+         AddPacket(1,Send(what,@GetPlayerType));
          SendPacket(poSession);
 
          if IsClass(self,&Admin) AND IsClass(what,&Admin)
@@ -2336,7 +2338,7 @@ messages:
    "show_type is used to get the look or inventory animation and overlays "
    "instead of the normal animation and overlays."
    {
-      local iFlags, iEnemyKarma, iSelfKarma, iMinimapFlags;
+      local iFlags, iEnemyKarma, iSelfKarma, iMinimapFlags, iNameColorFlags;
 
       % Send given object's id number, name, icon, and animation info
 
@@ -2406,8 +2408,12 @@ messages:
          iMinimapFlags = 0;
       }
 
+      iNameColorFlags = Send(what,@GetPlayerNameColor);
+
       AddPacket(4,iFlags);
       AddPacket(4,iMinimapFlags);
+      AddPacket(4,iNameColorFlags);
+      AddPacket(1,Send(what,@GetPlayerType));
 
       % Send the lighting information.
       Send(what,@SendLightingInformation);
@@ -2615,6 +2621,8 @@ messages:
 
          AddPacket(4,i, 4,rName, STRING_RESOURCE,rName);
          AddPacket(4,Send(i,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
+         AddPacket(4,Send(i,@GetPlayerNameColor));
+         AddPacket(1,Send(i,@GetPlayerType));
       }
       
       SendPacket(poSession);
@@ -8216,53 +8224,6 @@ messages:
 
       iFlags = MOVEON_NO | BATTLER_YES | USER_YES | OFFER_YES;
 
-      if IsClass(self,&Creator)
-      {
-         iFlags = iFlags | PLAYER_CREATOR;
-      }
-      else
-      {
-         if Send(self,@IsEventCharacter)
-         {
-            iFlags = iFlags | PLAYER_EVENT;
-         }
-         else
-         {
-            if Send(self,@GetDM)
-            {
-               if Send(self,@GreenNamed)
-               {
-                  iFlags = iFlags | PLAYER_SUPER;
-               }
-               else
-               {
-                  if Send(self,@IsModerator)
-                  {
-                     iFlags = iFlags | PLAYER_MODERATOR;
-                  }
-                  else
-                  {
-                     iFlags = iFlags | PLAYER_DM;
-                  }
-               }
-            }
-            else
-            {
-               if piFlags & PFLAG_MURDERER
-               {
-                  iFlags = iFlags | PLAYER_PK;
-               }
-               else
-               {
-                  if (piFlags & PFLAG_OUTLAW)
-                  {
-                     iFlags = iFlags | PLAYER_OUTLAW;
-                  }
-               }
-            }
-         }
-      }
-
       if (piFlags & PFLAG_INVISIBLE)
       {
          % invisibility overrides any other drawfx
@@ -8298,6 +8259,68 @@ messages:
       if NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
       {
          iFlags = (iFlags & ~MOVEON_NO);
+      }
+
+      return iFlags;
+   }
+
+   GetPlayerNameColor()
+   {
+      local iDrawFX, iFlags;
+
+      iFlags = 0;
+
+      % Check for any shadow form effects.
+      iDrawfX = Send(self,@GetPlayerDrawFX);
+      if (iDrawFX & DRAWFX_BLACK) = DRAWFX_BLACK
+      {
+         iFlags = iFlags | NC_SHADOW;
+      }
+
+      if piNameColor <> 0
+      {
+         iFlags = iFlags | piNameColor;
+
+         return iFlags;
+      }
+
+      % Send the appropriate flag to draw the name.
+      if piFlags & PFLAG_MURDERER
+      {
+         iFlags = iFlags | NC_KILLER;
+      }
+      else
+      {
+         if (piFlags & PFLAG_OUTLAW)
+         {
+            iFlags = iFlags | NC_OUTLAW;
+         }
+         else
+         {
+            iFlags = iFlags | NC_PLAYER;
+         }
+      }
+
+      return iFlags;
+   }
+
+   GetPlayerType()
+   {
+      local iFlags;
+
+      iFlags = 0;
+
+      % Send the appropriate flag to draw the name.
+      if piFlags & PFLAG_MURDERER
+      {
+         iFlags = iFlags | PF_KILLER;
+      }
+      else
+      {
+         if (piFlags & PFLAG_OUTLAW)
+         {
+            iFlags = iFlags | PF_OUTLAW;
+         }
       }
 
       return iFlags;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -927,7 +927,8 @@ messages:
          AddPacket(1,BP_PLAYER_ADD);
          AddPacket(4,what,4,rName);
          AddPacket(STRING_RESOURCE,rName);
-         AddPacket(4,Send(what,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
+         AddPacket(4,Send(what,@GetObjectFlags));
+         AddPacket(1,Send(what,@GetDrawingFlags) & ~DRAWFX_INVISIBLE);
          AddPacket(4,0); % minimapflags, don't need the value here.
          AddPacket(4,Send(what,@GetPlayerNameColor));
          AddPacket(1,Send(what,@GetClientObjectType));
@@ -2340,7 +2341,7 @@ messages:
    "show_type is used to get the look or inventory animation and overlays "
    "instead of the normal animation and overlays."
    {
-      local iFlags, iEnemyKarma, iSelfKarma, iMinimapFlags;
+      local iFlags, iEnemyKarma, iSelfKarma, iMinimapFlags, iDrawingFlags;
 
       % Send given object's id number, name, icon, and animation info
 
@@ -2366,14 +2367,16 @@ messages:
          AddPacket(4,Send(what,@GetApparentName));
       }
 
+      iDrawingFlags = Send(what,@GetDrawingFlags);
       iFlags = Send(what,@GetObjectFlags);
-
+      % If we can see the invisible object, remove its invis drawing flag
+      % and set it to flash instead (in object flags).
       if Send(self,@CheckPlayerFlag,#flag=PFLAG2_DETECT_INVIS,#flagset=2)
-         AND (iFlags & DRAWFX_MASK) = DRAWFX_INVISIBLE
+         AND (iDrawingFlags & DRAWFX_MASK) = DRAWFX_INVISIBLE
       {
-         iFlags = (iFlags & (~DRAWFX_MASK));
-         iFlags = (iFlags & (~FLICKERING_YES));
-         iFlags = (iFlags | FLASHING_YES);
+         iDrawingFlags = (iDrawingFlags & (~DRAWFX_MASK));
+         iFlags = (iFlags & (~OF_FLICKERING));
+         iFlags = (iFlags | OF_FLASHING);
       }
 
       if IsClass(what,&Battler)
@@ -2387,8 +2390,8 @@ messages:
             AND (IsClass(what,&Player)
                  OR (IsClass(what,&Monster) AND abs(iEnemyKarma) > iSelfKarma))
          {
-            iFlags = (iFlags & (~FLICKERING_YES));
-            iFlags = (iFlags | FLASHING_YES);
+            iFlags = (iFlags & (~OF_FLICKERING));
+            iFlags = (iFlags | OF_FLASHING);
          }
 
          if Send(self,@CheckPlayerFlag,#flag=PFLAG2_DETECT_GOOD,#flagset=2)
@@ -2397,8 +2400,8 @@ messages:
             AND (IsClass(what,&Player)
                  OR (IsClass(what,&Monster) AND iEnemyKarma > abs(iSelfKarma)))
          {
-            iFlags = (iFlags & (~FLICKERING_YES));
-            iFlags = (iFlags | FLASHING_YES);
+            iFlags = (iFlags & (~OF_FLICKERING));
+            iFlags = (iFlags | OF_FLASHING);
          }
       }
 
@@ -2411,6 +2414,7 @@ messages:
       }
 
       AddPacket(4,iFlags);
+      AddPacket(1,iDrawingFlags);
       AddPacket(4,iMinimapFlags);
       AddPacket(4,Send(what,@GetPlayerNameColor));
       AddPacket(1,Send(what,@GetClientObjectType));
@@ -2627,7 +2631,8 @@ messages:
          rName = Send(i,@GetTrueName);
 
          AddPacket(4,i, 4,rName, STRING_RESOURCE,rName);
-         AddPacket(4,Send(i,@GetObjectFlags) & ~DRAWFX_INVISIBLE);
+         AddPacket(4,Send(i,@GetObjectFlags));
+         AddPacket(1,Send(i,@GetDrawingFlags) & ~DRAWFX_INVISIBLE);
          AddPacket(4,0); % minimapflags, don't need the value here.
          AddPacket(4,Send(i,@GetPlayerNameColor));
          AddPacket(1,Send(i,@GetClientObjectType));
@@ -8247,11 +8252,11 @@ messages:
       return iFlags;
    }
 
-   GetObjectFlags()
+   GetDrawingFlags()
    {
-      local iFlags, oIllusion;
+      local iFlags;
 
-      iFlags = BATTLER_YES | USER_YES | OFFER_YES;
+      iFlags = piDrawFx;
 
       if (piFlags & PFLAG_INVISIBLE)
       {
@@ -8260,13 +8265,20 @@ messages:
          iFlags = iFlags | DRAWFX_INVISIBLE;
       }
 
+      return iFlags;
+   }
+
+   GetObjectFlags()
+   {
+      local iFlags, oIllusion;
+
+      iFlags = BATTLER_YES | USER_YES | OFFER_YES;
+
+
       if (piFlags & PFLAG_SAFETY)
       {
          iFlags = iFlags | SAFETY_YES;
       }
-
-      iFlags = iFlags | (piDrawfx & DRAWFX_MASK)
-               | (piDrawfx & (FLASHING_YES | FLICKERING_YES | PHASING_YES));
 
       oIllusion = Send(self,@GetIllusionForm);
 
@@ -8284,6 +8296,9 @@ messages:
          iFlags = (iFlags & ~BATTLER_YES & ~OFFER_YES & ~USER_YES);
       }
 
+      % Get the flashing/flickering/phasing/bouncing flags.
+      iFlags = iFlags | piDrawType;
+
       return iFlags;
    }
 
@@ -8294,7 +8309,7 @@ messages:
       iFlags = 0;
 
       % Check for any shadow form effects.
-      iDrawfX = Send(self,@GetPlayerDrawFX);
+      iDrawfX = Send(self,@GetDrawingFlags);
       if (iDrawFX & DRAWFX_BLACK) = DRAWFX_BLACK
       {
          iFlags = iFlags | NC_SHADOW;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -928,7 +928,7 @@ messages:
          AddPacket(4,what,4,rName);
          AddPacket(STRING_RESOURCE,rName);
          AddPacket(4,Send(what,@GetObjectFlags));
-         AddPacket(1,Send(what,@GetDrawingFlags) & ~DRAWFX_INVISIBLE);
+         AddPacket(1,Send(what,@GetDrawingEffects) & ~DRAWFX_INVISIBLE);
          AddPacket(4,0); % minimapflags, don't need the value here.
          AddPacket(4,Send(what,@GetPlayerNameColor));
          AddPacket(1,Send(what,@GetClientObjectType));
@@ -2367,7 +2367,7 @@ messages:
          AddPacket(4,Send(what,@GetApparentName));
       }
 
-      iDrawingFlags = Send(what,@GetDrawingFlags);
+      iDrawingFlags = Send(what,@GetDrawingEffects);
       iFlags = Send(what,@GetObjectFlags);
       % If we can see the invisible object, remove its invis drawing flag
       % and set it to flash instead (in object flags).
@@ -2632,7 +2632,7 @@ messages:
 
          AddPacket(4,i, 4,rName, STRING_RESOURCE,rName);
          AddPacket(4,Send(i,@GetObjectFlags));
-         AddPacket(1,Send(i,@GetDrawingFlags) & ~DRAWFX_INVISIBLE);
+         AddPacket(1,Send(i,@GetDrawingEffects) & ~DRAWFX_INVISIBLE);
          AddPacket(4,0); % minimapflags, don't need the value here.
          AddPacket(4,Send(i,@GetPlayerNameColor));
          AddPacket(1,Send(i,@GetClientObjectType));
@@ -8252,7 +8252,7 @@ messages:
       return iFlags;
    }
 
-   GetDrawingFlags()
+   GetDrawingEffects()
    {
       local iFlags;
 
@@ -8309,7 +8309,7 @@ messages:
       iFlags = 0;
 
       % Check for any shadow form effects.
-      iDrawfX = Send(self,@GetDrawingFlags);
+      iDrawfX = Send(self,@GetDrawingEffects);
       if (iDrawFX & DRAWFX_BLACK) = DRAWFX_BLACK
       {
          iFlags = iFlags | NC_SHADOW;

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
@@ -872,7 +872,7 @@ messages:
             piAttack_start = 1;
             piAttack_end = 1;
             piAttack_delay = 500;
-            Send(self,@ResetPlayerDrawfx,#drawfx=DRAWFX_NO);
+            Send(self,@ResetPlayerDrawfx,#drawfx=DRAWFX_NONE);
             piDMFlags = piDMFlags & ~DMFLAG_INVISIBLE;
             piDMFlags = piDMFlags & ~DMFLAG_SHADOW;
             Send(self,@ResetPlayerFlagList);
@@ -898,7 +898,7 @@ messages:
             Send(self,@MsgSendUser,#message_rsc=dm_plain);
             Send(self,@SetPlayerFlag,#flag=PFLAG_INVISIBLE,#value=FALSE);
             Send(self,@SetPlayerFlag,#flag=PFLAG_ANONYMOUS,#value=FALSE);
-            Send(self,@ResetPlayerDrawfx,#drawfx=DRAWFX_NO);
+            Send(self,@ResetPlayerDrawfx,#drawfx=DRAWFX_NONE);
 
             piDMFlags = piDMFlags & ~DMFLAG_INVISIBLE;
             piDMFlags = piDMFlags & ~DMFLAG_SHADOW;
@@ -1820,7 +1820,7 @@ messages:
       iFlags = 0;
 
       % Check for any shadow form effects.
-      iDrawfX = Send(self,@GetPlayerDrawFX);
+      iDrawfX = Send(self,@GetDrawingFlags);
       if (iDrawFX & DRAWFX_BLACK) = DRAWFX_BLACK
       {
          iFlags = iFlags | NC_SHADOW;

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
@@ -1774,7 +1774,7 @@ messages:
       return pbAppeal & 1;
    }
 
-   GetPlayerType()
+   GetClientObjectType()
    {
       local iFlags;
 
@@ -1782,29 +1782,29 @@ messages:
 
       if IsClass(self,&Creator)
       {
-         iFlags = iFlags | PF_CREATOR;
+         iFlags = iFlags | OT_CREATOR;
       }
       else
       {
          if Send(self,@IsEventCharacter)
          {
-            iFlags = iFlags | PF_EVENTCHAR;
+            iFlags = iFlags | OT_EVENTCHAR;
          }
          else
          {
             if pbImmortalSave = 2
             {
-               iFlags = iFlags | PF_SUPER;
+               iFlags = iFlags | OT_SUPER;
             }
             else
             {
                if prRank = dm_moderator
                {
-                  iFlags = iFlags | PF_MODERATOR;
+                  iFlags = iFlags | OT_MODERATOR;
                }
                else
                {
-                  iFlags = iFlags | PF_DM;
+                  iFlags = iFlags | OT_DM;
                }
             }
          }

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
@@ -1774,6 +1774,98 @@ messages:
       return pbAppeal & 1;
    }
 
+   GetPlayerType()
+   {
+      local iFlags;
+
+      iFlags = 0;
+
+      if IsClass(self,&Creator)
+      {
+         iFlags = iFlags | PF_CREATOR;
+      }
+      else
+      {
+         if Send(self,@IsEventCharacter)
+         {
+            iFlags = iFlags | PF_EVENTCHAR;
+         }
+         else
+         {
+            if pbImmortalSave = 2
+            {
+               iFlags = iFlags | PF_SUPER;
+            }
+            else
+            {
+               if prRank = dm_moderator
+               {
+                  iFlags = iFlags | PF_MODERATOR;
+               }
+               else
+               {
+                  iFlags = iFlags | PF_DM;
+               }
+            }
+         }
+      }
+
+      return iFlags;
+   }
+
+   GetPlayerNameColor()
+   {
+      local iDrawFX, iFlags;
+
+      iFlags = 0;
+
+      % Check for any shadow form effects.
+      iDrawfX = Send(self,@GetPlayerDrawFX);
+      if (iDrawFX & DRAWFX_BLACK) = DRAWFX_BLACK
+      {
+         iFlags = iFlags | NC_SHADOW;
+      }
+
+      if piNameColor <> 0
+      {
+         iFlags = iFlags | piNameColor;
+
+         return iFlags;
+      }
+
+      if IsClass(self,&Creator)
+      {
+         iFlags = iFlags | NC_CREATOR;
+      }
+      else
+      {
+         if Send(self,@IsEventCharacter)
+         {
+            iFlags = iFlags | NC_EVENTCHAR;
+         }
+         else
+         {
+            if pbImmortalSave = 2
+            {
+               iFlags = iFlags | NC_SUPER;
+            }
+            else
+            {
+               if prRank = dm_moderator
+               {
+                  iFlags = iFlags | NC_MODERATOR;
+               }
+               else
+               {
+                  iFlags = iFlags | NC_DM;
+               }
+            }
+         }
+      }
+
+      return iFlags;
+   }
+
    GreenNamed()
    {
       if pbImmortalSave = 2

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
@@ -1820,7 +1820,7 @@ messages:
       iFlags = 0;
 
       % Check for any shadow form effects.
-      iDrawfX = Send(self,@GetDrawingFlags);
+      iDrawfX = Send(self,@GetDrawingEffects);
       if (iDrawFX & DRAWFX_BLACK) = DRAWFX_BLACK
       {
          iFlags = iFlags | NC_SHADOW;

--- a/kod/object/active/holder/nomoveon/battler/player/user/escapedconvict.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/escapedconvict.kod
@@ -171,9 +171,9 @@ messages:
       propagate;
    }
 
-   GetPlayerType()
+   GetClientObjectType()
    {
-      return PF_EVENTCHAR;
+      return OT_EVENTCHAR;
    }
 
 end

--- a/kod/object/active/holder/nomoveon/battler/player/user/escapedconvict.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/escapedconvict.kod
@@ -30,13 +30,15 @@ properties:
    plAttackers = $
    % Number of attackers to keep in queue.
    piAttackers = 15
-   
+
    % List of treasure items
    plTreasure = $
-   
+
    % List of list of numbered treasure items and value
 
    pbDebug = FALSE
+
+   piNameColor = NC_EVENTCHAR
 
 messages:
 
@@ -167,6 +169,11 @@ messages:
       plAttackers = $;
 
       propagate;
+   }
+
+   GetPlayerType()
+   {
+      return PF_EVENTCHAR;
    }
 
 end

--- a/kod/object/active/holder/safebox.kod
+++ b/kod/object/active/holder/safebox.kod
@@ -21,7 +21,7 @@ resources:
 
 classvars:
 
-   viObject_flags = CONTAINER_YES
+   viObject_flags = OF_CONTAINER
 
    viBulk_hold_max = 2500
    viWeight_hold_max = $

--- a/kod/object/active/holder/storebox.kod
+++ b/kod/object/active/holder/storebox.kod
@@ -36,7 +36,7 @@ classvars:
 properties:
 
    % Placed here so we can change it when locked.
-   viObject_flags = CONTAINER_YES
+   viObject_flags = OF_CONTAINER
 
    pbLocked = FALSE
    ptClean = $
@@ -48,7 +48,7 @@ messages:
       if bLocked
       {
          pbLocked = TRUE;
-         viObject_Flags = viObject_Flags & ~CONTAINER_YES;
+         viObject_Flags = viObject_Flags & ~OF_CONTAINER;
       }
 
       propagate;
@@ -192,12 +192,12 @@ messages:
 
       if pbLocked
       {
-         viObject_Flags = viObject_Flags & ~CONTAINER_YES;
+         viObject_Flags = viObject_Flags & ~OF_CONTAINER;
       }
 
       if NOT pbLocked
       {
-         viObject_Flags = viObject_Flags | CONTAINER_YES;
+         viObject_Flags = viObject_Flags | OF_CONTAINER;
       }
       
       Send(poOwner,@SomethingChanged,#what=self);

--- a/kod/object/active/hotplate.kod
+++ b/kod/object/active/hotplate.kod
@@ -19,12 +19,15 @@ constants:
    include blakston.khd
 
 resources:
-   
+
    hotplate_icon_rsc = blank.bgf
 
 classvars:
 
-   viObject_flags = MOVEON_NOTIFY | LOOK_NO
+   viObject_flags = LOOK_NO
+
+   viMoveOn_type = MOVEON_NOTIFY
+
    vrIcon = hotplate_icon_rsc
 
 properties:
@@ -37,24 +40,29 @@ messages:
 
    GetObjectFlags()
    {
-      if not Send(Send(SYS, @GetSettings), @ShowHotPlates)
+      if NOT Send(Send(SYS,@GetSettings),@ShowHotPlates)
       {
-         return (MOVEON_NOTIFY | LOOK_NO);
+         return (LOOK_NO);
       }
-      
-      %% used for debugging
+
+      % Used for debugging.
 
       if piHotPlateID = 1
       {
-         return (MOVEON_NOTIFY | BATTLER_YES | USER_YES | LOOK_NO);
+         return (BATTLER_YES | USER_YES | LOOK_NO);
       }
 
-      return (MOVEON_NOTIFY | BATTLER_YES | LOOK_NO);
+      return (BATTLER_YES | LOOK_NO);
    }
 
    Constructor(hpid = 0)
-   {      
-      if hpid = $  { Debug("hotplate created with bad HPID!");  propagate; }
+   {
+      if hpid = $
+      {
+         Debug("hotplate created with bad HPID!");
+
+         propagate;
+      }
 
       piHotPlateID = hpid;
 
@@ -64,10 +72,10 @@ messages:
    SomethingMoved(what = $,new_row = $,new_col = $)
    {
       local iRow,iCol;
-      
+
       iRow = Send(self,@GetRow);
       iCol = Send(self,@GetCol);
-     
+
       if new_row = iRow AND new_col = iCol
       {
          if what = self
@@ -100,7 +108,6 @@ messages:
 
       propagate;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/hotplate.kod
+++ b/kod/object/active/hotplate.kod
@@ -24,7 +24,7 @@ resources:
 
 classvars:
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
 
    viMoveOn_type = MOVEON_NOTIFY
 
@@ -42,17 +42,17 @@ messages:
    {
       if NOT Send(Send(SYS,@GetSettings),@ShowHotPlates)
       {
-         return (LOOK_NO);
+         return (OF_NOEXAMINE);
       }
 
       % Used for debugging.
 
       if piHotPlateID = 1
       {
-         return (BATTLER_YES | USER_YES | LOOK_NO);
+         return (OF_ATTACKABLE | OF_PLAYER | OF_NOEXAMINE);
       }
 
-      return (BATTLER_YES | LOOK_NO);
+      return (OF_ATTACKABLE | OF_NOEXAMINE);
    }
 
    Constructor(hpid = 0)

--- a/kod/object/active/listener.kod
+++ b/kod/object/active/listener.kod
@@ -29,7 +29,7 @@ resources:
 classvars:
 
    viListenToEmotes = TRUE  %% toggle this if we want to ignore Emotes in the future.
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
    vrIcon = Listener_icon_rsc
 
 properties:

--- a/kod/object/active/logghost.kod
+++ b/kod/object/active/logghost.kod
@@ -1004,11 +1004,5 @@ messages:
       return poGhostedPlayer;
    }
 
-   GetObjectFlags()
-   {
-      return piDrawFX;
-   }
-
-
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/portal.kod
+++ b/kod/object/active/portal.kod
@@ -26,7 +26,7 @@ classvars:
 
    vrName = portal_name_rsc
 
-   viObject_flags = MOVEON_TELEPORTER
+   viMoveOn_type = MOVEON_TELEPORTER
 
    viAnimationSpeed = 100
    viMaxDistance = 3
@@ -163,11 +163,11 @@ messages:
       return;
    }
 
-   GetObjectFlags()
+   GetMoveOnType()
    {
       if NOT pbAnimate
       {
-         return MOVEON_NO;
+         return (viMoveOn_type | MOVEON_NO);
       }
 
       propagate;

--- a/kod/object/active/portal/corpnode.kod
+++ b/kod/object/active/portal/corpnode.kod
@@ -38,7 +38,7 @@ classvars:
 
    vrName = corpsenode_name_rsc
 
-   viObject_flags = ACTIVATE_YES | DRAWFX_TRANSLUCENT_75
+   viObject_flags = ACTIVATE_YES
    viMoveOn_type = MOVEON_TELEPORTER
 
    viAnimationSpeed = 400
@@ -49,6 +49,7 @@ properties:
    vrDesc = corpsenode_desc_rsc
 
    piNode_num = NODE_CORPSENODE
+   piDrawFx = DRAWFX_TRANSLUCENT_75
 
 messages:
 

--- a/kod/object/active/portal/corpnode.kod
+++ b/kod/object/active/portal/corpnode.kod
@@ -38,7 +38,7 @@ classvars:
 
    vrName = corpsenode_name_rsc
 
-   viObject_flags = ACTIVATE_YES
+   viObject_flags = OF_ACTIVATABLE
    viMoveOn_type = MOVEON_TELEPORTER
 
    viAnimationSpeed = 400

--- a/kod/object/active/portal/corpnode.kod
+++ b/kod/object/active/portal/corpnode.kod
@@ -38,7 +38,8 @@ classvars:
 
    vrName = corpsenode_name_rsc
 
-   viObject_flags = MOVEON_TELEPORTER | ACTIVATE_YES | DRAWFX_TRANSLUCENT_75
+   viObject_flags = ACTIVATE_YES | DRAWFX_TRANSLUCENT_75
+   viMoveOn_type = MOVEON_TELEPORTER
 
    viAnimationSpeed = 400
 

--- a/kod/object/active/portal/corpport.kod
+++ b/kod/object/active/portal/corpport.kod
@@ -28,7 +28,8 @@ classvars:
 
    vrName = corpseportal_name_rsc
 
-   viObject_flags = MOVEON_TELEPORTER | DRAWFX_TRANSLUCENT_75
+   viObject_flags = DRAWFX_TRANSLUCENT_75
+   viMoveOn_type = MOVEON_TELEPORTER
 
    viAnimationSpeed = 400
 

--- a/kod/object/active/portal/corpport.kod
+++ b/kod/object/active/portal/corpport.kod
@@ -28,7 +28,6 @@ classvars:
 
    vrName = corpseportal_name_rsc
 
-   viObject_flags = DRAWFX_TRANSLUCENT_75
    viMoveOn_type = MOVEON_TELEPORTER
 
    viAnimationSpeed = 400
@@ -40,6 +39,7 @@ properties:
 
    ptExpire = $
    poCorpse = $
+   piDrawFx = DRAWFX_TRANSLUCENT_75
 
 messages:
 

--- a/kod/object/active/portal/hellport.kod
+++ b/kod/object/active/portal/hellport.kod
@@ -36,7 +36,8 @@ classvars:
 
    vrName = hellportal_name_rsc
 
-   viObject_flags = MOVEON_TELEPORTER | DRAWFX_TRANSLUCENT_75
+   viObject_flags = DRAWFX_TRANSLUCENT_75
+   viMoveOn_type = MOVEON_TELEPORTER
 
    viAnimationSpeed = 400
 

--- a/kod/object/active/portal/hellport.kod
+++ b/kod/object/active/portal/hellport.kod
@@ -36,7 +36,6 @@ classvars:
 
    vrName = hellportal_name_rsc
 
-   viObject_flags = DRAWFX_TRANSLUCENT_75
    viMoveOn_type = MOVEON_TELEPORTER
 
    viAnimationSpeed = 400
@@ -50,6 +49,7 @@ properties:
 
    plPossibleLocations = $
    ptLocations = $
+   piDrawFx = DRAWFX_TRANSLUCENT_75
 
 messages:
 

--- a/kod/object/active/portal/necport.kod
+++ b/kod/object/active/portal/necport.kod
@@ -26,7 +26,7 @@ resources:
 
 classvars:
 
-   viObject_flags = MOVEON_TELEPORTER
+   viMoveOn_type = MOVEON_TELEPORTER
 
    viMaxDistance = 0
 

--- a/kod/object/active/portal/newbport.kod
+++ b/kod/object/active/portal/newbport.kod
@@ -35,7 +35,7 @@ resources:
 
 classvars:
 
-   viObject_flags = MOVEON_TELEPORTER
+   viMoveOn_type = MOVEON_TELEPORTER
 
 properties:
 

--- a/kod/object/active/radiustotem.kod
+++ b/kod/object/active/radiustotem.kod
@@ -20,7 +20,7 @@ resources:
    
 classvars:
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
    vrIcon = RadiusEnchantmentTotem_icon_rsc
 
 properties:

--- a/kod/object/active/spidtree.kod
+++ b/kod/object/active/spidtree.kod
@@ -30,10 +30,9 @@ classvars:
    vrIcon = SpiderTree_icon_rsc
    vrDesc = SpiderTree_desc_rsc
 
-   viObject_flags = MOVEON_TELEPORTER
+   viMoveOn_type = MOVEON_TELEPORTER
 
 properties:
-   
 
    piDest_room = RID_DEFAULT
    piDest_angle

--- a/kod/object/active/wallelem.kod
+++ b/kod/object/active/wallelem.kod
@@ -35,7 +35,9 @@ classvars:
    vrIcon = ActiveWallElement_icon_rsc
    vrdesc = ActiveWallElement_desc_rsc
 
-   viObject_flags = LOOK_NO | MOVEON_NOTIFY
+   viObject_flags = LOOK_NO
+
+   viMoveOn_type = MOVEON_NOTIFY
 
    vrDissipateMessage = ActiveWallElement_dissipate_rsc
    vrUnaffectedMessage = ActiveWallElement_unaffected_rsc

--- a/kod/object/active/wallelem.kod
+++ b/kod/object/active/wallelem.kod
@@ -35,7 +35,7 @@ classvars:
    vrIcon = ActiveWallElement_icon_rsc
    vrdesc = ActiveWallElement_desc_rsc
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
 
    viMoveOn_type = MOVEON_NOTIFY
 

--- a/kod/object/active/wallelem/asburstc.kod
+++ b/kod/object/active/wallelem/asburstc.kod
@@ -35,7 +35,7 @@ classvars:
    vrIcon = ActiveSporeCloud_icon_rsc
    vrDesc = ActiveSporeCloud_desc_rsc
 
-   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50 | MOVEON_NOTIFY
+   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50
 
    vrDissipateMessage = ActiveSporeCloud_dissipates
    vrUnaffectedMessage = ActiveSporeCloud_unaffected

--- a/kod/object/active/wallelem/asburstc.kod
+++ b/kod/object/active/wallelem/asburstc.kod
@@ -35,7 +35,7 @@ classvars:
    vrIcon = ActiveSporeCloud_icon_rsc
    vrDesc = ActiveSporeCloud_desc_rsc
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
 
    vrDissipateMessage = ActiveSporeCloud_dissipates
    vrUnaffectedMessage = ActiveSporeCloud_unaffected

--- a/kod/object/active/wallelem/asburstc.kod
+++ b/kod/object/active/wallelem/asburstc.kod
@@ -35,7 +35,7 @@ classvars:
    vrIcon = ActiveSporeCloud_icon_rsc
    vrDesc = ActiveSporeCloud_desc_rsc
 
-   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50
+   viObject_flags = LOOK_NO
 
    vrDissipateMessage = ActiveSporeCloud_dissipates
    vrUnaffectedMessage = ActiveSporeCloud_unaffected
@@ -43,6 +43,8 @@ classvars:
    vbPeriodic = FALSE
 
 properties:
+
+   piDrawFx = DRAWFX_TRANSLUCENT_50
 
    piRangeSquared = 1
    piBonus = 1

--- a/kod/object/active/wallelem/poisfogc.kod
+++ b/kod/object/active/wallelem/poisfogc.kod
@@ -34,14 +34,14 @@ resources:
 
    PoisonFog_dissipates = "Some of the poison fog fades, then clears."
    PoisonFog_unaffected = "You hold your breath and the noxious cloud does not affect you."
-   
+
 classvars:
 
    vrName = PoisonFogCloud_name_rsc
    vrIcon = PoisonFogCloud_icon_rsc
    vrDesc = PoisonFogCloud_desc_rsc
 
-   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50 | MOVEON_NOTIFY
+   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50
 
    vrDissipateMessage = PoisonFog_dissipates
    vrUnaffectedMessage = PoisonFog_unaffected

--- a/kod/object/active/wallelem/poisfogc.kod
+++ b/kod/object/active/wallelem/poisfogc.kod
@@ -41,7 +41,7 @@ classvars:
    vrIcon = PoisonFogCloud_icon_rsc
    vrDesc = PoisonFogCloud_desc_rsc
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
 
    vrDissipateMessage = PoisonFog_dissipates
    vrUnaffectedMessage = PoisonFog_unaffected

--- a/kod/object/active/wallelem/poisfogc.kod
+++ b/kod/object/active/wallelem/poisfogc.kod
@@ -41,12 +41,14 @@ classvars:
    vrIcon = PoisonFogCloud_icon_rsc
    vrDesc = PoisonFogCloud_desc_rsc
 
-   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50
+   viObject_flags = LOOK_NO
 
    vrDissipateMessage = PoisonFog_dissipates
    vrUnaffectedMessage = PoisonFog_unaffected
 
 properties:
+
+   piDrawFx = DRAWFX_TRANSLUCENT_50
 
    piOdds = 0
 

--- a/kod/object/active/wallelem/wallfire.kod
+++ b/kod/object/active/wallelem/wallfire.kod
@@ -38,7 +38,7 @@ classvars:
    vrIcon = WallofFire_icon_rsc
    vrdesc = WallofFire_desc_rsc
 
-   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50 | FLICKERING_YES
+   viObject_flags = LOOK_NO
 
    vrDissipateMessage = firewall_dissipates
    vrUnaffectedMessage = firewall_damage0
@@ -46,6 +46,9 @@ classvars:
    viLightBonus = 15
 
 properties:
+
+   piDrawType = OF_FLICKERING
+   piDrawFx = DRAWFX_TRANSLUCENT_50
 
    viIllusion = FALSE
    piMaxDamage = 0

--- a/kod/object/active/wallelem/wallfire.kod
+++ b/kod/object/active/wallelem/wallfire.kod
@@ -38,7 +38,7 @@ classvars:
    vrIcon = WallofFire_icon_rsc
    vrdesc = WallofFire_desc_rsc
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
 
    vrDissipateMessage = firewall_dissipates
    vrUnaffectedMessage = firewall_damage0

--- a/kod/object/active/wallelem/wallfire.kod
+++ b/kod/object/active/wallelem/wallfire.kod
@@ -47,7 +47,7 @@ classvars:
 
 properties:
 
-   piDrawType = OF_FLICKERING
+   piDrawEffectFlag = OF_FLICKERING
    piDrawFx = DRAWFX_TRANSLUCENT_50
 
    viIllusion = FALSE

--- a/kod/object/active/wallelem/wallfire.kod
+++ b/kod/object/active/wallelem/wallfire.kod
@@ -38,7 +38,7 @@ classvars:
    vrIcon = WallofFire_icon_rsc
    vrdesc = WallofFire_desc_rsc
 
-   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50 | MOVEON_NOTIFY | FLICKERING_YES
+   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50 | FLICKERING_YES
 
    vrDissipateMessage = firewall_dissipates
    vrUnaffectedMessage = firewall_damage0

--- a/kod/object/active/wallelem/wallltng.kod
+++ b/kod/object/active/wallelem/wallltng.kod
@@ -49,7 +49,7 @@ classvars:
 
 properties:
 
-   piDrawType = OF_FLICKERING
+   piDrawEffectFlag = OF_FLICKERING
    piDrawFx = DRAWFX_TRANSLUCENT_50
 
    piMaxDamage = 0

--- a/kod/object/active/wallelem/wallltng.kod
+++ b/kod/object/active/wallelem/wallltng.kod
@@ -40,7 +40,7 @@ classvars:
    vrIcon = WallofLightning_icon_rsc
    vrdesc = WallofLightning_desc_rsc
 
-   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50 | FLICKERING_YES
+   viObject_flags = LOOK_NO
 
    vrDissipateMessage = lightningwall_dissipates
    vrUnaffectedMessage = lightningwall_damage0
@@ -48,6 +48,9 @@ classvars:
    viLightBonus = 7
 
 properties:
+
+   piDrawType = OF_FLICKERING
+   piDrawFx = DRAWFX_TRANSLUCENT_50
 
    piMaxDamage = 0
    ptPeriodicEffect = $

--- a/kod/object/active/wallelem/wallltng.kod
+++ b/kod/object/active/wallelem/wallltng.kod
@@ -40,7 +40,7 @@ classvars:
    vrIcon = WallofLightning_icon_rsc
    vrdesc = WallofLightning_desc_rsc
 
-   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50 | MOVEON_NOTIFY | FLICKERING_YES
+   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50 | FLICKERING_YES
 
    vrDissipateMessage = lightningwall_dissipates
    vrUnaffectedMessage = lightningwall_damage0

--- a/kod/object/active/wallelem/wallltng.kod
+++ b/kod/object/active/wallelem/wallltng.kod
@@ -40,7 +40,7 @@ classvars:
    vrIcon = WallofLightning_icon_rsc
    vrdesc = WallofLightning_desc_rsc
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
 
    vrDissipateMessage = lightningwall_dissipates
    vrUnaffectedMessage = lightningwall_damage0

--- a/kod/object/active/wallelem/web.kod
+++ b/kod/object/active/wallelem/web.kod
@@ -38,7 +38,7 @@ classvars:
    vrIcon = Web_icon_rsc
    vrdesc = Web_desc_rsc
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
 
    vrDissipateMessage = web_dissipates
    vrUnaffectedMessage = web_stick0

--- a/kod/object/active/wallelem/web.kod
+++ b/kod/object/active/wallelem/web.kod
@@ -38,7 +38,7 @@ classvars:
    vrIcon = Web_icon_rsc
    vrdesc = Web_desc_rsc
 
-   viObject_flags = LOOK_NO | MOVEON_NOTIFY
+   viObject_flags = LOOK_NO
 
    vrDissipateMessage = web_dissipates
    vrUnaffectedMessage = web_stick0

--- a/kod/object/item.kod
+++ b/kod/object/item.kod
@@ -100,7 +100,7 @@ classvars:
 
 properties:
 
-   viObject_flags = GETTABLE_YES
+   viObject_flags = OF_GETTABLE
    piHits_init = 0
    piHits = 0
       
@@ -2438,12 +2438,11 @@ messages:
       return  (iRow_diff * iRow_diff + iCol_diff * iCol_diff);
    }
 
-
    AddMagicFlag()
    {
-      if viObject_flags <> (GETTABLE_YES | ITEM_MAGIC_YES)
+      if viObject_flags <> (OF_GETTABLE | OF_ITEM_MAGIC)
       {
-         viObject_flags = viObject_flags | ITEM_MAGIC_YES;
+         viObject_flags = viObject_flags | OF_ITEM_MAGIC;
       }
 
       if poOwner <> $
@@ -2466,7 +2465,7 @@ messages:
          
          if Send(oItemAtt,@IsMagicalEffect)
          {
-            viObject_flags = viObject_flags | ITEM_MAGIC_YES;
+            viObject_flags = viObject_flags | OF_ITEM_MAGIC;
             
             if poOwner <> $
                AND IsClass(poOwner,&Player)
@@ -2478,7 +2477,7 @@ messages:
          }
       }
 
-      viObject_flags = viObject_flags & ~ITEM_MAGIC_YES;
+      viObject_flags = viObject_flags & ~OF_ITEM_MAGIC;
 
       if poOwner <> $
          AND IsClass(poOwner,&Player)

--- a/kod/object/item/passitem/gem.kod
+++ b/kod/object/item/passitem/gem.kod
@@ -35,7 +35,7 @@ properties:
 
    poSocketedObject = $
 
-   viObject_flags = APPLY_YES
+   viObject_flags = OF_APPLYABLE
 
 messages:
    

--- a/kod/object/item/passitem/minigame.kod
+++ b/kod/object/item/passitem/minigame.kod
@@ -67,7 +67,7 @@ properties:
    plObservers = $      % People who should be informed of game events (doesn't include players)
    psState = $          % Current state of game, stored as a string  
 
-   viObject_flags = ACTIVATE_YES | GETTABLE_YES
+   viObject_flags = OF_ACTIVATABLE | OF_GETTABLE
 
 messages:
    

--- a/kod/object/item/passitem/numbitem.kod
+++ b/kod/object/item/passitem/numbitem.kod
@@ -44,7 +44,7 @@ properties:
 
    piNumber = 1
    
-   viObject_flags = APPLY_YES | GETTABLE_YES
+   viObject_flags = OF_APPLYABLE | OF_GETTABLE
 
 messages:
 

--- a/kod/object/item/passitem/numbitem/ammo.kod
+++ b/kod/object/item/passitem/numbitem/ammo.kod
@@ -46,7 +46,7 @@ properties:
    piAttack_type = ATCK_WEAP_PIERCE
    piAttack_spell = 0
 
-   viObject_flags = GETTABLE_YES
+   viObject_flags = OF_GETTABLE
 
 messages:
 

--- a/kod/object/item/passitem/numbitem/food.kod
+++ b/kod/object/item/passitem/numbitem/food.kod
@@ -34,7 +34,7 @@ classvars:
 
 properties:
 
-   viObject_flags = GETTABLE_YES
+   viObject_flags = OF_GETTABLE
 
 messages:
 

--- a/kod/object/item/passitem/numbitem/money.kod
+++ b/kod/object/item/passitem/numbitem/money.kod
@@ -45,7 +45,7 @@ classvars:
 
 properties:
 
-   viObject_flags = GETTABLE_YES
+   viObject_flags = OF_GETTABLE
 
 messages:
 

--- a/kod/object/item/passitem/prism.kod
+++ b/kod/object/item/passitem/prism.kod
@@ -413,7 +413,7 @@ messages:
 
       if piGlowing
       {
-         iNewFlags = iNewFlags | FLICKERING_YES;
+         iNewFlags = iNewFlags | OF_FLICKERING;
       }
 
       return iNewFlags;

--- a/kod/object/item/passitem/prism.kod
+++ b/kod/object/item/passitem/prism.kod
@@ -409,7 +409,7 @@ messages:
    {
       local iNewFlags;
 
-      iNewFlags = viObject_flags;
+      iNewFlags = viObject_flags | piDrawEffectFlag;
 
       if piGlowing
       {

--- a/kod/object/item/passitem/qormasgift.kod
+++ b/kod/object/item/passitem/qormasgift.kod
@@ -61,10 +61,11 @@ classvars:
    viWeight = 90
    viBulk = 90
 
+properties:
 
-properties:  
+   viObject_flags = OF_NOEXAMINE | OF_GETTABLE
    vrIcon = QormasGift_icon_rsc
-   
+
    poRecipient = $
 
    % individual gift payload toggles
@@ -427,12 +428,6 @@ messages:
       
       return FALSE;
    }
-   
-   GetObjectFlags()
-   {
-      return LOOK_NO | GETTABLE_YES;
-   }
-   
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-

--- a/kod/object/item/passitem/reagentbag.kod
+++ b/kod/object/item/passitem/reagentbag.kod
@@ -39,7 +39,7 @@ properties:
 
    plReagents = $
 
-   viObject_flags = CONTAINER_YES | GETTABLE_YES
+   viObject_flags = OF_CONTAINER | OF_GETTABLE
 
 messages:
 

--- a/kod/object/item/passitem/spelitem.kod
+++ b/kod/object/item/passitem/spelitem.kod
@@ -80,7 +80,7 @@ classvars:
 properties:
 
    vrName = Spellitem_name_rsc
-   viObject_flags = GETTABLE_YES
+   viObject_flags = OF_GETTABLE
 
    % Used by the item creation spells when making a spell item at a set power.
    piSpellPower = $

--- a/kod/object/item/passitem/spelitem/potion.kod
+++ b/kod/object/item/passitem/spelitem/potion.kod
@@ -185,11 +185,11 @@ messages:
 
    SetPotionFlags()
    "This can be used to fix potions that have their "
-   "viObject_flags set to APPLY_YES."
+   "viObject_flags set to OF_APPLYABLE."
    {
-      if viObject_flags = (GETTABLE_YES | APPLY_YES)
+      if viObject_flags = (OF_GETTABLE | OF_APPLYABLE)
       {
-         viObject_flags = viObject_flags & ~APPLY_YES;
+         viObject_flags = viObject_flags & ~OF_APPLYABLE;
       }
 
       return;

--- a/kod/object/item/passitem/spelitem/wand.kod
+++ b/kod/object/item/passitem/spelitem/wand.kod
@@ -53,7 +53,7 @@ properties:
    vrName = Wand_name_rsc
    vrDesc = Wand_desc_rsc
 
-   viObject_flags = APPLY_YES | GETTABLE_YES
+   viObject_flags = OF_APPLYABLE | OF_GETTABLE
 
    % Set to negative so it doesn't expire naturally.
    piGoBadTime = -1

--- a/kod/object/item/passitem/spelitemsplit.kod
+++ b/kod/object/item/passitem/spelitemsplit.kod
@@ -47,7 +47,7 @@ classvars:
 
 properties:
 
-   viObject_flags = APPLY_YES | GETTABLE_YES
+   viObject_flags = OF_APPLYABLE | OF_GETTABLE
 
 messages:
 

--- a/kod/object/item/passitem/spelitemsplit/potionsplit.kod
+++ b/kod/object/item/passitem/spelitemsplit/potionsplit.kod
@@ -46,7 +46,7 @@ classvars:
 
 properties:
 
-   viObject_flags = APPLY_YES | GETTABLE_YES
+   viObject_flags = OF_APPLYABLE | OF_GETTABLE
 
 messages:
 

--- a/kod/object/item/passitem/spelitemsplit/scrollsplit.kod
+++ b/kod/object/item/passitem/spelitemsplit/scrollsplit.kod
@@ -47,7 +47,7 @@ classvars:
 
 properties:
 
-   viObject_flags = APPLY_YES | GETTABLE_YES
+   viObject_flags = OF_APPLYABLE | OF_GETTABLE
 
 messages:
 

--- a/kod/object/item/passitem/spelitemsplit/wandsplit.kod
+++ b/kod/object/item/passitem/spelitemsplit/wandsplit.kod
@@ -48,7 +48,7 @@ classvars:
 
 properties:
 
-   viObject_flags = APPLY_YES | GETTABLE_YES
+   viObject_flags = OF_APPLYABLE | OF_GETTABLE
 
 messages:
 

--- a/kod/object/item/passitem/totem.kod
+++ b/kod/object/item/passitem/totem.kod
@@ -49,7 +49,7 @@ classvars:
 
 properties:
 
-   viObject_flags = GETTABLE_YES | LOOK_NO
+   viObject_flags = OF_GETTABLE | OF_NOEXAMINE
 
 messages:
 

--- a/kod/object/passive/PLTNGWLL.KOD
+++ b/kod/object/passive/PLTNGWLL.KOD
@@ -18,10 +18,13 @@ classvars:
    vrName = PassiveWallofLightning_name_rsc
    vrIcon = PassiveWallofLightning_icon_rsc
 
-   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50 | FLICKERING_YES
-   vrdesc = PassiveWallofLightning_desc_rsc
+   viObject_flags = LOOK_NO
+   vrDesc = PassiveWallofLightning_desc_rsc
 
 properties:
+
+   piDrawType = OF_FLICKERING
+   piDrawFx = DRAWFX_TRANSLUCENT_50
 
    viIllusion = TRUE
 

--- a/kod/object/passive/PLTNGWLL.KOD
+++ b/kod/object/passive/PLTNGWLL.KOD
@@ -18,7 +18,7 @@ classvars:
    vrName = PassiveWallofLightning_name_rsc
    vrIcon = PassiveWallofLightning_icon_rsc
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
    vrDesc = PassiveWallofLightning_desc_rsc
 
 properties:

--- a/kod/object/passive/PLTNGWLL.KOD
+++ b/kod/object/passive/PLTNGWLL.KOD
@@ -23,7 +23,7 @@ classvars:
 
 properties:
 
-   piDrawType = OF_FLICKERING
+   piDrawEffectFlag = OF_FLICKERING
    piDrawFx = DRAWFX_TRANSLUCENT_50
 
    viIllusion = TRUE

--- a/kod/object/passive/barstool.kod
+++ b/kod/object/passive/barstool.kod
@@ -33,7 +33,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
 end

--- a/kod/object/passive/bell.kod
+++ b/kod/object/passive/bell.kod
@@ -30,7 +30,7 @@ classvars:
    vrIcon = Bell_icon_rsc
    vrDesc = Bell_desc_rsc
 
-   viObject_flags = ACTIVATE_YES
+   viObject_flags = OF_ACTIVATABLE
 
 properties:
 

--- a/kod/object/passive/body.kod
+++ b/kod/object/passive/body.kod
@@ -199,11 +199,6 @@ messages:
       return (NOT pbMob);
    }
 
-   GetObjectFlags()
-   {
-      return viObject_flags | piDrawfx;
-   }
-   
    SendAnimation()
    {
       if piBodyTrans <> 0

--- a/kod/object/passive/bookped.kod
+++ b/kod/object/passive/bookped.kod
@@ -27,6 +27,8 @@ classvars:
 
    vrIcon = bookped_icon_rsc
 
+   viMoveOn_type = MOVEON_NO
+
 properties:
 
    vrName = bookped_name_rsc
@@ -39,9 +41,14 @@ messages:
    Constructor(Name=$,Text=$)
    {
       if name <> $
-	 { vrName = name; }
+      {
+         vrName = name;
+      }
+
       if Text <> $
-	 { prText = Text; }
+      {
+         prText = Text;
+      }
 
       propagate;
    }
@@ -54,7 +61,7 @@ messages:
 
    GetObjectFlags()
    {
-      return MOVEON_NO | LOOK_NO;
+      return LOOK_NO;
    }
 
    CanEditInscription()

--- a/kod/object/passive/bookped.kod
+++ b/kod/object/passive/bookped.kod
@@ -61,7 +61,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
    CanEditInscription()

--- a/kod/object/passive/chandelr.kod
+++ b/kod/object/passive/chandelr.kod
@@ -34,7 +34,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO | HANGING_YES;
+      return OF_NOEXAMINE | OF_HANGING;
    }
 
    ReqNewOwner(what = $)

--- a/kod/object/passive/dflycage.kod
+++ b/kod/object/passive/dflycage.kod
@@ -51,7 +51,7 @@ messages:
 
    GetObjectFlags()
    {
-      return HANGING_YES;
+      return OF_HANGING;
    }
 
    SendAnimation()

--- a/kod/object/passive/dice.kod
+++ b/kod/object/passive/dice.kod
@@ -42,14 +42,14 @@ resources:
    dice_wav = dice.wav
 
 classvars:
-      
-   viObject_flags = ACTIVATE_YES 
+
+   viObject_flags = OF_ACTIVATABLE
 
 properties:
 
    vbPair = FALSE
    vrName = dice_name
-   vrDesc = dice_desc   
+   vrDesc = dice_desc
    vrIcon = dice_icon
 
    ptRoll = $     %% This is simply used to keep the spam level tolerable.  3 seconds after each roll.

--- a/kod/object/passive/dispensr.kod
+++ b/kod/object/passive/dispensr.kod
@@ -21,7 +21,7 @@ resources:
 
 classvars:
 
-   viObject_flags = ACTIVATE_YES | LOOK_NO
+   viObject_flags = OF_ACTIVATABLE | OF_NOEXAMINE
 
 properties:
 

--- a/kod/object/passive/farytree.kod
+++ b/kod/object/passive/farytree.kod
@@ -122,7 +122,7 @@ messages:
       if piKarma_state = KVERY_GOOD
          OR piKarma_state = KGOOD
       {
-         return LOOK_NO | FLICKERING_YES;
+         return LOOK_NO | OF_FLICKERING;
       }
 
       return LOOK_NO;

--- a/kod/object/passive/farytree.kod
+++ b/kod/object/passive/farytree.kod
@@ -122,10 +122,10 @@ messages:
       if piKarma_state = KVERY_GOOD
          OR piKarma_state = KGOOD
       {
-         return LOOK_NO | OF_FLICKERING;
+         return OF_NOEXAMINE | OF_FLICKERING;
       }
 
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
    SendLightingInformation()

--- a/kod/object/passive/flikerer.kod
+++ b/kod/object/passive/flikerer.kod
@@ -23,7 +23,7 @@ resources:
 
 classvars:
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
 
    % Definitions for animations
    viOff_frame = 1

--- a/kod/object/passive/flikerer.kod
+++ b/kod/object/passive/flikerer.kod
@@ -94,10 +94,10 @@ messages:
       local iFlags;
 
       iFlags = viObject_flags;
-      
+
       if pbIsLit
       {
-         iFlags = iFlags | FLICKERING_YES;
+         iFlags = iFlags | OF_FLICKERING;
       }
 
       return iFlags;

--- a/kod/object/passive/flikerer/brazier.kod
+++ b/kod/object/passive/flikerer/brazier.kod
@@ -28,7 +28,7 @@ classvars:
    vrIcon = brazier_icon_rsc
    vrDesc = brazier_desc_rsc
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
 
    % Lighting flags.  Default "on" and wavering flags
    viLightFlags = LIGHT_FLAG_ON

--- a/kod/object/passive/flikerer/bswitch.kod
+++ b/kod/object/passive/flikerer/bswitch.kod
@@ -31,7 +31,7 @@ classvars:
    vrName = brazierswitch_name_rsc
    vrIcon = brazierswitch_icon_rsc
 
-   viObject_flags = ACTIVATE_YES
+   viObject_flags = OF_ACTIVATABLE
 
 properties:
 

--- a/kod/object/passive/flikerer/candelab.kod
+++ b/kod/object/passive/flikerer/candelab.kod
@@ -33,7 +33,7 @@ classvars:
    vrIcon = candelabra_icon_rsc
    vrDesc = candelabra_desc_on
 
-   viObject_flags = ACTIVATE_YES
+   viObject_flags = OF_ACTIVATABLE
 
    viOff_frame = 1
    viStart_frame = 2

--- a/kod/object/passive/flikerer/dynlight.kod
+++ b/kod/object/passive/flikerer/dynlight.kod
@@ -144,7 +144,7 @@ messages:
       % Show up with a name and map location if we're "visible"
       if vrIcon <> DynamicLight_icon
       {
-         return (viObject_flags | BATTLER_YES | USER_YES);
+         return (viObject_flags | OF_ATTACKABLE | OF_PLAYER);
       }
 
       propagate;

--- a/kod/object/passive/flikerer/glowtree.kod
+++ b/kod/object/passive/flikerer/glowtree.kod
@@ -32,7 +32,7 @@ classvars:
    vrDesc = GlowTree_desc
    vrIcon = GlowTree_icon
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
    viMoveOn_type = MOVEON_NO
 
    viStart_frame = 1

--- a/kod/object/passive/flikerer/glowtree.kod
+++ b/kod/object/passive/flikerer/glowtree.kod
@@ -32,7 +32,8 @@ classvars:
    vrDesc = GlowTree_desc
    vrIcon = GlowTree_icon
 
-   viObject_flags = MOVEON_NO | LOOK_NO
+   viObject_flags = LOOK_NO
+   viMoveOn_type = MOVEON_NO
 
    viStart_frame = 1
    viEnd_frame = 1

--- a/kod/object/passive/flikerer/kocbraz.kod
+++ b/kod/object/passive/flikerer/kocbraz.kod
@@ -31,7 +31,7 @@ classvars:
    vrIcon = kocatanbrazier_icon_rsc
    vrDesc = kocatanbrazier_desc_rsc
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
 
    % Lighting flags.  Default "on" and wavering flags
    viLightFlags = LIGHT_FLAG_ON | LIGHT_FLAG_WAVERING

--- a/kod/object/passive/flikerer/lamp.kod
+++ b/kod/object/passive/flikerer/lamp.kod
@@ -28,7 +28,7 @@ classvars:
    vrName = lamp_name_rsc
    vrIcon = lamp_icon_rsc
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
 
    % Lighting flags.  Default "on" and wavering flags
    viLightFlags = LIGHT_FLAG_ON | LIGHT_FLAG_WAVERING

--- a/kod/object/passive/flikerer/smoke.kod
+++ b/kod/object/passive/flikerer/smoke.kod
@@ -28,7 +28,7 @@ classvars:
    vrDesc = SmokeColumn_desc
    vrIcon = SmokeColumn_icon
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
 
    viStart_frame = 1
    viEnd_frame = 5

--- a/kod/object/passive/flikerer/smoke.kod
+++ b/kod/object/passive/flikerer/smoke.kod
@@ -28,7 +28,7 @@ classvars:
    vrDesc = SmokeColumn_desc
    vrIcon = SmokeColumn_icon
 
-   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_25
+   viObject_flags = LOOK_NO
 
    viStart_frame = 1
    viEnd_frame = 5
@@ -40,6 +40,8 @@ classvars:
    viLightColor = LIGHT_FIRE
 
 properties:
+
+   piDrawFx = DRAWFX_TRANSLUCENT_25
 
    % Intensity, from 0-255.
    piLightIntensity = 10

--- a/kod/object/passive/fogcloud.kod
+++ b/kod/object/passive/fogcloud.kod
@@ -25,10 +25,12 @@ classvars:
    vrName = fogcloud_name_rsc
    vrIcon = fogcloud_icon_rsc
 
-   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50
-   vrdesc = fogcloud_desc_rsc
+   viObject_flags = LOOK_NO
+   vrDesc = fogcloud_desc_rsc
 
 properties:
+
+   piDrawFx = DRAWFX_TRANSLUCENT_50
 
    poCaster = $
    ptExpire = $

--- a/kod/object/passive/fogcloud.kod
+++ b/kod/object/passive/fogcloud.kod
@@ -25,7 +25,7 @@ classvars:
    vrName = fogcloud_name_rsc
    vrIcon = fogcloud_icon_rsc
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
    vrDesc = fogcloud_desc_rsc
 
 properties:

--- a/kod/object/passive/fountain.kod
+++ b/kod/object/passive/fountain.kod
@@ -26,6 +26,7 @@ resources:
 
 classvars:
 
+   viMoveOn_type = MOVEON_NO
    vrName = fountain_name_rsc
    vrIcon = fountain_icon_rsc
    
@@ -99,11 +100,6 @@ messages:
       AddPacket(1,ANIMATE_CYCLE, 4,100, 2,1, 2,1);
 
       return;
-   }
-
-   GetObjectFlags()
-   {
-      return MOVEON_NO;
    }
 
    AmbientLightChanged()

--- a/kod/object/passive/fountjet.kod
+++ b/kod/object/passive/fountjet.kod
@@ -28,6 +28,8 @@ classvars:
    vrIcon = fountainjet_icon_rsc
    vrDesc = fountainjet_desc_rsc
 
+   viMoveOn_type = MOVEON_NO
+
 properties:
 
    % These settings are specific to the Duke's Feast Hall (RID_DUKE2).
@@ -35,7 +37,7 @@ properties:
    piSoundIntensity = 80
 
 messages:
-   
+
    Constructor(iSoundRadius = 18, iSoundIntensity = 80)
    {
       piSoundRadius = iSoundRadius;
@@ -49,7 +51,7 @@ messages:
       if poOwner <> $ AND IsClass(poOwner,&Room)
       {
          % Remove ourselves as part of the sound list.
-         send(poOwner,@RemoveObjectLoopingSound,#what=self);
+         Send(poOwner,@RemoveObjectLoopingSound,#what=self);
       }
 
       propagate;
@@ -59,23 +61,24 @@ messages:
    {
       local lPosition, lSoundData;
 
-      % Check the old (current) owner.  It shouldn't happen, but let's be sane about it.
+      % Check the old (current) owner.  It shouldn't
+      % happen, but let's be sane about it.
       if poOwner <> $ AND IsClass(poOwner,&Room)
       {
          % Remove ourselves as part of the sound list.
-         send(poOwner,@RemoveObjectLoopingSound,#what=self);
+         Send(poOwner,@RemoveObjectLoopingSound,#what=self);
       }
 
       if piSoundRadius AND what <> $ AND IsClass(what,&Room)
       {
          % Sound data is [wave_file, row, col, cutoff radius, maximum volume, object]
-         lPosition = send(what,@GetRoomPos,#what=self);
+         lPosition = Send(what,@GetRoomPos,#what=self);
          lSoundData = [fountainjet_sound_rsc, First(lPosition), Nth(lPosition,2),
                        piSoundRadius, piSoundIntensity, self];
-         send(what,@AddLoopingSound,#lSoundData=lSoundData);
+         Send(what,@AddLoopingSound,#lSoundData=lSoundData);
       }
 
-		propagate;
+      propagate;
    }
 
    SendAnimation()
@@ -84,12 +87,6 @@ messages:
 
       return;
    }
-
-   GetObjectFlags()
-   {
-      return MOVEON_NO | LOOK_NO;
-   }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/ghostitm.kod
+++ b/kod/object/passive/ghostitm.kod
@@ -24,7 +24,7 @@ resources:
 
 classvars:  
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
    vrName = ghostItem_name_rsc
    vrDesc = ghostItem_desc_rsc
    

--- a/kod/object/passive/gldlever.kod
+++ b/kod/object/passive/gldlever.kod
@@ -54,7 +54,7 @@ classvars:
    vrIcon = guildlever_icon_rsc
    vrDesc = guildlever_desc_rsc
 
-   viObject_flags = ACTIVATE_YES
+   viObject_flags = OF_ACTIVATABLE
 
 properties:
 

--- a/kod/object/passive/gstlever.kod
+++ b/kod/object/passive/gstlever.kod
@@ -38,7 +38,7 @@ classvars:
    vrIcon = guestlever_icon_rsc
    vrDesc = guestlever_desc_rsc
 
-   viObject_flags = ACTIVATE_YES
+   viObject_flags = OF_ACTIVATABLE
 
 properties:
 

--- a/kod/object/passive/lever.kod
+++ b/kod/object/passive/lever.kod
@@ -31,7 +31,7 @@ classvars:
 
    vrName = lever_name_rsc
 
-   viObject_flags = ACTIVATE_YES
+   viObject_flags = OF_ACTIVATABLE
 
 properties:
 

--- a/kod/object/passive/mananode.kod
+++ b/kod/object/passive/mananode.kod
@@ -57,7 +57,7 @@ classvars:
 
 properties:
 
-   piDrawType = OF_FLICKERING
+   piDrawEffectFlag = OF_FLICKERING
    piDrawFx = DRAWFX_TRANSLUCENT_50
 
    vrName = ManaNode_name_rsc

--- a/kod/object/passive/mananode.kod
+++ b/kod/object/passive/mananode.kod
@@ -53,7 +53,7 @@ classvars:
 
    vrIcon = ManaNode_icon_rsc
 
-   viObject_flags = ACTIVATE_YES
+   viObject_flags = OF_ACTIVATABLE
 
 properties:
 

--- a/kod/object/passive/mananode.kod
+++ b/kod/object/passive/mananode.kod
@@ -53,9 +53,12 @@ classvars:
 
    vrIcon = ManaNode_icon_rsc
 
-   viObject_flags = ACTIVATE_YES | DRAWFX_TRANSLUCENT_50 | FLICKERING_YES
+   viObject_flags = ACTIVATE_YES
 
 properties:
+
+   piDrawType = OF_FLICKERING
+   piDrawFx = DRAWFX_TRANSLUCENT_50
 
    vrName = ManaNode_name_rsc
    vrDesc = ManaNode_desc_rsc

--- a/kod/object/passive/modlnode.kod
+++ b/kod/object/passive/modlnode.kod
@@ -39,9 +39,9 @@ classvars:
    vrIcon = ModelNode_icon_rsc
    vrDesc = ModelNode_desc_rsc
 
-   viObject_flags = DRAWFX_TRANSLUCENT_50
-
 properties:
+
+   piDrawFx = DRAWFX_TRANSLUCENT_50
 
    vrName = ModelNode_name_rsc
    piState = NODE_NORMAL

--- a/kod/object/passive/nectome.kod
+++ b/kod/object/passive/nectome.kod
@@ -62,7 +62,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
    CanEditInscription()

--- a/kod/object/passive/nectome.kod
+++ b/kod/object/passive/nectome.kod
@@ -25,6 +25,8 @@ resources:
 
 classvars:
 
+   viMoveOn_type = MOVEON_NO
+
    vrIcon = NecromancerTome_icon_rsc
 
 properties:
@@ -39,9 +41,14 @@ messages:
    Constructor(Name=$,Text=$)
    {
       if name <> $
-	 { vrName = name; }
+      {
+         vrName = name;
+      }
+
       if Text <> $
-	 { prText = Text; }
+      {
+         prText = Text;
+      }
 
       propagate;
    }
@@ -49,12 +56,13 @@ messages:
    SendLookAnimation()
    {
       AddPacket(1, ANIMATE_NONE, 2, 2);
+
       return;
    }
 
    GetObjectFlags()
    {
-      return MOVEON_NO | LOOK_NO;
+      return LOOK_NO;
    }
 
    CanEditInscription()
@@ -75,12 +83,14 @@ messages:
    ShowInscription()
    {
       AddPacket(4, prText);
+
       return;
    }
 
    ShowDesc()
    {
       AddPacket(4, vrDesc);
+
       return;
    }
 

--- a/kod/object/passive/ornobj.kod
+++ b/kod/object/passive/ornobj.kod
@@ -767,8 +767,16 @@ messages:
       local f;
 
       f = LOOK_NO;
-      if pbHanging { f = f | HANGING_YES; }
-      if pbFlicker { f = f | FLICKERING_YES; }
+
+      if pbHanging
+      {
+         f = f | HANGING_YES;
+      }
+
+      if pbFlicker
+      {
+         f = f | OF_FLICKERING;
+      }
 
       return f;
    }

--- a/kod/object/passive/ornobj.kod
+++ b/kod/object/passive/ornobj.kod
@@ -766,11 +766,11 @@ messages:
    {
       local f;
 
-      f = LOOK_NO;
+      f = OF_NOEXAMINE;
 
       if pbHanging
       {
-         f = f | HANGING_YES;
+         f = f | OF_HANGING;
       }
 
       if pbFlicker
@@ -1340,7 +1340,7 @@ messages:
       local oDuplicate;
 
       oDuplicate = create(&OrnamentalObject,#type=piType,#rName=vrName,#rIcon=vrIcon,#rDesc=vrDesc);
-      if send(self,@GetObjectFlags) & HANGING_YES
+      if send(self,@GetObjectFlags) & OF_HANGING
       {
          send(oDuplicate,@SetHanging,#value=TRUE);
       }

--- a/kod/object/passive/ornobj.kod
+++ b/kod/object/passive/ornobj.kod
@@ -769,9 +769,18 @@ messages:
       f = LOOK_NO;
       if pbHanging { f = f | HANGING_YES; }
       if pbFlicker { f = f | FLICKERING_YES; }
-      if pbNoMoveOn { f = f | MOVEON_NO; }
-      
+
       return f;
+   }
+
+   GetMoveOnType()
+   {
+      if pbNoMoveOn
+      {
+         return MOVEON_NO;
+      }
+
+      propagate;
    }
 
    SetHanging(value = TRUE)
@@ -1327,7 +1336,7 @@ messages:
       {
          send(oDuplicate,@SetHanging,#value=TRUE);
       }
-      if send(self,@GetObjectFlags) & MOVEON_NO
+      if send(self,@GetMoveOnType) & MOVEON_NO
       {
          send(oDuplicate,@SetNoMoveOn,#value=TRUE);
       }

--- a/kod/object/passive/ornobj.kod
+++ b/kod/object/passive/ornobj.kod
@@ -766,7 +766,7 @@ messages:
    {
       local f;
 
-      f = OF_NOEXAMINE;
+      f = viObject_flags | piDrawEffectFlag | OF_NOEXAMINE;
 
       if pbHanging
       {

--- a/kod/object/passive/pfirewll.kod
+++ b/kod/object/passive/pfirewll.kod
@@ -32,7 +32,7 @@ classvars:
    vrName = PassiveWallofFire_name_rsc
    vrIcon = PassiveWallofFire_icon_rsc
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
    vrdesc = PassiveWallofFire_desc_rsc
 
 properties:

--- a/kod/object/passive/pfirewll.kod
+++ b/kod/object/passive/pfirewll.kod
@@ -37,7 +37,7 @@ classvars:
 
 properties:
 
-   piDrawType = OF_FLICKERING
+   piDrawEffectFlag = OF_FLICKERING
    piDrawFx = DRAWFX_TRANSLUCENT_50
 
    viIllusion = TRUE

--- a/kod/object/passive/pfirewll.kod
+++ b/kod/object/passive/pfirewll.kod
@@ -29,14 +29,16 @@ resources:
 
 classvars:
 
-
    vrName = PassiveWallofFire_name_rsc
    vrIcon = PassiveWallofFire_icon_rsc
 
-   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50 | FLICKERING_YES
+   viObject_flags = LOOK_NO
    vrdesc = PassiveWallofFire_desc_rsc
 
 properties:
+
+   piDrawType = OF_FLICKERING
+   piDrawFx = DRAWFX_TRANSLUCENT_50
 
    viIllusion = TRUE
 

--- a/kod/object/passive/pillar.kod
+++ b/kod/object/passive/pillar.kod
@@ -38,7 +38,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
 

--- a/kod/object/passive/pillow.kod
+++ b/kod/object/passive/pillow.kod
@@ -34,7 +34,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
    SendAnimation()

--- a/kod/object/passive/psporec.kod
+++ b/kod/object/passive/psporec.kod
@@ -25,10 +25,12 @@ classvars:
    vrName = SporeCloud_name_rsc
    vrIcon = SporeCloud_icon_rsc
 
-   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50
+   viObject_flags = LOOK_NO
    vrdesc = SporeCloud_desc_rsc
 
 properties:
+
+   piDrawFx = DRAWFX_TRANSLUCENT_50
 
    poCaster = $
    ptExpire = $

--- a/kod/object/passive/psporec.kod
+++ b/kod/object/passive/psporec.kod
@@ -25,7 +25,7 @@ classvars:
    vrName = SporeCloud_name_rsc
    vrIcon = SporeCloud_icon_rsc
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
    vrdesc = SporeCloud_desc_rsc
 
 properties:

--- a/kod/object/passive/quillpen.kod
+++ b/kod/object/passive/quillpen.kod
@@ -33,7 +33,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
 end

--- a/kod/object/passive/shrinfog.kod
+++ b/kod/object/passive/shrinfog.kod
@@ -27,7 +27,7 @@ classvars:
    vrName = shrinefog_name_rsc
    vrIcon = shrinefog_icon_rsc
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
    vrdesc = shrinefog_desc_rsc
 
 properties:

--- a/kod/object/passive/shrinfog.kod
+++ b/kod/object/passive/shrinfog.kod
@@ -18,17 +18,21 @@ resources:
 
    shrinefog_name_rsc = "acidic fog"
    shrinefog_icon_rsc = poisoncl.bgf
-   shrinefog_desc_rsc = "A thick cloud of deadly looking vapor spews from the vent. The air is filled with the stench of sulfur and acid."
+   shrinefog_desc_rsc = \
+      "A thick cloud of deadly looking vapor spews from the vent. The "
+      "air is filled with the stench of sulfur and acid."
 
 classvars:
 
    vrName = shrinefog_name_rsc
    vrIcon = shrinefog_icon_rsc
 
-   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50
+   viObject_flags = LOOK_NO
    vrdesc = shrinefog_desc_rsc
 
 properties:
+
+   piDrawFx = DRAWFX_TRANSLUCENT_50
 
 messages:
 

--- a/kod/object/passive/shrub.kod
+++ b/kod/object/passive/shrub.kod
@@ -33,7 +33,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
 end

--- a/kod/object/passive/spell/illform.kod
+++ b/kod/object/passive/spell/illform.kod
@@ -125,7 +125,7 @@ messages:
       }
          
       oIllusion = Nth(Send(SYS,@GetMonsterTemplates),iIllusion_type);
-      iFX = Send(oIllusion,@GetDrawFX);
+      iFX = Send(oIllusion,@GetDrawingFlags);
 
       if oIllusion <> $ AND iFX <> 0
       {

--- a/kod/object/passive/spell/illform.kod
+++ b/kod/object/passive/spell/illform.kod
@@ -125,7 +125,7 @@ messages:
       }
          
       oIllusion = Nth(Send(SYS,@GetMonsterTemplates),iIllusion_type);
-      iFX = Send(oIllusion,@GetDrawingFlags);
+      iFX = Send(oIllusion,@GetDrawingEffects);
 
       if oIllusion <> $ AND iFX <> 0
       {

--- a/kod/object/passive/spell/morph.kod
+++ b/kod/object/passive/spell/morph.kod
@@ -201,7 +201,7 @@ messages:
          Send(who,@SetPlayerFlag,#flag=PFLAG_MORPHED,#value=TRUE);
       }
 
-      iFX = Send(oIllusion,@GetDrawingFlags);
+      iFX = Send(oIllusion,@GetDrawingEffects);
       if iFX <> 0
       {
          Send(who,@SetPlayerDrawFX,#drawfx=iFX);

--- a/kod/object/passive/spell/morph.kod
+++ b/kod/object/passive/spell/morph.kod
@@ -201,7 +201,7 @@ messages:
          Send(who,@SetPlayerFlag,#flag=PFLAG_MORPHED,#value=TRUE);
       }
 
-      iFX = Send(oIllusion,@GetDrawFX);
+      iFX = Send(oIllusion,@GetDrawingFlags);
       if iFX <> 0
       {
          Send(who,@SetPlayerDrawFX,#drawfx=iFX);

--- a/kod/object/passive/spell/persench/shadform.kod
+++ b/kod/object/passive/spell/persench/shadform.kod
@@ -79,7 +79,7 @@ messages:
       % Check for lighting effect already applied
       if oTarget <> who
       {
-         iDrawfX = Send(oTarget,@GetPlayerDrawFX);
+         iDrawfX = Send(oTarget,@GetDrawingFlags);
 
          if (iDrawFX & DRAWFX_BLACK) = DRAWFX_BLACK
             OR (iDrawFX & DRAWFX_SECONDTRANS) = DRAWFX_SECONDTRANS

--- a/kod/object/passive/spell/persench/shadform.kod
+++ b/kod/object/passive/spell/persench/shadform.kod
@@ -79,7 +79,7 @@ messages:
       % Check for lighting effect already applied
       if oTarget <> who
       {
-         iDrawfX = Send(oTarget,@GetDrawingFlags);
+         iDrawfX = Send(oTarget,@GetDrawingEffects);
 
          if (iDrawFX & DRAWFX_BLACK) = DRAWFX_BLACK
             OR (iDrawFX & DRAWFX_SECONDTRANS) = DRAWFX_SECONDTRANS

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -640,7 +640,7 @@ messages:
       return iFlags;
    }
 
-   GetNameColorFlags()
+   GetPlayerNameColor()
    {
       local iFlags;
 
@@ -664,7 +664,7 @@ messages:
       return iFlags;
    }
 
-   GetPlayerType()
+   GetClientObjectType()
    {
       local iFlags;
 
@@ -672,17 +672,17 @@ messages:
 
       if piColor = COLOR_GREEN
       {
-         iFlags = iFlags | PF_SUPER;
+         iFlags = iFlags | OT_SUPER;
       }
 
       if piColor = COLOR_BLUE
       {
-         iFlags = iFlags | PF_DM;
+         iFlags = iFlags | OT_DM;
       }
 
       if piColor = COLOR_YELLOW
       {
-         iFlags = iFlags | PF_CREATOR;
+         iFlags = iFlags | OT_CREATOR;
       }
 
       return iFlags;

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -620,7 +620,7 @@ messages:
    {
       local iFlags;
 
-      iFlags = 0;
+      iFlags = viObject_flags | piDrawEffectFlag;
 
       if piColor = COLOR_GREEN
       {

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -619,26 +619,74 @@ messages:
    GetObjectFlags()
    {
       local iFlags;
+
       iFlags = piDrawFX;
-      
+
       if piColor = COLOR_GREEN
       {
-         iFlags = iFlags | PLAYER_SUPER | USER_YES ;
+         iFlags = iFlags | USER_YES;
       }
 
       if piColor = COLOR_BLUE
       {
-         iFlags = iFlags | PLAYER_DM | USER_YES ;
+         iFlags = iFlags | USER_YES;
       }
 
       if piColor = COLOR_YELLOW
       {
-         iFlags = iFlags | PLAYER_CREATOR | USER_YES;
+         iFlags = iFlags | USER_YES;
       }
 
       return iFlags;
    }
 
+   GetNameColorFlags()
+   {
+      local iFlags;
+
+      iFlags = 0;
+
+      if piColor = COLOR_GREEN
+      {
+         iFlags = iFlags | NC_SUPER;
+      }
+
+      if piColor = COLOR_BLUE
+      {
+         iFlags = iFlags | NC_DM;
+      }
+
+      if piColor = COLOR_YELLOW
+      {
+         iFlags = iFlags | NC_CREATOR;
+      }
+
+      return iFlags;
+   }
+
+   GetPlayerType()
+   {
+      local iFlags;
+
+      iFlags = 0;
+
+      if piColor = COLOR_GREEN
+      {
+         iFlags = iFlags | PF_SUPER;
+      }
+
+      if piColor = COLOR_BLUE
+      {
+         iFlags = iFlags | PF_DM;
+      }
+
+      if piColor = COLOR_YELLOW
+      {
+         iFlags = iFlags | PF_CREATOR;
+      }
+
+      return iFlags;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -624,17 +624,17 @@ messages:
 
       if piColor = COLOR_GREEN
       {
-         iFlags = iFlags | USER_YES;
+         iFlags = iFlags | OF_PLAYER;
       }
 
       if piColor = COLOR_BLUE
       {
-         iFlags = iFlags | USER_YES;
+         iFlags = iFlags | OF_PLAYER;
       }
 
       if piColor = COLOR_YELLOW
       {
-         iFlags = iFlags | USER_YES;
+         iFlags = iFlags | OF_PLAYER;
       }
 
       return iFlags;

--- a/kod/object/passive/statue.kod
+++ b/kod/object/passive/statue.kod
@@ -614,13 +614,13 @@ messages:
    GetOriginal()
    {
       return poOriginal;
-   }  
+   }
 
    GetObjectFlags()
    {
       local iFlags;
 
-      iFlags = piDrawFX;
+      iFlags = 0;
 
       if piColor = COLOR_GREEN
       {

--- a/kod/object/passive/stool.kod
+++ b/kod/object/passive/stool.kod
@@ -33,7 +33,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
 end

--- a/kod/object/passive/switch.kod
+++ b/kod/object/passive/switch.kod
@@ -36,7 +36,7 @@ classvars:
    vrIcon = switch_icon_rsc
    vrDesc = switch_desc_rsc
 
-   viObject_flags = ACTIVATE_YES
+   viObject_flags = OF_ACTIVATABLE
 
 properties:
 

--- a/kod/object/passive/table.kod
+++ b/kod/object/passive/table.kod
@@ -35,7 +35,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
 end

--- a/kod/object/passive/table.kod
+++ b/kod/object/passive/table.kod
@@ -22,6 +22,8 @@ resources:
 
 classvars:
 
+   viMoveOn_type = MOVEON_NO
+
    vrName = table_name_rsc
    vrIcon = table_icon_rsc
    vrDesc = table_desc_rsc
@@ -33,7 +35,7 @@ messages:
 
    GetObjectFlags()
    {
-      return MOVEON_NO + LOOK_NO;
+      return LOOK_NO;
    }
 
 end

--- a/kod/object/passive/tallbush.kod
+++ b/kod/object/passive/tallbush.kod
@@ -33,7 +33,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
 end

--- a/kod/object/passive/throne.kod
+++ b/kod/object/passive/throne.kod
@@ -18,9 +18,13 @@ resources:
 
    throne_name_rsc = "throne"
    throne_icon_rsc = throne.bgf
-   throne_desc_rsc = "This looks like a very uncomfortable place to sit, even if it means you get to boss people around."
+   throne_desc_rsc = \
+      "This looks like a very uncomfortable place to sit, "
+      "even if it means you get to boss people around."
 
 classvars:
+
+   viMoveOn_type = MOVEON_NO
 
    vrName = throne_name_rsc
    vrIcon = throne_icon_rsc
@@ -35,12 +39,6 @@ messages:
    {
       return False;
    }
-
-   GetObjectFlags()
-   {
-      return MOVEON_NO;
-   }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/tombston.kod
+++ b/kod/object/passive/tombston.kod
@@ -90,7 +90,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
 end

--- a/kod/object/passive/tree.kod
+++ b/kod/object/passive/tree.kod
@@ -53,7 +53,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
 

--- a/kod/object/passive/treeoak.kod
+++ b/kod/object/passive/treeoak.kod
@@ -33,7 +33,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
 end

--- a/kod/object/passive/treepine.kod
+++ b/kod/object/passive/treepine.kod
@@ -33,7 +33,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
 end

--- a/kod/object/passive/trgtglbe.kod
+++ b/kod/object/passive/trgtglbe.kod
@@ -34,7 +34,7 @@ messages:
 
    GetObjectFlags()
    {
-      return HANGING_YES;
+      return OF_HANGING;
    }
 
 end

--- a/kod/object/passive/ventstem.kod
+++ b/kod/object/passive/ventstem.kod
@@ -25,7 +25,7 @@ classvars:
    vrName = VentCloud_name_rsc
    vrIcon = VentCloud_icon_rsc
 
-   viObject_flags = LOOK_NO
+   viObject_flags = OF_NOEXAMINE
    vrDesc = VentCloud_desc_rsc
 
 properties:

--- a/kod/object/passive/ventstem.kod
+++ b/kod/object/passive/ventstem.kod
@@ -25,13 +25,15 @@ classvars:
    vrName = VentCloud_name_rsc
    vrIcon = VentCloud_icon_rsc
 
-   viObject_flags = LOOK_NO | DRAWFX_TRANSLUCENT_50
-   vrdesc = VentCloud_desc_rsc
+   viObject_flags = LOOK_NO
+   vrDesc = VentCloud_desc_rsc
 
 properties:
 
+   piDrawFx = DRAWFX_TRANSLUCENT_50
+
 messages:
-	
+
    Delete(obj=$)
    {
       %%delete message with item disolving

--- a/kod/object/passive/viewglbe.kod
+++ b/kod/object/passive/viewglbe.kod
@@ -35,7 +35,7 @@ properties:
    vrIcon = ViewPointGlobe_icon
    vrDesc = ViewPointGlobe_desc
 
-   viObject_flags = ACTIVATE_YES
+   viObject_flags = OF_ACTIVATABLE
    poTargetGlobe = $
    piRange = 1
 

--- a/kod/object/passive/wrmtrail.kod
+++ b/kod/object/passive/wrmtrail.kod
@@ -55,7 +55,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
 end

--- a/kod/object/passive/yrxltree.kod
+++ b/kod/object/passive/yrxltree.kod
@@ -92,7 +92,7 @@ messages:
 
    GetObjectFlags()
    {
-      return LOOK_NO;
+      return OF_NOEXAMINE;
    }
 
 

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -4971,6 +4971,7 @@ messages:
       plMonsterTemplates = cons(create(&OrcWizard),plMonsterTemplates);
       plMonsterTemplates = cons(create(&DragonFly),plMonsterTemplates);
       plMonsterTemplates = cons(create(&DragonFlyQueen),plMonsterTemplates);
+      plMonsterTemplates = cons(create(&DragonFlyPet),plMonsterTemplates);
       plMonsterTemplates = cons(create(&Kriipa),plMonsterTemplates);
 
       plMonsterTemplates = cons(create(&Lich),plMonsterTemplates);

--- a/module/admin/admin.c
+++ b/module/admin/admin.c
@@ -146,7 +146,7 @@ Bool WINAPI EventUserAction(int action, void *action_data)
       if (hAdminDlg == NULL || hidden || !MouseToRoom(&x, &y))
 	 return True;
       
-      objects = GetObjects3D(x, y, 0, 0, 0);
+      objects = GetObjects3D(x, y, 0, 0, 0, 0, 0);
       if (objects == NULL)
 	 return True;
 

--- a/module/dm/dm.c
+++ b/module/dm/dm.c
@@ -168,7 +168,7 @@ Bool WINAPI EventUserAction(int action, void *action_data)
       if (!MouseToRoom(&x, &y))
 	 return True;
 
-      objects = GetObjects3D(x, y, 0, 0, 0);
+      objects = GetObjects3D(x, y, 0, 0, 0, 0, 0);
       if (objects == NULL)
 	 return True;
 

--- a/module/merintr/guildinv.c
+++ b/module/merintr/guildinv.c
@@ -35,7 +35,7 @@ BOOL CALLBACK GuildInviteDialogProc(HWND hDlg, UINT message, UINT wParam, LONG l
 	room_contents_node *r = (room_contents_node *) (l->data);
 
 	if ((r->obj.flags & OF_PLAYER) && r->obj.id != cinfo->player->id &&
-	   GetDrawingEffect(r->obj.drawingflags) != DRAWFX_INVISIBLE)
+	   r->obj.drawingflags != DRAWFX_INVISIBLE)
 	{
 	   index = ListBox_AddString(hList, LookupNameRsc(r->obj.name_res));
 	   ListBox_SetItemData(hList, index, r->obj.id);

--- a/module/merintr/guildinv.c
+++ b/module/merintr/guildinv.c
@@ -35,7 +35,7 @@ BOOL CALLBACK GuildInviteDialogProc(HWND hDlg, UINT message, UINT wParam, LONG l
 	room_contents_node *r = (room_contents_node *) (l->data);
 
 	if ((r->obj.flags & OF_PLAYER) && r->obj.id != cinfo->player->id &&
-	   GetDrawingEffect(r->obj.flags) != OF_INVISIBLE)
+	   GetDrawingEffect(r->obj.drawingflags) != DRAWFX_INVISIBLE)
 	{
 	   index = ListBox_AddString(hList, LookupNameRsc(r->obj.name_res));
 	   ListBox_SetItemData(hList, index, r->obj.id);

--- a/module/merintr/guildinv.c
+++ b/module/merintr/guildinv.c
@@ -35,7 +35,7 @@ BOOL CALLBACK GuildInviteDialogProc(HWND hDlg, UINT message, UINT wParam, LONG l
 	room_contents_node *r = (room_contents_node *) (l->data);
 
 	if ((r->obj.flags & OF_PLAYER) && r->obj.id != cinfo->player->id &&
-	   r->obj.drawingflags != DRAWFX_INVISIBLE)
+	   r->obj.drawingtype != DRAWFX_INVISIBLE)
 	{
 	   index = ListBox_AddString(hList, LookupNameRsc(r->obj.name_res));
 	   ListBox_SetItemData(hList, index, r->obj.id);

--- a/module/merintr/merintr.c
+++ b/module/merintr/merintr.c
@@ -1739,7 +1739,7 @@ Bool WINAPI EventAnimate(int dt)
 
       // If self is invisible, redraw self view to make it shimmer
       r = GetRoomObjectById(cinfo->player->id);
-      if (r != NULL && GetDrawingEffect(r->obj.drawingflags) == DRAWFX_INVISIBLE)
+      if (r != NULL && r->obj.drawingflags == DRAWFX_INVISIBLE)
 	 UserAreaRedraw();
    }
    return True;

--- a/module/merintr/merintr.c
+++ b/module/merintr/merintr.c
@@ -1739,7 +1739,7 @@ Bool WINAPI EventAnimate(int dt)
 
       // If self is invisible, redraw self view to make it shimmer
       r = GetRoomObjectById(cinfo->player->id);
-      if (r != NULL && r->obj.drawingflags == DRAWFX_INVISIBLE)
+      if (r != NULL && r->obj.drawingtype == DRAWFX_INVISIBLE)
 	 UserAreaRedraw();
    }
    return True;

--- a/module/merintr/merintr.c
+++ b/module/merintr/merintr.c
@@ -1739,7 +1739,7 @@ Bool WINAPI EventAnimate(int dt)
 
       // If self is invisible, redraw self view to make it shimmer
       r = GetRoomObjectById(cinfo->player->id);
-      if (r != NULL && GetDrawingEffect(r->obj.flags) == OF_INVISIBLE)
+      if (r != NULL && GetDrawingEffect(r->obj.drawingflags) == DRAWFX_INVISIBLE)
 	 UserAreaRedraw();
    }
    return True;


### PR DESCRIPTION
Added a new flag bitfield for minimap dot drawing (minimapflags). This is sent alongside objectflags, but only holds flags related to map dot color and halos. These are implemented as a bitvector, allowing us 27 possible flags for drawing the map dots. NPCs have been given black dots, which are always visible to the player (same as for player dots). Guild allies now show as a slightly darker green, and the original bright green is used for builder group (now its own flag). Map dots made slightly bigger. Reflections and evil twins will now show the same dot type as the master (enemy, guildmate, ally).

Added a new field (type unsigned int) containing the data used to draw player names (namecolor). Name colors are now sent as hexadecimal RGB values, and messages have been added to set/get player name color, and a property added to all objects to allow overriding the default color for that object if necessary. Colors already used have been defined as constants. The standard client will match RGB to the nearest possible palette color (so in practice, only 256 colors are possible) however the Ogre client should be able to display the actual RGB color.

As the flags for player name color were used (by Ogre client) for differentiating objects, this function has been added back as a new enumerated type (object_type). This is sent alongside all other new flags plus the old objectflags. At present this only contains the previous player name color types, however could be expanded to other objects if needed.

Added a new enumerated type (moveontype) to hold data relating to the move on type of an object (can be moved on, teleporter, notify). Also sent alongside the other flag/type fields. Added a property (viMoveon_type) to all objects, as I think this may be a useful way to handle this in the future if we want to add different effects/outcomes for interacting with an object, or having objects easily set/switched.

Moved the drawing effect flags to a separate enum BYTE (drawingtype).

Moved OF_BOUNCING to from 0x00060000 to 0x00010000 to avoid potential overlap, and allow OF_FLICKERING and OF_FLASHING to both be set (fixes some issues with torches and invisibility/detect invis).

TODO:
Verify that OF_FLASHING and OF_FLICKERING can/do work together in all cases.
Compile a list of changes to current game behavior/fixes caused by this pull request.