### PR TITLE
Radius projectile angles now calculated by client, and only one BP_RADIUS_SHOOT message sent for each radius proj spell cast.

### DIFF
--- a/clientd3d/project.c
+++ b/clientd3d/project.c
@@ -149,74 +149,88 @@ Bool ProjectilesMove(int dt)
 }
 /********************************************************************/
 /*
- * RadiusProjectileAdd:  Starts a new radius projectile on its way.  Projectile goes
- *   from source object to the range limit of the spell.
+ * RadiusProjectileAdd:  Starts a new radius projectile on its way.
+ * Projectile goes from source object to the range limit of the spell.
  */
-void RadiusProjectileAdd(Projectile *p, ID source_obj, BYTE speed, WORD flags, WORD reserved, BYTE range, FLOAT initangle)
+void RadiusProjectileAdd(Projectile *p, ID source_obj, BYTE speed, WORD flags,
+                         WORD reserved, BYTE range, BYTE number)
 {
    float distance, destx, desty, radangle, fRange;
    int dx, dy, dz, destz;
    room_contents_node *s;
    fRange = range;
+   float initangle = 0.0;
 
-   // If animation off, don't bother with projectiles
+   // If animation off, don't bother with projectiles.
    if (!config.animate)
      return;
 
-   debug(("Adding new projectile\n"));
+   for (int i=1; i <= number; i++)
+   {
+      Projectile *q = (Projectile *) ZeroSafeMalloc(sizeof(Projectile));
 
-   // Set source coordinates based on object location
-   s = GetRoomObjectById(source_obj);
+      q->icon_res = p->icon_res;
+      q->translation = p->translation;
+      q->animate = p->animate;
+      q->dLighting = p->dLighting;
 
-   p->motion.source_x = s->motion.x;
-   p->motion.source_y = s->motion.y;
-   p->motion.source_z = s->motion.z; //GetPointFloor(s->motion.x, s->motion.y);
+      // Set source coordinates based on object location
+      s = GetRoomObjectById(source_obj);
+
+      q->motion.source_x = s->motion.x;
+      q->motion.source_y = s->motion.y;
+      q->motion.source_z = s->motion.z; //GetPointFloor(s->motion.x, s->motion.y);
 #if 0
-   if (source_obj == player.id)
-      p->motion.source_z += PlayerGetHeightOffset() / (FINENESS * 2);
-   else
-      p->motion.source_z += s->obj.boundingHeight / (FINENESS * 2);
+if (source_obj == player.id)
+   q->motion.source_z += PlayerGetHeightOffset() / (FINENESS * 2);
+else
+   q->motion.source_z += s->obj.boundingHeight / (FINENESS * 2);
 #endif
 
-   /* We're launching projectiles in a circle, so we need to determine
-      which angle we need to shoot this projectile, and the destination*/
+      /* We're launching projectiles in a circle, so we need to determine
+         which angle we need to shoot this projectile, and the destination. */
 
-   radangle = (initangle*3.14159)/180.0;
-   destx = s->motion.x + ((fRange*1000.0) * cos(radangle));
-   desty = s->motion.y + ((fRange*1000.0) * sin(radangle));
-   destz = s->motion.z;
+      radangle = (initangle*3.14159)/180.0;
+      destx = s->motion.x + ((fRange*1000.0) * cos(radangle));
+      desty = s->motion.y + ((fRange*1000.0) * sin(radangle));
+      destz = s->motion.z;
 #if 0
    destz += PlayerGetHeightOffset() / (FINENESS * 2);
 #endif
 
-   p->motion.dest_x = (destx);
-   p->motion.dest_y = (desty);
-   p->motion.dest_z = destz; //GetPointFloor(s->motion.x + range, s->motion.y + range);
+      q->motion.dest_x = (destx);
+      q->motion.dest_y = (desty);
+      q->motion.dest_z = destz; //GetPointFloor(s->motion.x + range, s->motion.y + range);
 
-   // See how far we should move per frame
-   dx = p->motion.dest_x - p->motion.source_x;
-   dy = p->motion.dest_y - p->motion.source_y;
-   dz = p->motion.dest_z - p->motion.source_z;
+      // See how far we should move per frame
+      dx = q->motion.dest_x - q->motion.source_x;
+      dy = q->motion.dest_y - q->motion.source_y;
+      dz = q->motion.dest_z - q->motion.source_z;
 
-   if (speed == 0 || (dx == 0 && dy == 0 && dz == 0))
-      p->motion.increment = 1.0;
-   else
-   {
-      distance = GetLongSqrt(dx * dx + dy * dy + dz * dz) / FINENESS;
-      p->motion.increment = ((float) speed) / 1000.0 / distance;
+      if (speed == 0 || (dx == 0 && dy == 0 && dz == 0))
+         q->motion.increment = 1.0;
+      else
+      {
+         distance = GetLongSqrt(dx * dx + dy * dy + dz * dz) / FINENESS;
+         q->motion.increment = ((float) speed) / 1000.0 / distance;
+      }
+
+      q->motion.x = q->motion.source_x;
+      q->motion.y = q->motion.source_y;
+      q->motion.z = q->motion.source_z;
+
+      q->motion.progress = 0.0;
+
+      // Set projectile angle.
+      q->angle = intATan2(dy, dx) & NUMDEGREES_MASK;
+
+      q->flags = flags;
+      q->reserved = reserved;
+
+      current_room.projectiles = list_add_item(current_room.projectiles, q);
+
+      // Set next angle.
+      initangle = initangle + 360.0/number;
    }
-
-   p->motion.x = p->motion.source_x;
-   p->motion.y = p->motion.source_y;
-   p->motion.z = p->motion.source_z;
-
-   p->motion.progress = 0.0;
-
-   // Set projectile angle
-   p->angle = intATan2(dy, dx) & NUMDEGREES_MASK;
-
-   p->flags = flags;
-   p->reserved = reserved;
-
-   current_room.projectiles = list_add_item(current_room.projectiles, p);
+   SafeFree(p);
 }

--- a/clientd3d/project.h
+++ b/clientd3d/project.h
@@ -29,5 +29,5 @@ typedef struct {
 
 void ProjectileAdd(Projectile *p, ID source_obj, ID dest_obj, BYTE speed, WORD flags, WORD reserved);
 Bool ProjectilesMove(int dt);
-void RadiusProjectileAdd(Projectile *p, ID source_obj, BYTE speed, WORD flags, WORD reserved, BYTE range, FLOAT initangle);
+void RadiusProjectileAdd(Projectile *p, ID source_obj, BYTE speed, WORD flags, WORD reserved, BYTE range, BYTE number);
 #endif /* #ifndef _PROJECT_H */

--- a/clientd3d/server.c
+++ b/clientd3d/server.c
@@ -1418,9 +1418,7 @@ Bool HandleRadiusShoot(char *ptr, long len)
    ID source;
    WORD flags;
    WORD reserved;
-   DWORD angle;
-   float initangle;
-   initangle = 0.0000;
+   BYTE number;
 
    Extract(&ptr, &p->icon_res, SIZE_ID);
    ExtractPaletteTranslation(&ptr,&p->translation,&p->effect);
@@ -1434,15 +1432,14 @@ Bool HandleRadiusShoot(char *ptr, long len)
    //Extract(&ptr, &reserved, SIZE_PROJECTILE_RESERVED);
    reserved = 0;
    Extract(&ptr, &range, 1);
-   Extract(&ptr, &angle, 4);
+   Extract(&ptr, &number, 1);
    ExtractDLighting(&ptr, &p->dLighting);
 
    len -= (ptr - start);
    if (len != 0)
       return False;
-   initangle = (float)angle;
 
-   RadiusProjectileAdd(p, source, speed, flags, reserved, range, initangle);
+   RadiusProjectileAdd(p, source, speed, flags, reserved, range, number);
 
    return True;
 }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -6597,47 +6597,36 @@ messages:
    {
       local iCount, iValue, iAngle;
 
-      iCount = 0;
-      iAngle = 0;
+      AddPacket(1,BP_RADIUS_SHOOT,4,Send(projectile,@GetProjectileIcon));
+      Send(projectile,@SendProjectileAnimation);
 
-      while iCount < number
+      % Send shooter.
+      AddPacket(4,who,1,speed,2,(flags & 0x000F),1,range,1,number);
+
+      if (flags & PROJ_FLAG_LIGHT_SOURCE)
       {
-         AddPacket(1,BP_RADIUS_SHOOT,4,Send(projectile,@GetProjectileIcon));
-         Send(projectile,@SendProjectileAnimation);
-
-         % Send shooter.
-         AddPacket(4,who,1,speed,2,(flags & 0x000F),1,range,4,iAngle);
-
-         if (flags & PROJ_FLAG_LIGHT_SOURCE)
+         % Lighting flags
+         iValue = Send(projectile,@GetProjectileLightFlags);
+         % Double-check for sanity
+         if iValue <> LIGHT_FLAG_NONE
          {
-            % Lighting flags
-            iValue = Send(projectile,@GetProjectileLightFlags);
-            % Double-check for sanity
-            if iValue <> LIGHT_FLAG_NONE
-            {
-               % Make sure projectiles are on and have the dynamic flag set.
-               iValue = iValue | LIGHT_FLAG_ON | LIGHT_FLAG_DYNAMIC;
-               % Flags, Intensity, color
-               AddPacket(2,iValue,1,iLightIntensity,2,iLightColor);
-            }
-            else
-            {
-               % No lighting info
-               AddPacket(2,0);
-            }
+            % Make sure projectiles are on and have the dynamic flag set.
+            iValue = iValue | LIGHT_FLAG_ON | LIGHT_FLAG_DYNAMIC;
+            % Flags, Intensity, color
+            AddPacket(2,iValue,1,iLightIntensity,2,iLightColor);
          }
          else
          {
             % No lighting info
             AddPacket(2,0);
          }
-
-         SendPacket(poSession);
-         iCount = iCount + 1;
-
-         % Increment iAngle by 360 degrees/number of projectiles needed.
-         iAngle = iAngle + (360/number);
       }
+      else
+      {
+         % No lighting info
+         AddPacket(2,0);
+      }
+      SendPacket(poSession);
 
       propagate;
    }


### PR DESCRIPTION
Rather than sending n BP_RADIUS_SHOOT packets, send one and let the client allocate n projectiles in RadiusProjectileAdd. Shifts the processing to the client (instead of the server sending the same info for however many projectiles need to be sent), and removes issues drawing large number of projectiles (due to each one requiring a separate BP_RADIUS_SHOOT message).