### PR TITLE
Speed up soldier's attack to make them a better fight

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/troop.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/troop.kod
@@ -158,7 +158,7 @@ classvars:
 
    viTreasure_type = TID_NONE
 
-   viSpeed = SPEED_AVERAGE
+   viSpeed = SPEED_FASTER
    viAttack_type = ATCK_WEAP_SLASH
    viAttributes = 0
    viDefault_behavior = AI_FIGHT_NEWBIESAFE | AI_MOVE_REGROUP


### PR DESCRIPTION
Currently a Soldier will hit you once to your 3 hits. Because of this I can kill them with a thirty hit point character with acid touch.

This should make then hit 1 for 1, making them very dangerous for characters under sixty hit points