### PR TITLE
Remove on-hit effects (i.e. dusk rat poison) for Illusionary Form.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5118,10 +5118,10 @@ messages:
                #use_weapon=Send(self,@GetWeapon));
       }
 
-      % Morphed? As a bonus, people in illusionary form
-      % get the hit side effect.  :)
+      % Morphed?
       oMonster = Send(self,@GetIllusionForm);
-      if (oMonster <> $)
+      if oMonster <> $
+         AND Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
       {
          Send(oMonster,@HitSideEffect,#what=what);
       }


### PR DESCRIPTION
By popular demand, on-hit effects such as dusk rat poison will now only apply to Morph, and not Illusionary Form.