### PR TITLE
Another ET deletion fix, rev timer property fix. SetMaster refactor.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -1112,6 +1112,7 @@ messages:
       {
          if iRow <> 0 AND iCol <> 0
             AND Send(poMaster,@GetOwner) <> $
+            AND (piBehavior & AI_MOVE_FOLLOW_MASTER)
          {
             if ((piRow - iRow) <= 3
                AND (piCol - iCol) <= 3)
@@ -6189,6 +6190,7 @@ messages:
       return poMaster;
    }
 
+   % Evil twin and reflection have an override for this.
    SetMaster(oMaster=$)
    {
       if oMaster = $
@@ -6196,43 +6198,11 @@ messages:
          if poMaster <> $
          {
             Send(poMaster,@RemoveControlledMinion,#what=self);
-            if poOwner <> $
-            {
-               Post(poOwner,@SomethingChanged,#what=self);
-            }
 
-            % After the honeymoon is over, go after the master! Exception here
-            % are Reflections who've been captured back by the original caster.
-            % Evil twins will go after the original target.
-            if IsClass(self,&EvilTwin)
-            {
-               poMaster = Send(self,@GetCaster);
-               Send(self,@TargetSwitch,#what=Send(self,@GetIllusionForm),
-                     #iHatred=1000);
-               Send(self,@SetBehaviorFlag,#flag=AI_MOVE_FOLLOW_MASTER,
-                     #value=FALSE);
-            }
-            else
-            {
-               % Reflections return to owner's control, attacking
-               % the player who stole them.
-               if IsClass(self,&Reflection)
-               {
-                  if poMaster = Send(self,@GetOriginal)
-                  {
-                     return;
-                  }
-                  Send(self,@TargetSwitch,#what=poMaster,#iHatred=150);
-                  poMaster = Send(self,@GetOriginal);
-                  % Add ourselves back to master's control list.
-                  Send(poMaster,@NewControlledMinion,#minion=self);
-               }
-               else
-               {
-                  Send(self,@TargetSwitch,#what=poMaster,#iHatred=150);
-                  poMaster = $;
-               }
-            }
+            % After the honeymoon is over, go after the master!
+            Send(self,@TargetSwitch,#what=poMaster,#iHatred=150);
+            poMaster = $;
+
             Send(self,@EnterStateChase);
          }
       }
@@ -6240,27 +6210,22 @@ messages:
       {
          poMaster = oMaster;
 
-         if poTarget = poMaster
-         {
-            Send(self,@EnterStateWait);
-         }
-         else
-         {
-            if NOT IsClass(self,&EvilTwin)
-            {
-               Send(self,@EnterStateWait);
-            }
-         }
+         % Break target.
+         Send(self,@EnterStateWait);
 
-         if poOwner <> $
-         {
-            Post(poOwner,@SomethingChanged,#what=self);
-         }
-         if NOT Send(SYS,@IsPKAllowed) AND poTarget <> $
-         {
-            % Forget our target
-            Send(self,@EnterStateWait);
-         }
+         % Uncomment this if post-capture attack behavior changes.
+         %if NOT Send(SYS,@IsPKAllowed)
+         %   AND (poTarget <> $
+         %      AND IsClass(poTarget,&Player))
+         %{
+         %   % Forget our target
+         %   Send(self,@EnterStateWait);
+         %}
+      }
+
+      if poOwner <> $
+      {
+         Post(poOwner,@SomethingChanged,#what=self);
       }
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -3440,9 +3440,9 @@ messages:
 
       % If we have a master, they are responsible for our kills.
       if poMaster <> $
-         AND IsClass(poMaster,&Player)
       {
          if IsClass(what,&Player)
+            AND IsClass(poMaster,&Player)
          {
             % If we killed an innocent, tell the master they're in trouble.
             if (NOT Send(poMaster,@CheckPlayerFlag,#flag=PFLAG_MURDERER))

--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -167,7 +167,7 @@ messages:
          OR (poCaster <> $
             AND victim = poCaster)
       {
-         Post(self,@Delete);
+         Send(self,@Delete);
       }
 
       return;
@@ -221,17 +221,9 @@ messages:
    ReqSomethingEntered(what=$)
    {
       if poOriginal = $
+         OR NOT Send(poOriginal,@IsLoggedOn)
       {
          return;
-      }
-      else
-      {
-         if NOT Send(poOriginal,@IsLoggedOn)
-         {
-            Post(self,@Delete);
-
-            return;
-         }
       }
 
       propagate;
@@ -247,7 +239,7 @@ messages:
       if IsClass(poOriginal,&Player)
          AND NOT Send(poOriginal,@IsLoggedOn)
       {
-         Post(self,@Delete);
+         Send(self,@Delete);
 
          return;
       }
@@ -257,7 +249,7 @@ messages:
          % If target leaves room, hunt them down.
          if IsClass(Send(poOriginal,@GetOwner),&UnderWorld)
          {
-            Post(self,@Delete);
+            Send(self,@Delete);
 
             return;
          }
@@ -294,7 +286,6 @@ messages:
       }
 
       return;
-
    }
 
    GetOriginalInfo()

--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -223,7 +223,7 @@ messages:
       if poOriginal = $
          OR NOT Send(poOriginal,@IsLoggedOn)
       {
-         return;
+         return TRUE;
       }
 
       propagate;
@@ -282,6 +282,65 @@ messages:
          {
             Post(self,@TargetSwitch,#what=poOriginal,#iHatred=1000);
             Post(self,@EnterStateChase);
+         }
+      }
+
+      return;
+   }
+
+   SetMaster(oMaster=$)
+   {
+      if oMaster = $
+      {
+         if poMaster <> $
+         {
+            Send(poMaster,@RemoveControlledMinion,#what=self);
+            if poOwner <> $
+            {
+               Post(poOwner,@SomethingChanged,#what=self);
+            }
+
+            % Evil twins will go after the original target.
+            if IsClass(self,&EvilTwin)
+            {
+               poMaster = Send(self,@GetCaster);
+               Send(self,@SetBehaviorFlag,#flag=AI_MOVE_FOLLOW_MASTER,
+                     #value=FALSE);
+               Send(self,@GoToOriginal);
+            }
+         }
+      }
+      else
+      {
+         poMaster = oMaster;
+
+         if poMaster <> poCaster
+         {
+            % We've been captured, break target in case the new master
+            % doesn't want to attack them.
+            Send(self,@EnterStateWait);
+         }
+         else
+         {
+            % Original caster captured us back, break target unless we're
+            % attacking the original.
+            if poTarget <> poOriginal
+            {
+               Send(self,@EnterStateWait);
+            }
+         }
+
+         if poOwner <> $
+         {
+            Post(poOwner,@SomethingChanged,#what=self);
+         }
+
+         if NOT Send(SYS,@IsPKAllowed)
+            AND (poTarget <> $
+               AND IsClass(poTarget,&Player))
+         {
+            % Forget our target
+            Send(self,@EnterStateWait);
          }
       }
 

--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -152,7 +152,7 @@ messages:
    {
       if poOriginal = $
       {
-         return;
+         return TRUE;
       }
       else
       {
@@ -161,7 +161,7 @@ messages:
          {
             Post(self,@Delete);
 
-            return;
+            return TRUE;
          }
       }
 
@@ -198,6 +198,55 @@ messages:
       }
 
       propagate;
+   }
+
+   SetMaster(oMaster=$)
+   {
+      if oMaster = $
+      {
+         if poMaster <> $
+         {
+            % Reflections return to owner's control, attacking the player
+            % who stole them.
+
+            if poMaster = Send(self,@GetOriginal)
+            {
+               % Don't need to do anything.
+               return;
+            }
+
+            Send(poMaster,@RemoveControlledMinion,#what=self);
+            Send(self,@TargetSwitch,#what=poMaster,#iHatred=150);
+            poMaster = Send(self,@GetOriginal);
+            % Add ourselves back to master's control list.
+            Send(poMaster,@NewControlledMinion,#minion=self);
+            Send(self,@EnterStateChase);
+
+         }
+      }
+      else
+      {
+         poMaster = oMaster;
+
+         % Break target.
+         Send(self,@EnterStateWait);
+
+         % Uncomment this if post-capture attack behavior changes.
+         %if NOT Send(SYS,@IsPKAllowed)
+         %   AND (poTarget <> $
+         %      AND IsClass(poTarget,&Player))
+         %{
+         %   % Forget our target
+         %   Send(self,@EnterStateWait);
+         %}
+      }
+
+      if poOwner <> $
+      {
+         Post(poOwner,@SomethingChanged,#what=self);
+      }
+
+      return;
    }
 
    ManaDrainTimer()

--- a/kod/object/active/holder/nomoveon/battler/monster/revenant.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/revenant.kod
@@ -148,19 +148,20 @@ messages:
       local oRoom, bValid_location, iTries, iRow, iCol, iRow_sign, iCol_sign,
             iTarg_row, iTarg_col ;
 
+      ptPlace = $;
       oRoom = Send(poHauntee,@GetOwner);
-      
+
       if oRoom <> poRoom
       {
          %% target has moved on, let new revenant take over
          Send(self,@Delete);
-         
+
          return;
       }
-      
+
       iTarg_row = Send(poHauntee,@GetRow);
       iTarg_col = Send(poHauntee,@GetCol);
-      
+
       iTries = 0;
       bValid_location = FALSE;
       

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -13921,6 +13921,7 @@ messages:
       if plControlledMinions = $
          OR oTarget = $
          OR NOT IsClass(oTarget,&Battler)
+         OR IsClass(oTarget,&Revenant)
       {
          return;
       }
@@ -13938,19 +13939,15 @@ messages:
          for oActive in plControlledMinions
          {
             if IsClass(oActive,&Monster)
+               AND Send(oActive,@GetMaster) = self
+               AND Send(oActive,@GetTarget) <> oTarget
             {
-               if Send(oActive,@GetMaster) = self
-               {
-                  if Send(oActive,@GetTarget) <> oTarget
-                  {
-                     Send(oActive,@SetBehaviorFlag,
-                           #flag=AI_MOVE_FOLLOW_MASTER,#value=FALSE);
-                     Send(oActive,@TargetSwitch,#what=oTarget,
-                           #iHatred=100);
-                     Send(oActive,@EnterStateChase,#target=oTarget,
-                           #actnow=TRUE);
-                  }
-               }
+               Send(oActive,@SetBehaviorFlag,
+                     #flag=AI_MOVE_FOLLOW_MASTER,#value=FALSE);
+               Send(oActive,@TargetSwitch,#what=oTarget,
+                     #iHatred=100);
+               Send(oActive,@EnterStateChase,#target=oTarget,
+                     #actnow=TRUE);
             }
          }
       }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -826,6 +826,12 @@ messages:
       }
       poOwner = $;
 
+      % If we still have an evil twin at this stage, tell it to delete itself.
+      if poEvilTwin <> $
+      {
+         Send(poEvilTwin,@SomethingLeft,#what=self);
+      }
+
       % Check for phase out
       for j in plEnchantments
       {


### PR DESCRIPTION
Catching remaining ET deletion errors, set revenant ptPlace timer
to $ in Place, dispel ETs if the original logs off in another room
and make players killed by ETs from monsters display the correct
name for the killer.

Refactor SetMaster to handle the special ET case by having a SetMaster in
eviltwin.kod. Added a behavior flag check (for AI_MOVE_FOLLOW_MASTER) in
SomethingLeft so minions don't follow if they aren't supposed to (i.e. ET).