### PR TITLE
Creating basic infrastructure for seeded wall elements.

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2032,6 +2032,7 @@
    SID_DEATH_RIFT = 185
    SID_PHASE = 186
    SID_MEDITATE = 187
+   SID_FLAME_WAVE = 188
 
    % Depreciated spell IDs
    SID_LIGHTNING = 1                   % use SID_LIGHTNING_BOLT

--- a/kod/object/active/holder/nomoveon/battler/monster/BRAMBLE.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/BRAMBLE.kod
@@ -92,40 +92,155 @@ properties:
    % The range at which this can affect people.
    piRange = 0
 
+   % The inherent properties of the wallelement that can be passed forward to
+   % its children.
+   plSeed = $
+
+   % The time after which an element spawns its child.
+   ptSeed = $
+
 messages:
 
-   Constructor(MaxDamage=0,Caster=$,Duration=$,HitPoints=15)
+   Constructor(seed=$)
    {
-      local iDuration;
-
-      if Duration <> $
+      plSeed = seed;
+      piBrambleHits = Nth(seed,2)/3;
+      piMaxDamage = Nth(seed,2)/6;
+      ptNoGrow = CreateTimer(self,@NoGrow,2000);
+      if Nth(seed,3)
       {
-         iDuration = Random(Duration-20,Duration+20);
-         iDuration = iDuration * 1000;
-         iDuration = bound(iDuration,30000,200000);
-         ptExpire = CreateTimer(self,@Expire,iDuration);
+         ptExpire = CreateTimer(self,@Expire,Nth(seed,3)+random(0,1000));
       }
-
       ptPeriodic = CreateTimer(self,@PeriodicEffect,
-                           Send(self,@GetPeriodicDuration));
+                        Send(self,@GetPeriodicDuration));
 
-      piBrambleHits = HitPoints;
-      piMaxDamage = MaxDamage;
-      if Caster <> $
+      if First(seed) <> $
       {
-         poCaster = Caster;
-         vbSummoned = isClass(Caster,&Player);
+         poCaster = First(seed);
+         vbSummoned = isClass(First(seed),&Player);
       }
       else
       {
          poCaster = self;
       }
 
-      ptNoGrow = CreateTimer(self,@NoGrow,2000);
+      % If we have a charge left, create a new element after an amount of ms
+      % specified in speed.
+      if Nth(plSeed,4) > 0 
+      {
+         ptSeed = CreateTimer(self,@SpawnNextElement,Nth(seed,5));
+      }
 
       propagate;
    }
+
+   SpawnNextElement()
+   {
+      local lSeed, iRow, iCol, iFine_Row, iFine_Col, iXStep, iYStep, oElement, oRoom;
+
+      ptSeed = $;
+      oRoom = Send(self,@GetOwner);
+
+      % Inherit the properties of the old element but remove one charge.
+      lSeed = plSeed;
+      setnth(lSeed,4,Nth(plSeed,4)-1);
       
+      % If 'twirl' is enabled, shift the direction by 45 degrees every 'twirl' charges.
+      if Nth(lSeed,9) AND (Nth(plSeed,4) MOD Nth(lSeed,9)) = 0
+      {
+         setnth(lSeed,6,(Nth(plSeed,6)+1) MOD 8);
+      }
+
+      % First, let's interpret the seed's direction. If the direction is 0 or
+      % invalid, let's assume it's north.
+      iXStep = 0;
+      iYStep = -1;
+
+      % NorthEast
+      if Nth(lSeed,6) = 1
+      {
+         iXStep = 1;
+         iYStep = -1;
+      }
+
+      % East
+      if Nth(lSeed,6) = 2
+      {
+         iXStep = 1;
+         iYStep = 0;
+      }
+
+      % SouthEast
+      if Nth(lSeed,6) = 3
+      {
+         iXStep = 1;
+         iYStep = 1;
+      }
+
+      % South
+      if Nth(lSeed,6) = 4
+      {
+         iXStep = 0;
+         iYStep = 1;
+      }
+
+      % SouthWest
+      if Nth(lSeed,6) = 5
+      {
+         iXStep = -1;
+         iYStep= 1;
+      }
+
+      % West
+      if Nth(lSeed,6) = 6
+      {
+         iXStep = -1;
+         iYStep = 0;
+      }
+
+      % NorthWest
+      if Nth(lSeed,6) = 7
+      {
+         iXStep = -1;
+         iYStep = -1;
+      }
+
+      % Figure out where to spawn the next element based on our current
+      % position, our direction, our stepsize and the randomization factor.
+      iRow = Send(self,@GetRow) + iYStep * Nth(lSeed,7);
+      iCol = Send(self,@GetCol) + iXStep * Nth(lSeed,7);
+      
+      iFine_Row = Send(self,@GetFineRow) + random(-Nth(lSeed,8),Nth(lSeed,8));
+      if iFine_Row < 0
+      {
+         iFine_Row = iFine_Row + 64;
+         iRow = iRow - 1;
+      }
+      if iFine_Row > 63
+      {
+         iFine_Row = iFine_Row - 64;
+         iRow = iRow + 1;
+      }
+
+      iFine_Col = Send(self,@GetFineCol) + random(-Nth(lSeed,8),Nth(lSeed,8));
+      if iFine_Col < 0
+      {
+         iFine_Col = iFine_Col + 64;
+         iCol = iCol - 1;
+      }
+      if iFine_Col > 63
+      {
+         iFine_Col = iFine_Col - 64;
+         iCol = iCol + 1;
+      }
+      
+      oElement = Create(GetClass(self),#seed=lSeed);
+      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol,
+         #fine_row=iFine_Row,#fine_col=iFine_Col);
+
+      return;
+   }
+
    Constructed()
    {
       piHit_points = piBrambleHits;
@@ -422,6 +537,12 @@ messages:
 
       poCaster = $;
       plAffected = $;
+
+      if ptSeed <> $
+      {
+         DeleteTimer(ptSeed);
+         ptSeed = $;
+      }
 
       if ptPeriodic <> $
       {

--- a/kod/object/active/holder/room/monsroom/objroom/k5.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/k5.kod
@@ -64,8 +64,8 @@ messages:
       plMonsters = [ [&GroundwormQueen, 100] ];
 
       plGenerators = [ [10, 15], [19, 12], [23, 23], [4, 24], [8, 50],
-		      [11, 30], [25, 37], [37, 28], [36, 43], [41, 48], 
-		      [49, 34], [45, 22], [14, 41], [19, 30], [28, 50], [39, 37] ];
+            [11, 30], [25, 37], [37, 28], [36, 43], [41, 48], 
+            [49, 34], [45, 22], [14, 41], [19, 30], [28, 50], [39, 37] ];
 
       poShrine = create(&shrine,#shrine_num=SHRINE_BRAMBLE);
       send(self,@newhold,#what=poShrine,#new_row=43,#new_col=32,#fine_col=32);
@@ -146,7 +146,7 @@ messages:
 
       plDeadBrambles = DelListElem(plDeadBrambles,lLoc);
       % No duration when creating the Bramble means it doesn't go away, it isn't DestroyDisposable'd.
-      oBramble = Create(&Brambles,#MaxDamage=piBrambleDamage,#HitPoints=piBrambleHits); 
+      oBramble = Create(&Brambles,#seed=[$,200,0,0,0,0,0,0,0]);
       Send(self,@NewHold,#what=oBramble,#New_row=nth(lLoc,1),#New_col=nth(lLoc,2));
 
       return;

--- a/kod/object/active/wallelem.kod
+++ b/kod/object/active/wallelem.kod
@@ -66,31 +66,40 @@ properties:
    % This is a list of objects already affected by the element
    %  this period.
    plAffected = $
-   
+
    % The wallelement carries all relevant information in its seed. This allows 
    % the element to spawn additional elements that inherit their behavior from
    % the parent. plSeed has the following structure:
-   % plSeed = [1caster,2spellpower,3duration,4charges,5speed,6direction,7step,8noise,9twirl]
+   % plSeed = [1caster,2spellpower,3duration,4charges,5speed,6direction,7step,8noise,9twirl,10seed]
    plSeed = $
+
+   % The wallelement carries all relevant information in its seed. This allows 
+   % the element to spawn additional elements that inherit their behavior from
+   % the parent. plSeed has the following structure:
+   % plSeed = [1caster,2spellpower,3duration,4charges,5speed,6direction,7step,8noise,9twirl,10seed]
+   plSecondarySeed = $
 
    % Timer that spawns the next element upon expiration.
    ptSeed = $
+   % Timer that may spawn a secondary seed upon expiration.
+   ptSecondarySeed = $
+   
 messages:
 
    Constructor(seed=$)
    {
       plSeed = seed;
 
-      poCaster = First(seed);
+      poCaster = First(plSeed);
 
-      if Nth(seed,3)
+      if Nth(plSeed,3)
       {
-         ptExpire = CreateTimer(self,@Expire,Nth(seed,3)+random(0,1000));
+         ptExpire = CreateTimer(self,@Expire,Nth(plSeed,3)+random(0,1000));
       }
       ptPeriodic = CreateTimer(self,@PeriodicEffect,
                         Send(self,@GetPeriodicDuration));
 
-      if IsClass(First(seed),&User)
+      if IsClass(First(plSeed),&User)
       {
          vbSummoned = TRUE;
       }
@@ -99,7 +108,14 @@ messages:
       % specified in speed.
       if Nth(plSeed,4) > 0 
       {
-         ptSeed = CreateTimer(self,@SpawnNextElement,Nth(seed,5));
+         ptSeed = CreateTimer(self,@SpawnNextElement,Nth(plSeed,5));
+      }
+
+      % If we have a secondary plSeed, spawn it afer the time specified.
+      if Length(plSeed) > 9
+      {
+         plSecondarySeed = Send(SYS,@ListCopy,#source=Nth(plSeed,10));
+         ptSecondarySeed = CreateTimer(self,@SpawnSecondaryElement,Nth(plSecondarySeed,5));
       }
 
       propagate;
@@ -107,19 +123,38 @@ messages:
 
    SpawnNextElement()
    {
-      local lSeed, iRow, iCol, iFine_Row, iFine_Col, iXStep, iYStep, oElement, oRoom;
+      local iRow, iCol, iFine_Row, iFine_Col, iXStep, iYStep, oElement, oRoom;
 
       ptSeed = $;
       oRoom = Send(self,@GetOwner);
 
       % Inherit the properties of the old element but remove one charge.
-      lSeed = plSeed;
-      setnth(lSeed,4,Nth(plSeed,4)-1);
+      setnth(plSeed,4,Nth(plSeed,4)-1);
       
-      % If 'twirl' is enabled, shift the direction by 45 degrees every 'twirl' charges.
-      if Nth(lSeed,9) AND (Nth(plSeed,4) MOD Nth(lSeed,9)) = 0
+      % If 'twirl' is enabled, shift the direction by 45 degrees every 'twirl' 
+      % charges. Positive twirl rotates cw, negative twirl roates ccw.
+      if Nth(plSeed,9) > 0 AND (Nth(plSeed,4) MOD Nth(plSeed,9)) = 0
       {
-         setnth(lSeed,6,(Nth(plSeed,6)+1) MOD 8);
+         if Nth(plSeed,6) = 7
+         {
+            setnth(plSeed,6,0);
+         }
+         else
+         {
+            setnth(plSeed,6,Nth(plSeed,6)+1);
+         }
+      }
+
+      if Nth(plSeed,9) < 0 AND (Nth(plSeed,4) MOD (-Nth(plSeed,9))) = 0
+      {
+         if Nth(plSeed,6) = 0
+         {
+            setnth(plSeed,6,7);
+         }
+         else
+         {
+            setnth(plSeed,6,Nth(plSeed,6)-1);
+         }
       }
 
       % First, let's interpret the seed's direction. If the direction is 0 or
@@ -128,49 +163,49 @@ messages:
       iYStep = -1;
 
       % NorthEast
-      if Nth(lSeed,6) = 1
+      if Nth(plSeed,6) = 1
       {
          iXStep = 1;
          iYStep = -1;
       }
 
       % East
-      if Nth(lSeed,6) = 2
+      if Nth(plSeed,6) = 2
       {
          iXStep = 1;
          iYStep = 0;
       }
 
       % SouthEast
-      if Nth(lSeed,6) = 3
+      if Nth(plSeed,6) = 3
       {
          iXStep = 1;
          iYStep = 1;
       }
 
       % South
-      if Nth(lSeed,6) = 4
+      if Nth(plSeed,6) = 4
       {
          iXStep = 0;
          iYStep = 1;
       }
 
       % SouthWest
-      if Nth(lSeed,6) = 5
+      if Nth(plSeed,6) = 5
       {
          iXStep = -1;
          iYStep= 1;
       }
 
       % West
-      if Nth(lSeed,6) = 6
+      if Nth(plSeed,6) = 6
       {
          iXStep = -1;
          iYStep = 0;
       }
 
       % NorthWest
-      if Nth(lSeed,6) = 7
+      if Nth(plSeed,6) = 7
       {
          iXStep = -1;
          iYStep = -1;
@@ -178,10 +213,10 @@ messages:
 
       % Figure out where to spawn the next element based on our current
       % position, our direction, our stepsize and the randomization factor.
-      iRow = Send(self,@GetRow) + iYStep * Nth(lSeed,7);
-      iCol = Send(self,@GetCol) + iXStep * Nth(lSeed,7);
+      iRow = Send(self,@GetRow) + iYStep * Nth(plSeed,7);
+      iCol = Send(self,@GetCol) + iXStep * Nth(plSeed,7);
       
-      iFine_Row = Send(self,@GetFineRow) + random(-Nth(lSeed,8),Nth(lSeed,8));
+      iFine_Row = Send(self,@GetFineRow) + random(-Nth(plSeed,8),Nth(plSeed,8));
       if iFine_Row < 0
       {
          iFine_Row = iFine_Row + 64;
@@ -193,7 +228,7 @@ messages:
          iRow = iRow + 1;
       }
 
-      iFine_Col = Send(self,@GetFineCol) + random(-Nth(lSeed,8),Nth(lSeed,8));
+      iFine_Col = Send(self,@GetFineCol) + random(-Nth(plSeed,8),Nth(plSeed,8));
       if iFine_Col < 0
       {
          iFine_Col = iFine_Col + 64;
@@ -205,13 +240,138 @@ messages:
          iCol = iCol + 1;
       }
       
-      oElement = Create(GetClass(self),#seed=lSeed);
+      oElement = Create(GetClass(self),#seed=plSeed);
       Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol,
          #fine_row=iFine_Row,#fine_col=iFine_Col);
 
       return;
    }
-   
+
+   SpawnSecondaryElement()
+   {
+      local iRow, iCol, iFine_Row, iFine_Col, iXStep, iYStep, oElement, oRoom;
+
+      ptSecondarySeed = $;
+      oRoom = Send(self,@GetOwner);
+
+      % Inherit the properties of the old element but remove one charge.
+      setnth(plSecondarySeed,4,Nth(plSecondarySeed,4)-1);
+      
+      % If 'twirl' is enabled, shift the direction by 45 degrees every 'twirl' 
+      % charges. Positive twirl rotates cw, negative twirl roates ccw.
+      if Nth(plSecondarySeed,9) > 0 AND (Nth(plSecondarySeed,4) MOD Nth(plSecondarySeed,9)) = 0
+      {
+         if Nth(plSecondarySeed,6) = 7
+         {
+            setnth(plSecondarySeed,6,0);
+         }
+         else
+         {
+            setnth(plSecondarySeed,6,Nth(plSecondarySeed,6)+1);
+         }
+      }
+
+      if Nth(plSecondarySeed,9) < 0 AND (Nth(plSecondarySeed,4) MOD (-Nth(plSecondarySeed,9))) = 0
+      {
+         if Nth(plSecondarySeed,6) = 0
+         {
+            setnth(plSecondarySeed,6,7);
+         }
+         else
+         {
+            setnth(plSecondarySeed,6,Nth(plSecondarySeed,6)-1);
+         }
+      }
+
+      % First, let's interpret the seed's direction. If the direction is 0 or
+      % invalid, let's assume it's north.
+      iXStep = 0;
+      iYStep = -1;
+
+      % NorthEast
+      if Nth(plSecondarySeed,6) = 1
+      {
+         iXStep = 1;
+         iYStep = -1;
+      }
+
+      % East
+      if Nth(plSecondarySeed,6) = 2
+      {
+         iXStep = 1;
+         iYStep = 0;
+      }
+
+      % SouthEast
+      if Nth(plSecondarySeed,6) = 3
+      {
+         iXStep = 1;
+         iYStep = 1;
+      }
+
+      % South
+      if Nth(plSecondarySeed,6) = 4
+      {
+         iXStep = 0;
+         iYStep = 1;
+      }
+
+      % SouthWest
+      if Nth(plSecondarySeed,6) = 5
+      {
+         iXStep = -1;
+         iYStep= 1;
+      }
+
+      % West
+      if Nth(plSecondarySeed,6) = 6
+      {
+         iXStep = -1;
+         iYStep = 0;
+      }
+
+      % NorthWest
+      if Nth(plSecondarySeed,6) = 7
+      {
+         iXStep = -1;
+         iYStep = -1;
+      }
+
+      % Figure out where to spawn the next element based on our current
+      % position, our direction, our stepsize and the randomization factor.
+      iRow = Send(self,@GetRow) + iYStep * Nth(plSecondarySeed,7);
+      iCol = Send(self,@GetCol) + iXStep * Nth(plSecondarySeed,7);
+      
+      iFine_Row = Send(self,@GetFineRow) + random(-Nth(plSecondarySeed,8),Nth(plSecondarySeed,8));
+      if iFine_Row < 0
+      {
+         iFine_Row = iFine_Row + 64;
+         iRow = iRow - 1;
+      }
+      if iFine_Row > 63
+      {
+         iFine_Row = iFine_Row - 64;
+         iRow = iRow + 1;
+      }
+
+      iFine_Col = Send(self,@GetFineCol) + random(-Nth(plSecondarySeed,8),Nth(plSecondarySeed,8));
+      if iFine_Col < 0
+      {
+         iFine_Col = iFine_Col + 64;
+         iCol = iCol - 1;
+      }
+      if iFine_Col > 63
+      {
+         iFine_Col = iFine_Col - 64;
+         iCol = iCol + 1;
+      }
+      
+      oElement = Create(GetClass(self),#seed=plSecondarySeed);
+      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol,
+         #fine_row=iFine_Row,#fine_col=iFine_Col);
+
+      return;
+   }
 
    GetPeriodicDuration()
    {
@@ -413,6 +573,12 @@ messages:
       {
          DeleteTimer(ptSeed);
          ptSeed = $;
+      }
+
+      if ptSecondarySeed <> $
+      {
+         DeleteTimer(ptSecondarySeed);
+         ptSecondarySeed = $;
       }
 
       if ptExpire <> $

--- a/kod/object/active/wallelem.kod
+++ b/kod/object/active/wallelem.kod
@@ -66,36 +66,157 @@ properties:
    % This is a list of objects already affected by the element
    %  this period.
    plAffected = $
+   
+   % The wallelement carries all relevant information in its seed. This allows 
+   % the element to spawn additional elements that inherit their behavior from
+   % the parent. plSeed has the following structure:
+   % plSeed = [1caster,2spellpower,3duration,4charges,5speed,6direction,7step,8noise,9twirl]
+   plSeed = $
 
+   % Timer that spawns the next element upon expiration.
+   ptSeed = $
 messages:
 
-   Constructor(caster=$,duration=$)
+   Constructor(seed=$)
    {
-      poCaster = caster;
+      plSeed = seed;
 
-      ptExpire = CreateTimer(self,@Expire,
-                        Send(self,@GetDuration,#duration=duration));
+      poCaster = First(seed);
+
+      if Nth(seed,3)
+      {
+         ptExpire = CreateTimer(self,@Expire,Nth(seed,3)+random(0,1000));
+      }
       ptPeriodic = CreateTimer(self,@PeriodicEffect,
                         Send(self,@GetPeriodicDuration));
 
-      if IsClass(caster,&User)
+      if IsClass(First(seed),&User)
       {
          vbSummoned = TRUE;
+      }
+
+      % If we have a charge left, create a new element after an amount of ms
+      % specified in speed.
+      if Nth(plSeed,4) > 0 
+      {
+         ptSeed = CreateTimer(self,@SpawnNextElement,Nth(seed,5));
       }
 
       propagate;
    }
 
+   SpawnNextElement()
+   {
+      local lSeed, iRow, iCol, iFine_Row, iFine_Col, iXStep, iYStep, oElement, oRoom;
+
+      ptSeed = $;
+      oRoom = Send(self,@GetOwner);
+
+      % Inherit the properties of the old element but remove one charge.
+      lSeed = plSeed;
+      setnth(lSeed,4,Nth(plSeed,4)-1);
+      
+      % If 'twirl' is enabled, shift the direction by 45 degrees every 'twirl' charges.
+      if Nth(lSeed,9) AND (Nth(plSeed,4) MOD Nth(lSeed,9)) = 0
+      {
+         setnth(lSeed,6,(Nth(plSeed,6)+1) MOD 8);
+      }
+
+      % First, let's interpret the seed's direction. If the direction is 0 or
+      % invalid, let's assume it's north.
+      iXStep = 0;
+      iYStep = -1;
+
+      % NorthEast
+      if Nth(lSeed,6) = 1
+      {
+         iXStep = 1;
+         iYStep = -1;
+      }
+
+      % East
+      if Nth(lSeed,6) = 2
+      {
+         iXStep = 1;
+         iYStep = 0;
+      }
+
+      % SouthEast
+      if Nth(lSeed,6) = 3
+      {
+         iXStep = 1;
+         iYStep = 1;
+      }
+
+      % South
+      if Nth(lSeed,6) = 4
+      {
+         iXStep = 0;
+         iYStep = 1;
+      }
+
+      % SouthWest
+      if Nth(lSeed,6) = 5
+      {
+         iXStep = -1;
+         iYStep= 1;
+      }
+
+      % West
+      if Nth(lSeed,6) = 6
+      {
+         iXStep = -1;
+         iYStep = 0;
+      }
+
+      % NorthWest
+      if Nth(lSeed,6) = 7
+      {
+         iXStep = -1;
+         iYStep = -1;
+      }
+
+      % Figure out where to spawn the next element based on our current
+      % position, our direction, our stepsize and the randomization factor.
+      iRow = Send(self,@GetRow) + iYStep * Nth(lSeed,7);
+      iCol = Send(self,@GetCol) + iXStep * Nth(lSeed,7);
+      
+      iFine_Row = Send(self,@GetFineRow) + random(-Nth(lSeed,8),Nth(lSeed,8));
+      if iFine_Row < 0
+      {
+         iFine_Row = iFine_Row + 64;
+         iRow = iRow - 1;
+      }
+      if iFine_Row > 63
+      {
+         iFine_Row = iFine_Row - 64;
+         iRow = iRow + 1;
+      }
+
+      iFine_Col = Send(self,@GetFineCol) + random(-Nth(lSeed,8),Nth(lSeed,8));
+      if iFine_Col < 0
+      {
+         iFine_Col = iFine_Col + 64;
+         iCol = iCol - 1;
+      }
+      if iFine_Col > 63
+      {
+         iFine_Col = iFine_Col - 64;
+         iCol = iCol + 1;
+      }
+      
+      oElement = Create(GetClass(self),#seed=lSeed);
+      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol,
+         #fine_row=iFine_Row,#fine_col=iFine_Col);
+
+      return;
+   }
+   
+
    GetPeriodicDuration()
    {
       % 90 - 110% of base interval
       return (EFFECT_INTERVAL * Random(90,110))/100;
-   }
-
-   GetDuration(duration = 0)
-   "Return the final duration modified as necessary."
-   {
-      return duration;
    }
 
    SomethingMoved(what = $,new_row = $,new_col = $)
@@ -286,6 +407,12 @@ messages:
       {
          DeleteTimer(ptPeriodic);
          ptPeriodic = $;
+      }
+
+      if ptSeed <> $
+      {
+         DeleteTimer(ptSeed);
+         ptSeed = $;
       }
 
       if ptExpire <> $

--- a/kod/object/active/wallelem/asburstc.kod
+++ b/kod/object/active/wallelem/asburstc.kod
@@ -44,18 +44,13 @@ classvars:
 
 properties:
 
-   piRangeSquared = 1
-   piBonus = 1
+   piMaxHoldTime = 0
 
 messages:
    
-   Constructor(caster=$,duration=$,range=$)
+   Constructor(seed=$)
    {
-      if range <> $
-      {
-         piRange = range;
-         piBonus = range;
-      }
+      piMaxHoldTime = Nth(seed,2)*80;
 
       propagate;
    }
@@ -67,7 +62,7 @@ messages:
       oSpell = Send(SYS,@FindSpellByNum,#num=SID_HOLD);
 
       Send(oSpell,@DoHold,#what=self,#otarget=what,
-           #iDurationSecs=BASE_HOLD_DURATION+piBonus);
+           #iDuration=piMaxHoldTime);
 
       propagate;
    }   

--- a/kod/object/active/wallelem/makefile
+++ b/kod/object/active/wallelem/makefile
@@ -5,7 +5,7 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\wallelem.bof
-BOFS =  wallfire.bof wallltng.bof poisfogc.bof web.bof asburstc.bof
+BOFS =  wallfire.bof wallltng.bof poisfogc.bof web.bof asburstc.bof wallifire.bof
 
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/active/wallelem/poisfogc.kod
+++ b/kod/object/active/wallelem/poisfogc.kod
@@ -52,22 +52,11 @@ properties:
 
 messages:
    
-   Constructor(Caster = $, Duration = 75, Odds = 0)
+   Constructor(seed=$)
    {
-      piOdds = Odds;
+      piOdds = Nth(seed,2);
 
       propagate;
-   }
-
-   GetDuration(duration = 0)
-   {
-      local iDuration;
-
-      iDuration = Random(duration-20,duration+20);
-      iDuration = iDuration * 1000;
-      iDuration = bound(iDuration,30000,200000);
-
-      return iDuration;
    }
 
    DoEffect(what = $)

--- a/kod/object/active/wallelem/wallifire.kod
+++ b/kod/object/active/wallelem/wallifire.kod
@@ -8,29 +8,13 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-WallofFire is ActiveWallElement
+IllusionaryWallOfFire is ActiveWallElement
 
 constants:
 
    include blakston.khd
 
 resources:
-
-   WallofFire_name_rsc = "wall of fire"
-   WallofFire_icon_rsc = woflame.bgf
-   WallofFire_desc_rsc = \
-      "The wall of fire flickers dangerously, threatening to make the day "
-      "of anyone passing through a bad one."
-
-   firewall_damage0 = "You withstand the fire unscathed."
-   firewall_damage5 = "You feel a bit toasted from the flames."
-   firewall_damage10 = "Something smells like burnt hair.  Wait, it's you!"
-   firewall_damage15 = "You are on fire!  Put it out!"
-   firewall_damage20 = "Ouch, that really burned!"
-
-   firewall_burn_snd = frying.wav
-
-   firewall_dissipates = "A bit of the firewall fades into coldness."
 
 classvars:
 
@@ -44,16 +28,17 @@ classvars:
    vrUnaffectedMessage = firewall_damage0
 
    viLightBonus = 15
+   viIllusion = TRUE
 
 properties:
 
-   piMaxDamage = 0
+   piSpellpower = 0
 
 messages:
 
    Constructor(seed=$)
    {
-      piMaxDamage = Nth(seed,2)/5;
+      piSpellpower = Nth(seed,2);
 
       propagate;
    }
@@ -63,9 +48,26 @@ messages:
       local iDamage, oIllusWounds, iDuration, rMessage;
 
       iDamage = 0;
-      
-      iDamage = Send(what,@AssessDamage,#what=poCaster,#damage=Random(0,piMaxDamage),
-                     #aspell=ATCK_SPELL_ALL+ATCK_SPELL_FIRE,#report=FALSE,#report_resistance=FALSE);
+
+      if (piSpellpower < 35)
+      {
+         return;
+      }
+
+      oIllusWounds = Send(SYS,@FindSpellByNum,#num=SID_ILLUSIONARY_WOUNDS);
+      iDuration = Send(oIllusWounds,@GetDuration,#iSpellPower=piSpellpower);
+      iDamage = Send(oIllusWounds,@GetHPLoss,#who=poCaster,#victim=what,#iSpellPower=piSpellpower);
+
+      if iDamage > 0
+      {
+         % We technically don't have a damage type, but we count as spell damage.
+         %  Also, don't lower damage based on resistances.
+         iDamage = Send(what,@AssessDamage,#what=poCaster,#damage=Random(0,iDamage),
+                        #aspell=ATCK_SPELL_ALL,#absolute=TRUE,#report=FALSE,
+                        #report_resistance=FALSE);
+         Send(what,@StartEnchantment,#what=oIllusWounds,#time=iDuration,#lastcall=TRUE,
+              #state=iDamage,#addicon=FALSE);
+      }
 
       if iDamage = $
       {
@@ -82,7 +84,7 @@ messages:
          }
          else
          {
-            if piMaxDamage > 0
+            if piSpellpower > 0
             {
                Send(poCaster,@SetPlayerFlag,#flag=PFLAG_DID_DAMAGE,#value=TRUE);
             }
@@ -139,8 +141,6 @@ messages:
 
    NewOwner(what = $)
    {
-      % Add a bit of light if this isn't an illusion.  Firewalls should add some light.
-
       % new room
       if what <> $
       {
@@ -158,7 +158,6 @@ messages:
 
    Delete()
    {
-
       if poOwner <> $
       {
          Send(poOwner,@AddBaseLight,#amount=-viLightBonus);
@@ -172,6 +171,7 @@ messages:
       AddPacket(2,(LIGHT_FLAG_ON | LIGHT_FLAG_DYNAMIC));
       % 5 out of 255 intensity of light
       AddPacket(1,5);
+
 
       % Red color
       AddPacket(2,LIGHT_RED);

--- a/kod/object/active/wallelem/wallltng.kod
+++ b/kod/object/active/wallelem/wallltng.kod
@@ -54,22 +54,11 @@ properties:
 
 messages:
    
-   Constructor(caster = $, duration=75, MaxDamage = 0)
+   Constructor(seed=$)
    {
-      piMaxDamage = MaxDamage;
+      piMaxDamage = Nth(seed,2)/4;
 
       propagate;
-   }
-
-   GetDuration(duration = 0)
-   {
-      local iDuration;
-
-      iDuration = Random(duration-20,duration+20);
-      iDuration = iDuration * 1000;
-      iDuration = bound(iDuration,30000,200000);
-
-      return iDuration;
    }
 
    DoEffect(what = $, periodic=FALSE)

--- a/kod/object/active/wallelem/web.kod
+++ b/kod/object/active/wallelem/web.kod
@@ -55,9 +55,9 @@ properties:
 
 messages:
    
-   Constructor(caster = $, duration = 75, MaxHoldTime = 0)
+   Constructor(seed=$)
    {
-      piMaxHoldTime = MaxHoldTime;
+      piMaxHoldTime = Nth(seed,2)*50;
 
       % A list of monsters not affected by webbing
       % Includes: Spiders, Bosses, Fliers, Xeos, and Revenants
@@ -69,17 +69,6 @@ messages:
                            ];
      
       propagate;
-   }
-
-   GetDuration(duration = 0)
-   {
-      local iDuration;
-
-      iDuration = Random(duration-20,duration+20);
-      iDuration = iDuration * 1000;
-      iDuration = bound(iDuration,20000,150000);
-
-      return iDuration;
    }
 
    SomethingMoved(what = $,new_row = $,new_col = $)
@@ -112,8 +101,8 @@ messages:
 
       if piMaxHoldTime > 0
       {
-         iHoldTime = Random(piMaxHoldTime - 2,piMaxHoldTime);
-         iHoldTime = bound(iHoldTime,1,$);
+         iHoldTime = Random(piMaxHoldTime - 2000,piMaxHoldTime);
+         iHoldTime = bound(iHoldTime,1000,$);
 
          if IsClass(what,&Monster)
          {
@@ -123,7 +112,7 @@ messages:
 
       if iHoldTime > 0
       {
-         Send(oSpell,@DoHold,#what=poCaster,#oTarget=what,#iDurationSecs=iHoldTime,
+         Send(oSpell,@DoHold,#what=poCaster,#oTarget=what,#duration=iHoldTime,
               #report=FALSE);
       }
 
@@ -138,20 +127,20 @@ messages:
             % Duration greater than 0
             Send(what,@WaveSendUser,#wave_rsc=web_stick_snd);
 
-            if iHoldTime < 2
+            if iHoldTime < 2000
             {
                rMessage = web_stick1;
             }
             else
             {
 
-               if iHoldTime < 3
+               if iHoldTime < 3000
                {
                   rMessage = web_stick2;
                }
                else
                {
-                  if iHoldTime < 4
+                  if iHoldTime < 4000
                   {
                      rMessage = web_stick3;
                   }

--- a/kod/object/passive/fogcloud.kod
+++ b/kod/object/passive/fogcloud.kod
@@ -34,22 +34,40 @@ properties:
    ptExpire = $
    vbSummoned = TRUE
 
+   % The wallelement carries all relevant information in its seed. This allows 
+   % the element to spawn additional elements that inherit their behavior from
+   % the parent. plSeed has the following structure:
+   % plSeed = [1caster,2spellpower,3duration,4charges,5speed,6direction,7step,8noise,9twirl]
+   plSeed = $
+
+   % Timer that spawns the next element upon expiration.
+   ptSeed = $
+
 messages:
 
-   constructor(Caster=$,Duration=75)
+   Constructor(seed=$)
    {
-     local iDuration;
-     iDuration = Random(Duration-15,Duration+15);
-     iDuration = iDuration * 750;
-     iDuration = bound(iDuration,22500,150000);
+      plSeed = seed;
 
-     poCaster = Caster;
-     vbSummoned = isClass(Caster,&User);
-     ptExpire = CreateTimer(self,@Expire,iDuration);
+      poCaster = First(seed);
 
-     propagate;
+      ptExpire = CreateTimer(self,@Expire,Nth(seed,3)+random(0,1000));
+
+      if IsClass(First(seed),&User)
+      {
+         vbSummoned = TRUE;
+      }
+
+      % If we have a charge left, create a new element after an amount of ms
+      % specified in speed.
+      if Nth(plSeed,4) > 0 
+      {
+         ptSeed = CreateTimer(self,@SpawnNextElement,Nth(seed,5));
+      }
+
+      propagate;
    }
-
+   
    Constructed()
    {
       %% at this point, the wall should have already been created.
@@ -57,6 +75,113 @@ messages:
       post(self,@ArenaCheck);
 
       propagate;
+   }
+
+   SpawnNextElement()
+   {
+      local lSeed, iRow, iCol, iFine_Row, iFine_Col, iXStep, iYStep, oElement, oRoom;
+
+      ptSeed = $;
+      oRoom = Send(self,@GetOwner);
+
+      % Inherit the properties of the old element but remove one charge.
+      lSeed = plSeed;
+      setnth(lSeed,4,Nth(plSeed,4)-1);
+      
+      % If 'twirl' is enabled, shift the direction by 45 degrees every 'twirl' charges.
+      if Nth(lSeed,9) AND (Nth(plSeed,4) MOD Nth(lSeed,9)) = 0
+      {
+         setnth(lSeed,6,(Nth(plSeed,6)+1) MOD 8);
+      }
+
+      % First, let's interpret the seed's direction. If the direction is 0 or
+      % invalid, let's assume it's north.
+      iXStep = 0;
+      iYStep = -1;
+
+      % NorthEast
+      if Nth(lSeed,6) = 1
+      {
+         iXStep = 1;
+         iYStep = -1;
+      }
+
+      % East
+      if Nth(lSeed,6) = 2
+      {
+         iXStep = 1;
+         iYStep = 0;
+      }
+
+      % SouthEast
+      if Nth(lSeed,6) = 3
+      {
+         iXStep = 1;
+         iYStep = 1;
+      }
+
+      % South
+      if Nth(lSeed,6) = 4
+      {
+         iXStep = 0;
+         iYStep = 1;
+      }
+
+      % SouthWest
+      if Nth(lSeed,6) = 5
+      {
+         iXStep = -1;
+         iYStep= 1;
+      }
+
+      % West
+      if Nth(lSeed,6) = 6
+      {
+         iXStep = -1;
+         iYStep = 0;
+      }
+
+      % NorthWest
+      if Nth(lSeed,6) = 7
+      {
+         iXStep = -1;
+         iYStep = -1;
+      }
+
+      % Figure out where to spawn the next element based on our current
+      % position, our direction, our stepsize and the randomization factor.
+      iRow = Send(self,@GetRow) + iYStep * Nth(lSeed,7);
+      iCol = Send(self,@GetCol) + iXStep * Nth(lSeed,7);
+      
+      iFine_Row = Send(self,@GetFineRow) + random(-Nth(lSeed,8),Nth(lSeed,8));
+      if iFine_Row < 0
+      {
+         iFine_Row = iFine_Row + 64;
+         iRow = iRow - 1;
+      }
+      if iFine_Row > 63
+      {
+         iFine_Row = iFine_Row - 64;
+         iRow = iRow + 1;
+      }
+
+      iFine_Col = Send(self,@GetFineCol) + random(-Nth(lSeed,8),Nth(lSeed,8));
+      if iFine_Col < 0
+      {
+         iFine_Col = iFine_Col + 64;
+         iCol = iCol - 1;
+      }
+      if iFine_Col > 63
+      {
+         iFine_Col = iFine_Col - 64;
+         iCol = iCol + 1;
+      }
+      
+      oElement = Create(GetClass(self),#seed=lSeed);
+      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol,
+         #fine_row=iFine_Row,#fine_col=iFine_Col);
+
+      return;
    }
 
    ArenaCheck()
@@ -83,6 +208,13 @@ messages:
          DeleteTimer(ptExpire);
          ptExpire = $;
       }
+
+      if ptSeed <> $
+      {
+         DeleteTimer(ptSeed);
+         ptSeed = $;
+      }
+
       propagate;
    }
 

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -2311,7 +2311,7 @@ messages:
       if viSchool = SS_KRAANAN
       {
          % Kraanan favors adversity and armies.  More people in a room, the better.
-         iPrimaryBonus = Length(Send(oRoom,@GetHolderActive));
+         iPrimaryBonus = Send(oRoom,@CountMonsters,#class=&Battler);
          % Kraanan also favors the healthy warrior.  Full hps = more bonus.
          iSecondaryBonus = (Send(who,@GetHealth)*10)/Send(who,@GetMaxHealth);
 

--- a/kod/object/passive/spell/walspell.kod
+++ b/kod/object/passive/spell/walspell.kod
@@ -34,8 +34,8 @@ classvars:
    % Can wall elements kill?  Affects the warning message we append.
    viWallCanKill = TRUE
 
-   % How many elements do we expect to summon?
-   viNumElements = 9
+   % How many empty spots does the room need before we can summon the wall?
+   viNumElements = 1
 
    vrSummonLimitMsg = WallSpell_failed_rsc
 
@@ -71,10 +71,136 @@ messages:
 
    CastSpell(who = $, lTargets = $, iSpellPower = 1)
    {
-      Send(self,@PlaceWallElements,#who=who,#lTargets=lTargets,
-           #iSpellPower=iSpellPower);
+      Send(self,@CreateWallSeed,#who=who,#iSpellPower=iSpellPower);
 
       propagate;
+   }
+
+   CreateWallSeed(who = $, iSpellPower = 0)
+   {
+      local iAngle, iDirection, lSeed;
+
+      iAngle = Send(who,@GetAngle);
+      
+      iDirection = Send(self,@GetDirection,#who=who);
+
+      % This is a generic seed, individual spells may create different ones.
+      % [(1)caster,(2)spellpower,(3)duration,(4)charges,(5)speed,(6)direction,(7)step,(8)noise,(9)twirl]
+      lSeed = [who,iSpellPower,1200*iSpellPower,iSpellPower/10,20000/iSpellPower,iDirection,1,63*(100-iSpellpower)/100,0];
+
+      Send(self,@PlaceWallElements,#seed=lSeed);
+
+      return;
+   }
+
+   SpawnElement(seed=$,who=$,xoffset=0,yoffset=0,walltype=$)
+   {
+      local iCol, iRow, oElement, oRoom;
+
+      oRoom = Send(who,@GetOwner);
+      
+      iCol = Send(who,@GetCol) + xoffset;
+      iRow = Send(who,@GetRow) + yoffset;
+
+      oElement = Create(walltype,#seed=seed);
+      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol,#fine_row=Send(who,@GetFineRow),#fine_col=Send(who,@GetFineCol));
+      
+      return;
+   }
+
+   GetDirection(who=$)
+   {
+      local iAngle;
+
+      iAngle = Send(who,@GetAngle);
+
+      % Facing North
+      if iAngle >= ANGLE_NNW AND iAngle < ANGLE_NNE
+      {
+         return 0;
+      }
+
+      % Facing NorthEast
+      if iAngle >= ANGLE_NNE AND iAngle < ANGLE_ENE
+      {
+         return 1;
+      }
+
+      % Facing East
+      if iAngle >= ANGLE_ENE OR iAngle < ANGLE_ESE
+      {
+         return 2;
+      }
+
+      % Facing SouthEast
+      if iAngle >= ANGLE_ESE AND iAngle < ANGLE_SSE
+      {
+         return 3;
+      }
+
+      % Facing South
+      if iAngle >= ANGLE_SSE AND iAngle < ANGLE_SSW
+      {
+         return 4;
+      }
+
+      % Facing SouthWest
+      if iAngle >= ANGLE_SSW AND iAngle < ANGLE_WSW
+      {
+         return 5;
+      }
+
+      % Facing West
+      if iAngle >= ANGLE_WSW AND iAngle < ANGLE_WNW
+      {
+         return 6;
+      }
+
+      % Facing NorthWest
+      if iAngle >= ANGLE_WNW AND iAngle < ANGLE_NNW
+      {
+         return 7;
+      }
+      
+      return 0;
+   }
+
+   GetXStep(direction=0)
+   {
+      % Facing North or South
+      if direction = 0 OR direction = 4 
+      {
+         return 0;
+      }
+
+      % Facing Eastish
+      if direction < 4
+      {
+         return 1;
+      }
+
+      % Facing Westish
+      return -1;
+
+   }
+   
+   GetYStep(direction=0)
+   {
+      % Facing East or West
+      if direction = 2 OR direction = 6 
+      {
+         return 0;
+      }
+
+      % Facing Southish
+      if direction = 3 OR direction = 4 OR direction = 5  
+      {
+         return 1;
+      }
+
+      % Facing Northish
+      return -1;
+
    }
 
    PlaceWallElements(who = $, lTargets=$, iSpellPower = 0)

--- a/kod/object/passive/spell/walspell/brmblwll.kod
+++ b/kod/object/passive/spell/walspell/brmblwll.kod
@@ -50,8 +50,6 @@ classvars:
 
    viHarmful = TRUE
 
-   viNumElements = 5
-
    vrSummonLimitMsg = BrambleWall_failed_rsc
 
 properties:
@@ -75,182 +73,29 @@ messages:
       propagate;
    }
 
-   PlaceWallElements(who = $, iSpellPower = 0)
+   PlaceWallElements(seed = $)
    {
-      local  oRoom, iRow, iCol, iFine_Row, iFine_Col, iXStep, iYStep, iAngle,
-         iMaxDamage, iDuration, iHalfrow, iHalfCol, iHalfFine_Row,
-         iHalfFine_Col, iBrambleHits, oElement;
+      local lSeeda, lSeedb, lSeedc, lSeedd, lSeede, lSeedf, iDirection, iXStep, iYStep;
 
-      iAngle = Send(who,@GetAngle);
-      iMaxDamage = iSpellPower / 15;
-      iMaxDamage = bound(iMaxDamage,$,5);
-      iDuration = (iSpellPower * 3) + 45;
-      iDuration = bound(iDuration,45,270);
-      iBrambleHits = bound(iSpellPower/2,10,50);
+      iDirection = Nth(seed,6);
+      iXStep = Send(self,@GetXStep,#direction=iDirection);
+      iYStep = Send(self,@GetYStep,#direction=iDirection);
 
-      % Facing East
-      if iAngle > ANGLE_ENE OR iAngle < ANGLE_ESE
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol) + 1;
-         iXStep = 0;
-         iyStep = 1;
-      }
+      % The standard seed is modified here.
+      % [(1)caster,(2)spellpower,(3)duration,(4)charges,(5)speed,(6)direction,(7)step,(8)noise,(9)twirl]
+      lSeeda = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+6) MOD 8,1,Nth(seed,8),0];
+      lSeedb = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+6) MOD 8,1,Nth(seed,8),0];
+      lSeedc = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+6) MOD 8,1,Nth(seed,8),0];
+      lSeedd = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+2) MOD 8,1,Nth(seed,8),0];
+      lSeede = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+2) MOD 8,1,Nth(seed,8),0];
+      lSeedf = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+2) MOD 8,1,Nth(seed,8),0];
 
-      % Facing SouthEast
-      if iAngle >= ANGLE_ESE AND iAngle < ANGLE_SSE
-      {
-         iRow = Send(who,@GetRow) - 1;
-         iCol = Send(who,@GetCol) + 3;
-         iXStep = -1;
-         iyStep = 1;
-      }
-
-      % Facing South
-      if iAngle >= ANGLE_SSE AND iAngle < ANGLE_SSW
-      {
-         iRow = Send(who,@GetRow) + 1;
-         iCol = Send(who,@GetCol) - 2;
-         iXStep = 1;
-         iyStep = 0;
-      }
-
-      % Facing SouthWest
-      if iAngle >= ANGLE_SSW AND iAngle < ANGLE_WSW
-      {
-         iRow = Send(who,@GetRow) + 3;
-         iCol = Send(who,@GetCol) + 1;
-         iXStep = -1;
-         iyStep = -1;
-      }
-
-      % Facing West
-      if iAngle >= ANGLE_WSW AND iAngle < ANGLE_WNW
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol) - 1;
-         iXStep = 0;
-         iYStep = 1;
-      }
-
-      % Facing NorthWest
-      if iAngle >= ANGLE_WNW AND iAngle < ANGLE_NNW
-      {
-         iRow = Send(who,@GetRow) + 1;
-         iCol = Send(who,@GetCol) - 3;
-         iXStep = 1;
-         iyStep = -1;
-      }
-
-      % Facing North
-      if iAngle >= ANGLE_NNW AND iAngle < ANGLE_NNE
-      {
-         iRow = Send(who,@GetRow) - 1;
-         iCol = Send(who,@GetCol) - 2;
-         iXStep = 1;
-         iyStep = 0;
-      }
-
-      % Facing NorthEast
-      if iAngle >= ANGLE_NNE AND iAngle < ANGLE_ENE
-      {
-         iRow = Send(who,@GetRow) - 3;
-         iCol = Send(who,@GetCol) - 1;
-         iXStep = 1;
-         iyStep = 1;
-      }
-
-      oRoom = Send(who,@GetOwner);
-
-      iFine_Row = Send(who,@GetFineRow);
-      iFine_Col = Send(who,@GetFineCol);
-
-
-      iHalfRow = 0;
-      iHalfCol = 0;
-      iHalfFine_Row = iFine_Row;
-      iHalfFine_Col = iFine_Col;
-
-      if iYStep < 0 
-      {
-         if iHalfFine_Row > 31
-         {
-            iHalfFine_Row = iHalfFine_Row - 32;
-         }
-         else
-         {
-            iHalfRow = -1;
-            iHalfFine_Row = 32 + iHalfFine_Row;
-         }
-      }
-
-      if iYStep > 0 
-      {
-         if iHalfFine_Row < 33
-         {
-            iHalfFine_Row = iHalfFine_Row + 32;
-         }
-         else
-         {
-            iHalfRow = 1;
-            iHalfFine_Row = iHalfFine_Row - 32;
-         }
-      }
-
-      if iXStep < 0 
-      {
-         if iHalfFine_Col > 31
-         {
-            iHalfFine_Col = iHalfFine_Col - 32;
-         }
-         else
-         {
-            iHalfCol = -1;
-            iHalfFine_Col = 32 + iHalfFine_Col;
-         }
-      }
-
-      if iXStep > 0 
-      {
-         if iHalfFine_Col < 33
-         {
-            iHalfFine_Col = iHalfFine_Col + 32;
-         }
-         else
-         {
-            iHalfCol = 1;
-            iHalfFine_Col = iHalfFine_Col - 32;
-         }
-      }
-
-      oElement = Create(&Brambles,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration,#HitPoints=iBrambleHits);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&Brambles,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration,#HitPoints=iBrambleHits);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+iYStep,#new_col=iCol+iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&Brambles,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration,#HitPoints=iBrambleHits);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+2*iYStep,#new_col=iCol+2*iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&Brambles,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration,#HitPoints=iBrambleHits);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+3*iYStep,#new_col=iCol+3*iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&Brambles,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration,#HitPoints=iBrambleHits);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+4*iYStep,#new_col=iCol+4*iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
+      Send(self,@SpawnElement,#seed=lSeeda,#who=Nth(seed,1),#xoffset=iXStep,#yoffset=iYStep,#walltype=&Brambles);
+      Send(self,@SpawnElement,#seed=lSeedb,#who=Nth(seed,1),#xoffset=iXStep*2,#yoffset=iYStep*2,#walltype=&Brambles);
+      Send(self,@SpawnElement,#seed=lSeedc,#who=Nth(seed,1),#xoffset=iXStep*3,#yoffset=iYStep*3,#walltype=&Brambles);
+      Send(self,@SpawnElement,#seed=lSeedd,#who=Nth(seed,1),#xoffset=iXStep,#yoffset=iYStep,#walltype=&Brambles);
+      Send(self,@SpawnElement,#seed=lSeede,#who=Nth(seed,1),#xoffset=iXStep*2,#yoffset=iYStep*2,#walltype=&Brambles);
+      Send(self,@SpawnElement,#seed=lSeedf,#who=Nth(seed,1),#xoffset=iXStep*3,#yoffset=iYStep*3,#walltype=&Brambles);
 
       propagate;
    }

--- a/kod/object/passive/spell/walspell/firewall.kod
+++ b/kod/object/passive/spell/walspell/firewall.kod
@@ -45,8 +45,6 @@ classvars:
 
    viHarmful = TRUE
 
-   viNumElements = 9
-
    vrSummonLimitMsg = FireWall_failed_rsc
 
 properties:
@@ -70,204 +68,29 @@ messages:
       propagate;
    }
 
-   PlaceWallElements(who = $, iSpellPower = 0)
+   PlaceWallElements(seed = $)
    {
-      local oRoom, iRow, iCol, iFine_Row, iFine_Col, iXStep, iYStep,
-            iAngle, iMaxDamage, iDuration, iHalfrow, iHalfCol, iHalfFine_Row,
-            iHalfFine_Col, oElement;
+      local lSeeda, lSeedb, lSeedc, lSeedd, lSeede, lSeedf, iDirection, iXStep, iYStep;
 
-      iAngle = Send(who,@GetAngle);
-      iMaxDamage = iSpellPower / 6;
-      iMaxDamage = Bound(iMaxDamage,1,16);
-      iDuration = (iSpellPower * 2) + 30;
-      iDuration = Bound(iDuration,30,180);
+      iDirection = Nth(seed,6);
+      iXStep = Send(self,@GetXStep,#direction=iDirection);
+      iYStep = Send(self,@GetYStep,#direction=iDirection);
 
-      % Facing East
-      if iAngle >= ANGLE_ENE OR iAngle < ANGLE_ESE
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol) + 1;
-         iXStep = 0;
-         iyStep = 1;
-      }
+      % The standard seed is modified here.
+      % [(1)caster,(2)spellpower,(3)duration,(4)charges,(5)speed,(6)direction,(7)step,(8)noise,(9)twirl]
+      lSeeda = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+6) MOD 8,1,Nth(seed,8),0];
+      lSeedb = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+6) MOD 8,1,Nth(seed,8),0];
+      lSeedc = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+6) MOD 8,1,Nth(seed,8),0];
+      lSeedd = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+2) MOD 8,1,Nth(seed,8),0];
+      lSeede = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+2) MOD 8,1,Nth(seed,8),0];
+      lSeedf = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+2) MOD 8,1,Nth(seed,8),0];
 
-      % Facing SouthEast
-      if iAngle >= ANGLE_ESE AND iAngle < ANGLE_SSE
-      {
-         iRow = Send(who,@GetRow) - 1;
-         iCol = Send(who,@GetCol) + 3;
-         iXStep = -1;
-         iyStep = 1;
-      }
-
-      % Facing South
-      if iAngle >= ANGLE_SSE AND iAngle < ANGLE_SSW
-      {
-         iRow = Send(who,@GetRow) + 1;
-         iCol = Send(who,@GetCol) - 2;
-         iXStep = 1;
-         iyStep = 0;
-      }
-
-      % Facing SouthWest
-      if iAngle >= ANGLE_SSW AND iAngle < ANGLE_WSW
-      {
-         iRow = Send(who,@GetRow) + 3;
-         iCol = Send(who,@GetCol) + 1;
-         iXStep = -1;
-         iyStep = -1;
-      }
-
-      % Facing West
-      if iAngle >= ANGLE_WSW AND iAngle < ANGLE_WNW
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol) - 1;
-         iXStep = 0;
-         iYStep = 1;
-      }
-
-      % Facing NorthWest
-      if iAngle >= ANGLE_WNW AND iAngle < ANGLE_NNW
-      {
-         iRow = Send(who,@GetRow) + 1;
-         iCol = Send(who,@GetCol) - 3;
-         iXStep = 1;
-         iyStep = -1;
-      }
-
-      % Facing North
-      if iAngle >= ANGLE_NNW AND iAngle < ANGLE_NNE
-      {
-         iRow = Send(who,@GetRow) - 1;
-         iCol = Send(who,@GetCol) - 2;
-         iXStep = 1;
-         iyStep = 0;
-      }
-
-      % Facing NorthEast
-      if iAngle >= ANGLE_NNE AND iAngle < ANGLE_ENE
-      {
-         iRow = Send(who,@GetRow) - 3;
-         iCol = Send(who,@GetCol) - 1;
-         iXStep = 1;
-         iyStep = 1;
-      }
-
-      oRoom = Send(who,@GetOwner);
-
-      iFine_Row = Send(who,@GetFineRow);
-      iFine_Col = Send(who,@GetFineCol);
-
-      iHalfRow = 0;
-      iHalfCol = 0;
-      iHalfFine_Row = iFine_Row;
-      iHalfFine_Col = iFine_Col;
-
-      if iYStep < 0 
-      {
-         if iHalfFine_Row > (FINENESS_HALF - 1)
-         {
-            iHalfFine_Row = iHalfFine_Row - FINENESS_HALF;
-         }
-         else
-         {
-            iHalfRow = -1;
-            iHalfFine_Row = FINENESS_HALF + iHalfFine_Row;
-         }
-      }
-
-      if iYStep > 0 
-      {
-         if iHalfFine_Row < (FINENESS_HALF + 1)
-         {
-            iHalfFine_Row = iHalfFine_Row + FINENESS_HALF;
-         }
-         else
-         {
-            iHalfRow = 1;
-            iHalfFine_Row = iHalfFine_Row - FINENESS_HALF;
-         }
-      }
-      if iXStep < 0 
-      {
-         if iHalfFine_Col > (FINENESS_HALF - 1)
-         {
-            iHalfFine_Col = iHalfFine_Col - FINENESS_HALF;
-         }
-         else
-         {
-            iHalfCol = -1;
-            iHalfFine_Col = FINENESS_HALF + iHalfFine_Col;
-         }
-      }
-
-      if iXStep > 0 
-      {
-         if iHalfFine_Col < (FINENESS_HALF + 1)
-         {
-            iHalfFine_Col = iHalfFine_Col + FINENESS_HALF;
-         }
-         else
-         {
-            iHalfCol = 1;
-            iHalfFine_Col = iHalfFine_Col - FINENESS_HALF;
-         }
-      }
-
-      oElement = Create(&WallOfFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration,#Illusionary=FALSE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow,#new_col=iCol,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PassiveWallOfFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration,#Illusionary=FALSE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+iHalfRow,#new_col=iCol+iHalfCol,
-           #fine_row=iHalfFine_Row,#fine_col=iHalfFine_Col);
-
-      oElement = Create(&WallOfFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration,#Illusionary=FALSE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+iYStep,#new_col=iCol+iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PassiveWallOfFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration,#Illusionary=FALSE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+iYStep+iHalfRow,#new_col=iCol+iXStep+iHalfCol,
-           #fine_row=iHalfFine_Row,#fine_col=iHalfFine_Col);
-
-      oElement = Create(&WallOfFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration,#Illusionary=FALSE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+2*iYStep,#new_col=iCol+2*iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PassiveWallOfFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration,#Illusionary=FALSE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+(2*iYStep)+iHalfRow,#new_col=iCol+(2*iXStep)+iHalfCol,
-           #fine_row=iHalfFine_Row,#fine_col=iHalfFine_Col);
-
-      oElement = Create(&WallOfFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration,#Illusionary=FALSE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+3*iYStep,#new_col=iCol+3*iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PassiveWallOfFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration,#Illusionary=FALSE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+(3*iYStep)+iHalfRow,#new_col=iCol+(3*iXStep)+iHalfCol,
-           #fine_row=iHalfFine_Row,#fine_col=iHalfFine_Col);
-
-      oElement = Create(&WallOfFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration,#Illusionary=FALSE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+4*iYStep,#new_col=iCol+4*iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
+      Send(self,@SpawnElement,#seed=lSeeda,#who=Nth(seed,1),#xoffset=iXStep,#yoffset=iYStep,#walltype=&WallOfFire);
+      Send(self,@SpawnElement,#seed=lSeedb,#who=Nth(seed,1),#xoffset=iXStep*2,#yoffset=iYStep*2,#walltype=&WallOfFire);
+      Send(self,@SpawnElement,#seed=lSeedc,#who=Nth(seed,1),#xoffset=iXStep*3,#yoffset=iYStep*3,#walltype=&WallOfFire);
+      Send(self,@SpawnElement,#seed=lSeedd,#who=Nth(seed,1),#xoffset=iXStep,#yoffset=iYStep,#walltype=&WallOfFire);
+      Send(self,@SpawnElement,#seed=lSeede,#who=Nth(seed,1),#xoffset=iXStep*2,#yoffset=iYStep*2,#walltype=&WallOfFire);
+      Send(self,@SpawnElement,#seed=lSeedf,#who=Nth(seed,1),#xoffset=iXStep*3,#yoffset=iYStep*3,#walltype=&WallOfFire);
 
       propagate;
    }

--- a/kod/object/passive/spell/walspell/flamewave.kod
+++ b/kod/object/passive/spell/walspell/flamewave.kod
@@ -1,0 +1,95 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+FlameWave is WallSpell
+
+constants:
+   include blakston.khd
+
+resources:
+
+   FlameWave_name_rsc = "flame wave"
+   FlameWave_icon_rsc = iwalfire.bgf
+   FlameWave_desc_rsc = \
+      "Creates a flame wave that leaves a swathe of fiery "
+      "destruction in its path.  "
+      "Requires red mushrooms and firesand to cast."
+
+   FlameWave_cast_rsc = "A blazing hot wave of flame and cinder spreads before you!"
+   FlameWave_failed_rsc = \
+      "There is too much summoning magic focused here to create a flame wave.  " 
+   FlameWave_sound = farenwala822m.wav
+
+classvars:
+
+   vrName = FlameWave_name_rsc
+   vrIcon = FlameWave_icon_rsc
+   vrDesc = FlameWave_desc_rsc
+
+   viSpell_num = SID_FLAME_WAVE
+   viSchool = SS_FAREN
+   viSpell_level = 4
+   viMana = 15
+   viSpellExertion = 10
+   viMeditate_ratio = 30
+
+   viCast_time = 1000
+   vrSucceed_wav = FlameWave_sound
+
+   viHarmful = TRUE
+
+   vrSummonLimitMsg = FlameWave_failed_rsc
+
+properties:
+
+
+messages:
+
+   ResetReagents()
+   {
+      plReagents = $;
+      plReagents = Cons([&RedMushroom,3],plReagents);
+      plReagents = Cons([&Firesand,2], plReagents);
+
+      return;
+   }
+
+   CastSpell(who = $, lTargets = $, iSpellPower = 1)
+   {
+      Send(who,@MsgSendUser,#message_rsc=FlameWave_cast_rsc);
+
+      propagate;
+   }
+
+   PlaceWallElements(seed = $)
+   {
+      local lSecondarySeed, lSeeda, lSeedb, iDirection, iXStep, iYStep;
+
+      iDirection = Nth(seed,6);
+      iXStep = Send(self,@GetXStep,#direction=iDirection);
+      iYStep = Send(self,@GetYStep,#direction=iDirection);
+
+      lSecondarySeed = [Nth(seed,1),Nth(seed,2)*3/2,500+Nth(seed,2)*25,Nth(seed,2)/3,300-Nth(seed,2)*2,iDirection,1,0,0];
+
+      % This creates a single row of wall elements up to 10 elements wide. These
+      % will then spawn the secondary wall elements specified above.
+      % [(1)caster,(2)spellpower,(3)duration,(4)charges,(5)speed,(6)direction,(7)step,(8)noise,(9)twirl]
+      lSeeda = [Nth(seed,1),Nth(seed,2)*3/2,500+Nth(seed,2)*25,Nth(seed,2)/20,300-Nth(seed,2)*2,(iDirection+6) MOD 8,1,0,0,lSecondarySeed];
+      lSeedb = [Nth(seed,1),Nth(seed,2)*3/2,500+Nth(seed,2)*25,Nth(seed,2)/20,300-Nth(seed,2)*2,(iDirection+2) MOD 8,1,0,0,lSecondarySeed];
+
+      Send(self,@SpawnElement,#seed=lSeeda,#who=Nth(seed,1),#xoffset=iXStep,#yoffset=iYStep,#walltype=&WallOfFire);
+      Send(self,@SpawnElement,#seed=lSeedb,#who=Nth(seed,1),#xoffset=iXStep,#yoffset=iYStep,#walltype=&WallOfFire);
+
+      propagate;
+   }
+
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/walspell/ifirewal.kod
+++ b/kod/object/passive/spell/walspell/ifirewal.kod
@@ -51,8 +51,6 @@ classvars:
    % Illusionary fire can't kill anyone, so don't warn about being a murderer.
    viWallCanKill = FALSE
 
-   viNumElements = 9
-
    vrSummonLimitMsg = IllusionaryFireWall_failed_rsc
 
 properties:
@@ -76,206 +74,32 @@ messages:
       propagate;
    }
 
-   PlaceWallElements(who = $, iSpellPower = 0)
+   PlaceWallElements(seed = $)
    {
-      local oRoom, iRow, iCol, iFine_Row, iFine_Col, iXStep, iYStep, iAngle,
-            iDuration, iHalfrow, iHalfCol, iHalfFine_Row, iHalfFine_Col,
-            oElement;
+      local lSeeda, lSeedb, lSeedc, lSeedd, lSeede, lSeedf, iDirection, iXStep, iYStep;
 
-      iAngle = Send(who,@GetAngle);
-      iDuration = (iSpellPower * 2) + 30;
-      iDuration = Bound(iDuration,30,180);
+      iDirection = Nth(seed,6);
+      iXStep = Send(self,@GetXStep,#direction=iDirection);
+      iYStep = Send(self,@GetYStep,#direction=iDirection);
 
-      % Facing East
-      if iAngle >= ANGLE_ENE OR iAngle < ANGLE_ESE
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol) + 1;
-         iXStep = 0;
-         iyStep = 1;
-      }
+      % The standard seed is modified here.
+      % [(1)caster,(2)spellpower,(3)duration,(4)charges,(5)speed,(6)direction,(7)step,(8)noise,(9)twirl]
+      lSeeda = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+6) MOD 8,1,Nth(seed,8),0];
+      lSeedb = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+6) MOD 8,1,Nth(seed,8),0];
+      lSeedc = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+6) MOD 8,1,Nth(seed,8),0];
+      lSeedd = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+2) MOD 8,1,Nth(seed,8),0];
+      lSeede = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+2) MOD 8,1,Nth(seed,8),0];
+      lSeedf = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+2) MOD 8,1,Nth(seed,8),0];
 
-      % Facing SouthEast
-      if iAngle >= ANGLE_ESE AND iAngle < ANGLE_SSE
-      {
-         iRow = Send(who,@GetRow) - 1;
-         iCol = Send(who,@GetCol) + 3;
-         iXStep = -1;
-         iyStep = 1;
-      }
-
-      % Facing South
-      if iAngle >= ANGLE_SSE AND iAngle < ANGLE_SSW
-      {
-         iRow = Send(who,@GetRow) + 1;
-         iCol = Send(who,@GetCol) - 2;
-         iXStep = 1;
-         iyStep = 0;
-      }
-
-      % Facing SouthWest
-      if iAngle >= ANGLE_SSW AND iAngle < ANGLE_WSW
-      {
-         iRow = Send(who,@GetRow) + 3;
-         iCol = Send(who,@GetCol) + 1;
-         iXStep = -1;
-         iyStep = -1;
-      }
-
-      % Facing West
-      if iAngle >= ANGLE_WSW AND iAngle < ANGLE_WNW
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol) - 1;
-         iXStep = 0;
-         iYStep = 1;
-      }
-
-      % Facing NorthWest
-      if iAngle >= ANGLE_WNW AND iAngle < ANGLE_NNW
-      {
-         iRow = Send(who,@GetRow) + 1;
-         iCol = Send(who,@GetCol) - 3;
-         iXStep = 1;
-         iyStep = -1;
-      }
-
-      % Facing North
-      if iAngle >= ANGLE_NNW AND iAngle < ANGLE_NNE
-      {
-         iRow = Send(who,@GetRow) - 1;
-         iCol = Send(who,@GetCol) - 2;
-         iXStep = 1;
-         iyStep = 0;
-      }
-
-      % Facing NorthEast
-      if iAngle >= ANGLE_NNE and iAngle < ANGLE_ENE
-      {
-         iRow = Send(who,@GetRow) - 3;
-         iCol = Send(who,@GetCol) - 1;
-         iXStep = 1;
-         iyStep = 1;
-      }
-
-      oRoom = Send(who,@GetOwner);
-
-      iFine_Row = Send(who,@GetFineRow);
-      iFine_Col = Send(who,@GetFineCol);
-
-      iHalfRow = 0;
-      iHalfCol = 0;
-      iHalfFine_Row = iFine_Row;
-      iHalfFine_Col = iFine_Col;
-
-      if iYStep < 0 
-      {
-         if iHalfFine_Row > (FINENESS_HALF - 1)
-         {
-            iHalfFine_Row = iHalfFine_Row - FINENESS_HALF;
-         }
-         else
-         {
-            iHalfRow = -1;
-            iHalfFine_Row = FINENESS_HALF + iHalfFine_Row;
-         }
-      }
-
-      if iYStep > 0 
-      {
-         if iHalfFine_Row < (FINENESS_HALF + 1)
-         {
-            iHalfFine_Row = iHalfFine_Row + FINENESS_HALF;
-         }
-         else
-         {
-            iHalfRow = 1;
-            iHalfFine_Row = iHalfFine_Row - FINENESS_HALF;
-         }
-      }
-      if iXStep < 0 
-      {
-         if iHalfFine_Col > (FINENESS_HALF - 1)
-         {
-            iHalfFine_Col = iHalfFine_Col - FINENESS_HALF;
-         }
-         else
-         {
-            iHalfCol = -1;
-            iHalfFine_Col = FINENESS_HALF + iHalfFine_Col;
-         }
-      }
-
-      if iXStep > 0 
-      {
-         if iHalfFine_Col < (FINENESS_HALF + 1)
-         {
-            iHalfFine_Col = iHalfFine_Col + FINENESS_HALF;
-         }
-         else
-         {
-            iHalfCol = 1;
-            iHalfFine_Col = iHalfFine_Col - FINENESS_HALF;
-         }
-      }
-
-      oElement = Create(&WallOfFire,#MaxDamage=iSpellPower,#Caster=who,
-                        #Duration=iDuration,#Illusionary=TRUE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow,#new_col=iCol,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PassiveWallOfFire,#MaxDamage=iSpellPower,#Caster=who,
-                        #Duration=iDuration,#Illusionary=TRUE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+iHalfRow,#new_col=iCol+iHalfCol,
-           #fine_row=iHalfFine_Row,#fine_col=iHalfFine_Col);
-
-      oElement = Create(&WallOfFire,#MaxDamage=iSpellPower,#Caster=who,
-                        #Duration=iDuration,#Illusionary=TRUE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+iYStep,#new_col=iCol+iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PassiveWallOfFire,#MaxDamage=iSpellPower,#Caster=who,
-                        #Duration=iDuration,#Illusionary=TRUE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+iYStep+iHalfRow,#new_col=iCol+iXStep+iHalfCol,
-           #fine_row=iHalfFine_Row,#fine_col=iHalfFine_Col);
-
-      oElement = Create(&WallOfFire,#MaxDamage=iSpellPower,#Caster=who,
-                        #Duration=iDuration,#Illusionary=TRUE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+2*iYStep,#new_col=iCol+2*iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PassiveWallOfFire,#MaxDamage=iSpellPower,#Caster=who,
-                        #Duration=iDuration,#Illusionary=TRUE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+(2*iYStep)+iHalfRow,#new_col=iCol+(2*iXStep)+iHalfCol,
-           #fine_row=iHalfFine_Row,#fine_col=iHalfFine_Col);
-
-      oElement = Create(&WallOfFire,#MaxDamage=iSpellPower,#Caster=who,
-                        #Duration=iDuration,#Illusionary=TRUE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+3*iYStep,#new_col=iCol+3*iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PassiveWallOfFire,#MaxDamage=iSpellPower,#Caster=who,
-                        #Duration=iDuration,#Illusionary=TRUE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+(3*iYStep)+iHalfRow,#new_col=iCol+(3*iXStep)+iHalfCol,
-           #fine_row=iHalfFine_Row,#fine_col=iHalfFine_Col);
-
-      oElement = Create(&WallOfFire,#MaxDamage=iSpellPower,#Caster=who,
-                        #Duration=iDuration,#Illusionary=TRUE);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+4*iYStep,#new_col=iCol+4*iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
+      Send(self,@SpawnElement,#seed=lSeeda,#who=Nth(seed,1),#xoffset=iXStep,#yoffset=iYStep,#walltype=&IllusionaryWallOfFire);
+      Send(self,@SpawnElement,#seed=lSeedb,#who=Nth(seed,1),#xoffset=iXStep*2,#yoffset=iYStep*2,#walltype=&IllusionaryWallOfFire);
+      Send(self,@SpawnElement,#seed=lSeedc,#who=Nth(seed,1),#xoffset=iXStep*3,#yoffset=iYStep*3,#walltype=&IllusionaryWallOfFire);
+      Send(self,@SpawnElement,#seed=lSeedd,#who=Nth(seed,1),#xoffset=iXStep,#yoffset=iYStep,#walltype=&IllusionaryWallOfFire);
+      Send(self,@SpawnElement,#seed=lSeede,#who=Nth(seed,1),#xoffset=iXStep*2,#yoffset=iYStep*2,#walltype=&IllusionaryWallOfFire);
+      Send(self,@SpawnElement,#seed=lSeedf,#who=Nth(seed,1),#xoffset=iXStep*3,#yoffset=iYStep*3,#walltype=&IllusionaryWallOfFire);
 
       propagate;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/walspell/ltngwall.kod
+++ b/kod/object/passive/spell/walspell/ltngwall.kod
@@ -49,8 +49,6 @@ classvars:
 
    viHarmful = TRUE
 
-   viNumElements = 9
-
    vrSummonLimitMsg = LightningWall_failed_rsc
 
 properties:
@@ -73,204 +71,29 @@ messages:
       propagate;
    }
 
-   PlaceWallElements(who = $, iSpellPower = 0)
+   PlaceWallElements(seed = $)
    {
-      local oRoom, iRow, iCol, iFine_Row, iFine_Col, iXStep, iYStep,
-            iAngle, iMaxDamage, iDuration, iHalfrow, iHalfCol, iHalfFine_Row,
-            iHalfFine_Col, oElement;
+      local lSeeda, lSeedb, lSeedc, lSeedd, lSeede, lSeedf, iDirection, iXStep, iYStep;
 
-      iAngle = Send(who,@GetAngle);
-      iMaxDamage = iSpellPower / 4;
-      iMaxDamage = Bound(iMaxDamage,1,25);
-      iDuration = (iSpellPower * 2) + 20;
-      iDuration = Bound(iDuration,20,120);
+      iDirection = Nth(seed,6);
+      iXStep = Send(self,@GetXStep,#direction=iDirection);
+      iYStep = Send(self,@GetYStep,#direction=iDirection);
 
-      % Facing East
-      if iAngle >= ANGLE_ENE OR iAngle < ANGLE_ESE
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol) + 1;
-         iXStep = 0;
-         iyStep = 1;
-      }
+      % The standard seed is modified here.
+      % [(1)caster,(2)spellpower,(3)duration,(4)charges,(5)speed,(6)direction,(7)step,(8)noise,(9)twirl]
+      lSeeda = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+6) MOD 8,1,Nth(seed,8),0];
+      lSeedb = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+6) MOD 8,1,Nth(seed,8),0];
+      lSeedc = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+6) MOD 8,1,Nth(seed,8),0];
+      lSeedd = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+2) MOD 8,1,Nth(seed,8),0];
+      lSeede = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+2) MOD 8,1,Nth(seed,8),0];
+      lSeedf = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,4),Nth(seed,5),(iDirection+2) MOD 8,1,Nth(seed,8),0];
 
-      % Facing SouthEast
-      if iAngle >= ANGLE_ESE AND iAngle < ANGLE_SSE
-      {
-         iRow = Send(who,@GetRow) - 1;
-         iCol = Send(who,@GetCol) + 3;
-         iXStep = -1;
-         iyStep = 1;
-      }
-
-      % Facing South
-      if iAngle >= ANGLE_SSE AND iAngle < ANGLE_SSW
-      {
-         iRow = Send(who,@GetRow) + 1;
-         iCol = Send(who,@GetCol) - 2;
-         iXStep = 1;
-         iyStep = 0;
-      }
-
-      % Facing SouthWest
-      if iAngle >= ANGLE_SSW AND iAngle < ANGLE_WSW
-      {
-         iRow = Send(who,@GetRow) + 3;
-         iCol = Send(who,@GetCol) + 1;
-         iXStep = -1;
-         iyStep = -1;
-      }
-
-      % Facing West
-      if iAngle >= ANGLE_WSW AND iAngle < ANGLE_WNW
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol) - 1;
-         iXStep = 0;
-         iYStep = 1;
-      }
-
-      % Facing NorthWest
-      if iAngle >= ANGLE_WNW AND iAngle < ANGLE_NNW
-      {
-         iRow = Send(who,@GetRow) + 1;
-         iCol = Send(who,@GetCol) - 3;
-         iXStep = 1;
-         iyStep = -1;
-      }
-
-      % Facing North
-      if iAngle >= ANGLE_NNW AND iAngle < ANGLE_NNE
-      {
-         iRow = Send(who,@GetRow) - 1;
-         iCol = Send(who,@GetCol) - 2;
-         iXStep = 1;
-         iyStep = 0;
-      }
-
-      % Facing NorthEast
-      if iAngle >= ANGLE_NNE and iAngle < ANGLE_ENE
-      {
-         iRow = Send(who,@GetRow) - 3;
-         iCol = Send(who,@GetCol) - 1;
-         iXStep = 1;
-         iyStep = 1;
-      }
-
-      oRoom = Send(who,@GetOwner);
-
-      iFine_Row = Send(who,@GetFineRow);
-      iFine_Col = Send(who,@GetFineCol);
-
-      iHalfRow = 0;
-      iHalfCol = 0;
-      iHalfFine_Row = iFine_Row;
-      iHalfFine_Col = iFine_Col;
-
-      if iYStep < 0 
-      {
-         if iHalfFine_Row > (FINENESS_HALF - 1)
-         {
-            iHalfFine_Row = iHalfFine_Row - FINENESS_HALF;
-         }
-         else
-         {
-            iHalfRow = -1;
-            iHalfFine_Row = FINENESS_HALF + iHalfFine_Row;
-         }
-      }
-
-      if iYStep > 0 
-      {
-         if iHalfFine_Row < (FINENESS_HALF + 1)
-         {
-            iHalfFine_Row = iHalfFine_Row + FINENESS_HALF;
-         }
-         else
-         {
-            iHalfRow = 1;
-            iHalfFine_Row = iHalfFine_Row - FINENESS_HALF;
-         }
-      }
-      if iXStep < 0 
-      {
-         if iHalfFine_Col > (FINENESS_HALF - 1)
-         {
-            iHalfFine_Col = iHalfFine_Col - FINENESS_HALF;
-         }
-         else
-         {
-            iHalfCol = -1;
-            iHalfFine_Col = FINENESS_HALF + iHalfFine_Col;
-         }
-      }
-
-      if iXStep > 0 
-      {
-         if iHalfFine_Col < (FINENESS_HALF + 1)
-         {
-            iHalfFine_Col = iHalfFine_Col + FINENESS_HALF;
-         }
-         else
-         {
-            iHalfCol = 1;
-            iHalfFine_Col = iHalfFine_Col - FINENESS_HALF;
-         }
-      }
-
-      oElement = Create(&WallOfLightning,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow,#new_col=iCol,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PassiveWallOfLightning,#MaxDamage=iMaxDamage,
-                        #Caster=who,#Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+iHalfRow,#new_col=iCol+iHalfCol,
-           #fine_row=iHalfFine_Row,#fine_col=iHalfFine_Col);
-
-      oElement = Create(&WallOfLightning,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+iYStep,#new_col=iCol+iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PassiveWallOfLightning,#MaxDamage=iMaxDamage,
-                        #Caster=who,#Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+iYStep+iHalfRow,#new_col=iCol+iXStep+iHalfCol,
-           #fine_row=iHalfFine_Row,#fine_col=iHalfFine_Col);
-
-      oElement = Create(&WallOfLightning,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+2*iYStep,#new_col=iCol+2*iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PassiveWallOfLightning,#MaxDamage=iMaxDamage,
-                        #Caster=who,#Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+(2*iYStep)+iHalfRow,#new_col=iCol+(2*iXStep)+iHalfCol,
-           #fine_row=iHalfFine_Row,#fine_col=iHalfFine_Col);
-
-      oElement = Create(&WallOfLightning,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+3*iYStep,#new_col=iCol+3*iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PassiveWallOfLightning,#MaxDamage=iMaxDamage,
-                        #Caster=who,#Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+(3*iYStep)+iHalfRow,#new_col=iCol+(3*iXStep)+iHalfCol,
-           #fine_row=iHalfFine_Row,#fine_col=iHalfFine_Col);
-
-      oElement = Create(&WallOfLightning,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,
-           #new_row=iRow+4*iYStep,#new_col=iCol+4*iXStep,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
+      Send(self,@SpawnElement,#seed=lSeeda,#who=Nth(seed,1),#xoffset=iXStep,#yoffset=iYStep,#walltype=&WallOfLightning);
+      Send(self,@SpawnElement,#seed=lSeedb,#who=Nth(seed,1),#xoffset=iXStep*2,#yoffset=iYStep*2,#walltype=&WallOfLightning);
+      Send(self,@SpawnElement,#seed=lSeedc,#who=Nth(seed,1),#xoffset=iXStep*3,#yoffset=iYStep*3,#walltype=&WallOfLightning);
+      Send(self,@SpawnElement,#seed=lSeedd,#who=Nth(seed,1),#xoffset=iXStep,#yoffset=iYStep,#walltype=&WallOfLightning);
+      Send(self,@SpawnElement,#seed=lSeede,#who=Nth(seed,1),#xoffset=iXStep*2,#yoffset=iYStep*2,#walltype=&WallOfLightning);
+      Send(self,@SpawnElement,#seed=lSeedf,#who=Nth(seed,1),#xoffset=iXStep*3,#yoffset=iYStep*3,#walltype=&WallOfLightning);
 
       propagate;
    }

--- a/kod/object/passive/spell/walspell/makefile
+++ b/kod/object/passive/spell/walspell/makefile
@@ -6,6 +6,6 @@
 
 DEPEND = ..\walspell.bof
 BOFS = brmblwll.bof summpfog.bof summweb.bof summfog.bof ifirewal.bof \
-       firewall.bof ltngwall.bof rngflame.bof sporbrst.bof
+       firewall.bof ltngwall.bof rngflame.bof sporbrst.bof flamewave.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/passive/spell/walspell/rngflame.kod
+++ b/kod/object/passive/spell/walspell/rngflame.kod
@@ -19,11 +19,11 @@ resources:
    RingOfFlames_name_rsc = "ring of flames"
    RingOfFlames_icon_rsc = iringfir.bgf
    RingOfFlames_desc_rsc = \
-      "Creates a ring of flames around target.  "
+      "Creates a devastating firestorm around the caster.  "
       "Requires red mushrooms and firesand to cast."
 
-   RingOfFlames_caster = "A blazing hot ring of flames appears around %s%q."
-   RingOfFlames_target = "A blazing hot ring of flames appears around you!"
+   RingOfFlames_cast_rsc = "A ring of flames begins to form around you!"
+
    RingOfFlames_failed_rsc = \
       "There is too much summoning magic focused here to create a ring of "
       "flames." 
@@ -48,10 +48,6 @@ classvars:
    viHarmful = TRUE
    viOutlaw = TRUE
 
-   % We technically have 12 elements, but that would never let us cast this while
-   %  another wall spell is active.  A little cheat here, only count 9 elements.
-   viNumElements = 9
-
    vrSummonLimitMsg = RingOfFlames_failed_rsc
 
 properties:
@@ -67,120 +63,36 @@ messages:
       return;
    }
 
-   GetNumSpellTargets()
+   CastSpell(who = $, lTargets = $, iSpellPower = 1)
    {
-      return 1;
-   }
-
-   CastSpell(who=$,lTargets=$,iSpellPower=0)
-   {
-      local oTarget;
-
-      if lTargets = $
-      {
-         Debug("Ring of Flames cast will nil target list");
-
-         return;
-      }
-
-      oTarget = First(lTargets);
-
-      if oTarget = $
-      {
-         Debug("Ring of Flames cast will nil target");
-
-         return;
-      }
-
-      Send(oTarget,@MsgSendUser,#message_rsc=RingOfFlames_target,
-            #parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
-
-      Send(who,@MsgSendUser,#message_rsc=RingOfFlames_caster);
+      Send(who,@MsgSendUser,#message_rsc=RingOfFlames_cast_rsc);
 
       propagate;
    }
 
-   PlaceWallElements(who=$,lTargets=$,iSpellPower=0)
+   PlaceWallElements(seed = $)
    {
-      local oRoom, iRow, iCol, iFine_Row, iFine_Col, iXStep, iYStep,
-            iAngle, iMaxDamage, iDuration, iHalfrow, iHalfCol, iHalfFine_Row,
-            iHalfFine_Col, oElement, oTarget;
+      local lSeeda, lSeedb, lSeedc, lSeedd, lSeede, lSeedf, lSeedg, lSeedh;
 
-      oTarget = First(lTargets);
+      % The standard seed is modified here.
+      % [(1)caster,(2)spellpower,(3)duration,(4)charges,(5)speed,(6)direction,(7)step,(8)noise,(9)twirl]
+      lSeeda = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),0,1,Nth(seed,8),3];
+      lSeedb = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),1,1,Nth(seed,8),3];
+      lSeedc = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),2,1,Nth(seed,8),3];
+      lSeedd = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),3,1,Nth(seed,8),3];
+      lSeede = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),4,1,Nth(seed,8),3];
+      lSeedf = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),5,1,Nth(seed,8),3];
+      lSeedg = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),6,1,Nth(seed,8),3];
+      lSeedh = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),7,1,Nth(seed,8),3];
 
-      iAngle = Send(oTarget,@GetAngle);
-      iMaxDamage = iSpellPower / 5;
-      iMaxDamage = Bound(iMaxDamage,1,20);
-      iDuration = (iSpellPower * 2) + 30;
-      iDuration = Bound(iDuration,30,180);
-
-      oRoom = Send(oTarget,@GetOwner);
-
-      iRow = Send(oTarget,@GetRow);
-      iCol = Send(oTarget,@GetCol);
-
-      % Create fire in eight cardinal directions
-      oElement = Create(&WallofFire,#Caster=who,#MaxDamage=iMaxDamage,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=(iRow+1),#new_col=(iCol+1),
-           #fine_row=FINENESS_HALF,#fine_col=FINENESS_HALF);
-
-      oElement = Create(&WallofFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=(iRow+1),#new_col=iCol,
-           #fine_row=FINENESS_HALF,#fine_col=FINENESS_HALF);
-
-      oElement = Create(&WallofFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=(iRow+1),#new_col=(iCol-1),
-           #fine_row=FINENESS_HALF,#fine_col=FINENESS_HALF);
-
-      oElement = Create(&WallofFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=(iCol+1),
-           #fine_row=FINENESS_HALF,#fine_col=FINENESS_HALF);
-
-      oElement = Create(&WallofFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=(iCol-1),
-           #fine_row=FINENESS_HALF,#fine_col=FINENESS_HALF);
-
-      oElement = Create(&WallofFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=(iRow-1),#new_col=(iCol+1),
-           #fine_row=FINENESS_HALF,#fine_col=FINENESS_HALF);
-
-      oElement = Create(&WallofFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=(iRow-1),#new_col=iCol,
-           #fine_row=FINENESS_HALF,#fine_col=FINENESS_HALF);
-
-      oElement = Create(&WallofFire,#MaxDamage=iMaxDamage,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=(iRow-1),#new_col=(iCol-1),
-           #fine_row=FINENESS_HALF,#fine_col=FINENESS_HALF);
-
-
-      % Create four "filler" elements in corners.
-      oElement = Create(&PassiveWallofFire,#Caster=who,#MaxDamage=iMaxDamage,
-                        #Duration=iDuration,#Illusionary=FALSE);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol,
-           #fine_row=0,#fine_col=0);
-
-      oElement = Create(&PassiveWallofFire,#Caster=who,#MaxDamage=iMaxDamage,
-                        #Duration=iDuration,#Illusionary=FALSE);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol,
-           #fine_row=0,#fine_col=FINENESS);
-
-      oElement = Create(&PassiveWallofFire,#Caster=who,#MaxDamage=iMaxDamage,
-                        #Duration=iDuration,#Illusionary=FALSE);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol,
-           #fine_row=FINENESS,#fine_col=0);
-
-      oElement = Create(&PassiveWallofFire,#Caster=who,#MaxDamage=iMaxDamage,
-                        #Duration=iDuration,#Illusionary=FALSE);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol,
-           #fine_row=FINENESS,#fine_col=FINENESS);
+      Send(self,@SpawnElement,#seed=lSeeda,#who=Nth(seed,1),#xoffset=0,#yoffset=-1,#walltype=&WallOfFire);
+      Send(self,@SpawnElement,#seed=lSeedb,#who=Nth(seed,1),#xoffset=1,#yoffset=-1,#walltype=&WallOfFire);
+      Send(self,@SpawnElement,#seed=lSeedc,#who=Nth(seed,1),#xoffset=1,#yoffset=0,#walltype=&WallOfFire);
+      Send(self,@SpawnElement,#seed=lSeedd,#who=Nth(seed,1),#xoffset=1,#yoffset=1,#walltype=&WallOfFire);
+      Send(self,@SpawnElement,#seed=lSeede,#who=Nth(seed,1),#xoffset=0,#yoffset=1,#walltype=&WallOfFire);
+      Send(self,@SpawnElement,#seed=lSeedf,#who=Nth(seed,1),#xoffset=-1,#yoffset=1,#walltype=&WallOfFire);
+      Send(self,@SpawnElement,#seed=lSeedg,#who=Nth(seed,1),#xoffset=-1,#yoffset=0,#walltype=&WallOfFire);
+      Send(self,@SpawnElement,#seed=lSeedh,#who=Nth(seed,1),#xoffset=-1,#yoffset=-1,#walltype=&WallOfFire);
 
       propagate;
    }

--- a/kod/object/passive/spell/walspell/sporbrst.kod
+++ b/kod/object/passive/spell/walspell/sporbrst.kod
@@ -53,11 +53,6 @@ classvars:
    % Sporeburst can't kill anyone, so don't warn about being a murderer.
    viWallCanKill = FALSE
 
-   % We technically have more elements, but that would never let us cast this
-   %  while another wall spell is active.  A little cheat here, only count 9
-   %  elements.
-   viNumElements = 9
-
    vrSummonLimitMsg = SporeBurst_failed_rsc
 
 properties:
@@ -81,187 +76,31 @@ messages:
       propagate;
    }
 
-   PlaceWallElements(who = $, iSpellPower = 0)
+   PlaceWallElements(seed = $)
    {
-      local i, oRoom, iCounter, iDiff, oActiveFog, oPassiveFog, iRadius,
-            iDuration, iCasterRow, iCasterCol, iCasterFineRow, iCasterFineCol;
+      local lSeeda, lSeedb, lSeedc, lSeedd, lSeede, lSeedf, lSeedg, lSeedh;
 
-      oRoom = Send(who,@GetOwner);
-      iRadius = Bound(iSpellpower/30,1,3);
-      iDuration = Send(self,@GetDuration,#iSpellpower=iSpellpower);
+      % The standard seed is modified here.
+      % [(1)caster,(2)spellpower,(3)duration,(4)charges,(5)speed,(6)direction,(7)step,(8)noise,(9)twirl]
+      lSeeda = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),0,1,Nth(seed,8),2];
+      lSeedb = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),1,1,Nth(seed,8),2];
+      lSeedc = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),2,1,Nth(seed,8),2];
+      lSeedd = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),3,1,Nth(seed,8),2];
+      lSeede = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),4,1,Nth(seed,8),2];
+      lSeedf = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),5,1,Nth(seed,8),2];
+      lSeedg = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),6,1,Nth(seed,8),2];
+      lSeedh = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),7,1,Nth(seed,8),2];
 
-      iCasterRow = Send(who,@GetRow);
-      iCasterCol = Send(who,@GetCol);
-      iCasterFineRow = Send(who,@GetFineRow);
-      iCasterFineCol = Send(who,@GetFineCol);
-
-      % Active element, placed in the center of it all.
-      oActiveFog = Create(&ActiveSporeCloud,#Caster=who,#duration=iDuration,
-                          #range=iRadius);
-      Send(oRoom,@NewHold,#what=oActiveFog,#new_row=iCasterRow,#new_col=iCasterCol);
-
-      % Place the inactive elems.
-      % Our goal is to place the clouds in such a way that it gives the illusion of a
-      %  a larger cloud.  We don't want to use too many elements, but a radius of 3 is
-      %  going to require a fair number of elements to look right.
-
-      if iRadius >= 1
-      {
-         % Create 4 elements on the cardinal directions.
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+1,#new_col=iCasterCol);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-1,#new_col=iCasterCol);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow,#new_col=iCasterCol+1);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow,#new_col=iCasterCol-1);
-      }
-
-      if iRadius >= 2
-      {
-         % Create a diamond around the outside.
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+2,#new_col=iCasterCol);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+1,#new_col=iCasterCol+1);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+1,#new_col=iCasterCol-1);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow,#new_col=iCasterCol+2);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow,#new_col=iCasterCol-2);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-1,#new_col=iCasterCol+1);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-1,#new_col=iCasterCol-1);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-2,#new_col=iCasterCol);
-      }
-
-      if iRadius >= 3
-      {
-         % Add a few elements along the outside to simulate bulk.  The final pattern
-         % will look like a 7x7 checkerboard pattern with no corners and the center
-         % element being the active one.
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+3,#new_col=iCasterCol+1,
-              #fine_row=0,#fine_col=0);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+3,#new_col=iCasterCol-1,
-              #fine_row=0,#fine_col=FINENESS);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+2,#new_col=iCasterCol+2);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+2,#new_col=iCasterCol-2);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+1,#new_col=iCasterCol+3,
-              #fine_row=0,#fine_col=0);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow+1,#new_col=iCasterCol-3,
-              #fine_row=0,#fine_col=FINENESS);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-1,#new_col=iCasterCol+3,
-              #fine_row=FINENESS,#fine_col=0);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-1,#new_col=iCasterCol-3,
-              #fine_row=FINENESS,#fine_col=FINENESS);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-2,#new_col=iCasterCol+2);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-2,#new_col=iCasterCol-2);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-3,#new_col=iCasterCol+1,
-              #fine_row=FINENESS,#fine_col=0);
-
-         oPassiveFog = Create(&SporeCloud,#oRoom=oRoom,#Active_Elem=oActiveFog,
-                              #Caster=who,#duration=iDuration);
-         Send(oRoom,@NewHold,#what=oPassiveFog,
-              #new_row=iCasterRow-3,#new_col=iCasterCol-1,
-              #fine_row=FINENESS,#fine_col=FINENESS);
-      }         
+      Send(self,@SpawnElement,#seed=lSeeda,#who=Nth(seed,1),#xoffset=0,#yoffset=-1,#walltype=&ActiveSporeCloud);
+      Send(self,@SpawnElement,#seed=lSeedb,#who=Nth(seed,1),#xoffset=1,#yoffset=-1,#walltype=&ActiveSporeCloud);
+      Send(self,@SpawnElement,#seed=lSeedc,#who=Nth(seed,1),#xoffset=1,#yoffset=0,#walltype=&ActiveSporeCloud);
+      Send(self,@SpawnElement,#seed=lSeedd,#who=Nth(seed,1),#xoffset=1,#yoffset=1,#walltype=&ActiveSporeCloud);
+      Send(self,@SpawnElement,#seed=lSeede,#who=Nth(seed,1),#xoffset=0,#yoffset=1,#walltype=&ActiveSporeCloud);
+      Send(self,@SpawnElement,#seed=lSeedf,#who=Nth(seed,1),#xoffset=-1,#yoffset=1,#walltype=&ActiveSporeCloud);
+      Send(self,@SpawnElement,#seed=lSeedg,#who=Nth(seed,1),#xoffset=-1,#yoffset=0,#walltype=&ActiveSporeCloud);
+      Send(self,@SpawnElement,#seed=lSeedh,#who=Nth(seed,1),#xoffset=-1,#yoffset=-1,#walltype=&ActiveSporeCloud);
 
       propagate;
-   }
-
-   GetDuration(iSpellPower=$, caster=0)
-   {
-      local iDuration;
-
-      % Duration, in seconds
-      iDuration = iSpellPower * 2; 
-      iDuration = bound(iDuration,30,200);
-      % Convert to ms.
-      iDuration = iDuration * 1000;
-
-      return iDuration;
    }
 
    ModifyMonsterBehavior(mob = $)

--- a/kod/object/passive/spell/walspell/summfog.kod
+++ b/kod/object/passive/spell/walspell/summfog.kod
@@ -55,8 +55,6 @@ classvars:
    viHarmful = FALSE
    viOutlaw = FALSE
 
-   viNumElements = 9
-
    vrSummonLimitMsg = SummonFog_failed_rsc
 
 properties:
@@ -79,115 +77,29 @@ messages:
       propagate;
    }
 
-   PlaceWallElements(who = $, iSpellPower = 0)
+   PlaceWallElements(seed = $)
    {
-      local oRoom, iRow, iCol, iFine_Row, iFine_Col, iAngle, iOdds, iDuration,
-            oElement;
+      local lSeeda, lSeedb, lSeedc, lSeedd, lSeede, lSeedf, lSeedg, lSeedh;
 
-      iAngle = Send(who,@GetAngle);
-      iOdds = 50+(iSpellPower/2);
-      iOdds = Bound(iOdds,50,90);
+      % The standard seed is modified here.
+      % [(1)caster,(2)spellpower,(3)duration,(4)charges,(5)speed,(6)direction,(7)step,(8)noise,(9)twirl]
+      lSeeda = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),0,1,Nth(seed,8),2];
+      lSeedb = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),1,1,Nth(seed,8),2];
+      lSeedc = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),2,1,Nth(seed,8),2];
+      lSeedd = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),3,1,Nth(seed,8),2];
+      lSeede = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),4,1,Nth(seed,8),2];
+      lSeedf = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),5,1,Nth(seed,8),2];
+      lSeedg = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),6,1,Nth(seed,8),2];
+      lSeedh = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),7,1,Nth(seed,8),2];
 
-      iDuration = iSpellPower + 20;
-      iDuration = Bound(iDuration,15,95);
-
-      % Facing East
-      if iAngle > ANGLE_ENE OR iAngle < ANGLE_ESE
-      {
-         iCol = Send(who,@GetCol) + 2;
-         iRow = Send(who,@GetRow);
-      }
-
-      % Facing SouthEast
-      if iAngle >= ANGLE_ESE AND iAngle < ANGLE_SSE
-      {
-         iRow = Send(who,@GetRow) + 2;
-         iCol = Send(who,@GetCol) + 2;
-      }
-
-      % Facing South
-      if iAngle >= ANGLE_SSE AND iAngle < ANGLE_SSW
-      {
-         iRow = Send(who,@GetRow) + 2;
-         iCol = Send(who,@GetCol);
-      }
-
-      % Facing SouthWest
-      if iAngle >= ANGLE_SSW AND iAngle < ANGLE_WSW
-      {
-         iRow = Send(who,@GetRow) + 2;
-         iCol = Send(who,@GetCol) - 2;
-      }
-
-      % Facing West
-      if iAngle >= ANGLE_WSW AND iAngle < ANGLE_WNW
-      {
-         iCol = Send(who,@GetCol) - 2;
-         iRow = Send(who,@GetRow);
-      }
-
-      % Facing NorthWest
-      if iAngle >= ANGLE_WNW AND iAngle < ANGLE_NNW
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol) - 2;
-      }
-
-      % Facing North
-      if iAngle >= ANGLE_NNW AND iAngle < ANGLE_NNE
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol);
-      }
-
-      % Facing NorthEast
-      if iAngle >= ANGLE_NNE AND iAngle < ANGLE_ENE
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol) + 2;
-      }
-
-      oRoom = Send(who,@GetOwner);
-
-      iFine_Row = Send(who,@GetFineRow);
-      iFine_Col = Send(who,@GetFineCol);
-
-      % Center, then clockwise from 12 o'clock
-      oElement = Create(&FogCloud,#Odds=iOdds,#Caster=who,#Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&FogCloud,#Odds=iOdds,#Caster=who,#Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow-1,#new_col=iCol,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&FogCloud,#Odds=iOdds,#Caster=who,#Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow-1,#new_col=iCol+1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&FogCloud,#Odds=iOdds,#Caster=who,#Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol+1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&FogCloud,#Odds=iOdds,#Caster=who,#Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow+1,#new_col=iCol+1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&FogCloud,#Odds=iOdds,#Caster=who,#Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow+1,#new_col=iCol,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&FogCloud,#Odds=iOdds,#Caster=who,#Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow+1,#new_col=iCol-1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&FogCloud,#Odds=iOdds,#Caster=who,#Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol-1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&FogCloud,#Odds=iOdds,#Caster=who,#Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow-1,#new_col=iCol-1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
+      Send(self,@SpawnElement,#seed=lSeeda,#who=Nth(seed,1),#xoffset=0,#yoffset=-1,#walltype=&FogCloud);
+      Send(self,@SpawnElement,#seed=lSeedb,#who=Nth(seed,1),#xoffset=1,#yoffset=-1,#walltype=&FogCloud);
+      Send(self,@SpawnElement,#seed=lSeedc,#who=Nth(seed,1),#xoffset=1,#yoffset=0,#walltype=&FogCloud);
+      Send(self,@SpawnElement,#seed=lSeedd,#who=Nth(seed,1),#xoffset=1,#yoffset=1,#walltype=&FogCloud);
+      Send(self,@SpawnElement,#seed=lSeede,#who=Nth(seed,1),#xoffset=0,#yoffset=1,#walltype=&FogCloud);
+      Send(self,@SpawnElement,#seed=lSeedf,#who=Nth(seed,1),#xoffset=-1,#yoffset=1,#walltype=&FogCloud);
+      Send(self,@SpawnElement,#seed=lSeedg,#who=Nth(seed,1),#xoffset=-1,#yoffset=0,#walltype=&FogCloud);
+      Send(self,@SpawnElement,#seed=lSeedh,#who=Nth(seed,1),#xoffset=-1,#yoffset=-1,#walltype=&FogCloud);
 
       propagate;
    }

--- a/kod/object/passive/spell/walspell/summpfog.kod
+++ b/kod/object/passive/spell/walspell/summpfog.kod
@@ -53,8 +53,6 @@ classvars:
    % Poison fog can't kill anyone, so don't warn about being a murderer.
    viWallCanKill = FALSE
 
-   viNumElements = 9
-
    vrSummonLimitMsg = SummonPoisonFog_failed_rsc
 
 properties:
@@ -77,124 +75,29 @@ messages:
       propagate;
    }
 
-   PlaceWallElements(who = $, iSpellPower = 0)
+   PlaceWallElements(seed = $)
    {
-      local oRoom, iRow, iCol, iFine_Row, iFine_Col, iAngle, iOdds, iDuration,
-            oElement;
+      local lSeeda, lSeedb, lSeedc, lSeedd, lSeede, lSeedf, lSeedg, lSeedh;
 
-      iAngle = Send(who,@GetAngle);
-      iOdds = 50+(iSpellPower/2);
-      iOdds = Bound(iOdds,50,90);
+      % The standard seed is modified here.
+      % [(1)caster,(2)spellpower,(3)duration,(4)charges,(5)speed,(6)direction,(7)step,(8)noise,(9)twirl]
+      lSeeda = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),0,1,Nth(seed,8),2];
+      lSeedb = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),1,1,Nth(seed,8),2];
+      lSeedc = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),2,1,Nth(seed,8),2];
+      lSeedd = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),3,1,Nth(seed,8),2];
+      lSeede = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),4,1,Nth(seed,8),2];
+      lSeedf = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),5,1,Nth(seed,8),2];
+      lSeedg = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),6,1,Nth(seed,8),2];
+      lSeedh = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/10,Nth(seed,5),7,1,Nth(seed,8),2];
 
-      iDuration = (iSpellPower * 4) / 3 + 20;
-      iDuration = Bound(iDuration,20,130);
-
-      % Facing East
-      if iAngle > ANGLE_ENE OR iAngle < ANGLE_ESE
-      {
-         iCol = Send(who,@GetCol) + 2;
-         iRow = Send(who,@GetRow);
-      }
-
-      % Facing SouthEast
-      if iAngle >= ANGLE_ESE AND iAngle < ANGLE_SSE
-      {
-         iRow = Send(who,@GetRow) + 2;
-         iCol = Send(who,@GetCol) + 2;
-      }
-
-      % Facing South
-      if iAngle >= ANGLE_SSE AND iAngle < ANGLE_SSW
-      {
-         iRow = Send(who,@GetRow) + 2;
-         iCol = Send(who,@GetCol);
-      }
-
-      % Facing SouthWest
-      if iAngle >= ANGLE_SSW AND iAngle < ANGLE_WSW
-      {
-         iRow = Send(who,@GetRow) + 2;
-         iCol = Send(who,@GetCol) - 2;
-      }
-
-      % Facing West
-      if iAngle >= ANGLE_WSW AND iAngle < ANGLE_WNW
-      {
-         iCol = Send(who,@GetCol) - 2;
-         iRow = Send(who,@GetRow);
-      }
-
-      % Facing NorthWest
-      if iAngle >= ANGLE_WNW AND iAngle < ANGLE_NNW
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol) - 2;
-      }
-
-      % Facing North
-      if iAngle >= ANGLE_NNW AND iAngle < ANGLE_NNE
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol);
-      }
-
-      % Facing NorthEast
-      if iAngle >= ANGLE_NNE AND iAngle < ANGLE_ENE
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol) + 2;
-      }
-
-      oRoom = Send(who,@GetOwner);
-
-      iFine_Row = Send(who,@GetFineRow);
-      iFine_Col = Send(who,@GetFineCol);
-
-      % Center, then clockwise from 12 o'clock
-      oElement = Create(&PoisonFogCloud,#Odds=iOdds,#Caster=who,
-                         #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PoisonFogCloud,#Odds=iOdds,#Caster=who,
-                         #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow-1,#new_col=iCol,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PoisonFogCloud,#Odds=iOdds,#Caster=who,
-                         #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow-1,#new_col=iCol+1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PoisonFogCloud,#Odds=iOdds,#Caster=who,
-                         #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol+1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PoisonFogCloud,#Odds=iOdds,#Caster=who,
-                         #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow+1,#new_col=iCol+1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PoisonFogCloud,#Odds=iOdds,#Caster=who,
-                         #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow+1,#new_col=iCol,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PoisonFogCloud,#Odds=iOdds,#Caster=who,
-                         #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow+1,#new_col=iCol-1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PoisonFogCloud,#Odds=iOdds,#Caster=who,
-                         #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol-1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&PoisonFogCloud,#Odds=iOdds,#Caster=who,
-                         #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow-1,#new_col=iCol-1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
+      Send(self,@SpawnElement,#seed=lSeeda,#who=Nth(seed,1),#xoffset=0,#yoffset=-1,#walltype=&PoisonFogCloud);
+      Send(self,@SpawnElement,#seed=lSeedb,#who=Nth(seed,1),#xoffset=1,#yoffset=-1,#walltype=&PoisonFogCloud);
+      Send(self,@SpawnElement,#seed=lSeedc,#who=Nth(seed,1),#xoffset=1,#yoffset=0,#walltype=&PoisonFogCloud);
+      Send(self,@SpawnElement,#seed=lSeedd,#who=Nth(seed,1),#xoffset=1,#yoffset=1,#walltype=&PoisonFogCloud);
+      Send(self,@SpawnElement,#seed=lSeede,#who=Nth(seed,1),#xoffset=0,#yoffset=1,#walltype=&PoisonFogCloud);
+      Send(self,@SpawnElement,#seed=lSeedf,#who=Nth(seed,1),#xoffset=-1,#yoffset=1,#walltype=&PoisonFogCloud);
+      Send(self,@SpawnElement,#seed=lSeedg,#who=Nth(seed,1),#xoffset=-1,#yoffset=0,#walltype=&PoisonFogCloud);
+      Send(self,@SpawnElement,#seed=lSeedh,#who=Nth(seed,1),#xoffset=-1,#yoffset=-1,#walltype=&PoisonFogCloud);
 
       propagate;
    }

--- a/kod/object/passive/spell/walspell/summweb.kod
+++ b/kod/object/passive/spell/walspell/summweb.kod
@@ -52,8 +52,6 @@ classvars:
    % Webs can't kill anyone, so don't warn about being a murderer.
    viWallCanKill = FALSE
 
-   viNumElements = 9
-
    vrSummonLimitMsg = SummonWeb_failed_rsc
 
 properties:
@@ -75,146 +73,42 @@ messages:
       propagate;
    }
 
-   PlaceWallElements(who = $, iSpellPower = 0)
+   PlaceWallElements(seed = $)
    {
-      local oRoom, iRow, iCol, iFine_Row, iFine_Col, iAngle, iMaxHoldTime,
-            iDuration, oElement;
+      local lSeeda, lSeedb, lSeedc, lSeedd, lSeede, lSeedf, lSeedg, lSeedh;
 
-      iAngle = Send(who,@GetAngle);
-      iMaxHoldTime = 3+(iSpellPower/33);
-      iMaxHoldTime = Bound(iMaxHoldtime,$,5);
+      % The standard seed is modified here.
+      % [(1)caster,(2)spellpower,(3)duration,(4)charges,(5)speed,(6)direction,(7)step,(8)noise,(9)twirl]
+      lSeeda = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),0,1,Nth(seed,8),3];
+      lSeedb = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),1,1,Nth(seed,8),3];
+      lSeedc = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),2,1,Nth(seed,8),3];
+      lSeedd = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),3,1,Nth(seed,8),3];
+      lSeede = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),4,1,Nth(seed,8),3];
+      lSeedf = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),5,1,Nth(seed,8),3];
+      lSeedg = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),6,1,Nth(seed,8),3];
+      lSeedh = [Nth(seed,1),Nth(seed,2),Nth(seed,3),Nth(seed,2)/5,Nth(seed,5),7,1,Nth(seed,8),3];
 
-      iDuration = (iSpellPower * 4) / 3 + 20;
-      iDuration = Bound(iDuration,20,130);
-
-
-      % Facing East
-      if iAngle > ANGLE_ENE OR iAngle < ANGLE_ESE
-      {
-         iCol = Send(who,@GetCol) + 2;
-         iRow = Send(who,@GetRow);
-      }
-
-      % Facing SouthEast
-      if iAngle >= ANGLE_ESE AND iAngle < ANGLE_SSE
-      {
-         iRow = Send(who,@GetRow) + 2;
-         iCol = Send(who,@GetCol) + 2;
-      }
-
-      % Facing South
-      if iAngle >= ANGLE_SSE AND iAngle < ANGLE_SSW
-      {
-         iRow = Send(who,@GetRow) + 2;
-         iCol = Send(who,@GetCol);
-      }
-
-      % Facing SouthWest
-      if iAngle >= ANGLE_SSW AND iAngle < ANGLE_WSW
-      {
-         iRow = Send(who,@GetRow) + 2;
-         iCol = Send(who,@GetCol) - 2;
-      }
-
-      % Facing West
-      if iAngle >= ANGLE_WSW AND iAngle < ANGLE_WNW
-      {
-         iCol = Send(who,@GetCol) - 2;
-         iRow = Send(who,@GetRow);
-      }
-
-      % Facing NorthWest
-      if iAngle >= ANGLE_WNW AND iAngle < ANGLE_NNW
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol) - 2;
-      }
-
-      % Facing North
-      if iAngle >= ANGLE_NNW AND iAngle < ANGLE_NNE
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol);
-      }
-
-      % Facing NorthEast
-      if iAngle >= ANGLE_NNE AND iAngle < ANGLE_ENE
-      {
-         iRow = Send(who,@GetRow) - 2;
-         iCol = Send(who,@GetCol) + 2;
-      }
-
-      % Sanity check for invalid location.
-      if iRow = $
-         OR iCol = $
-      {
-         % Don't try to place the web on $ coordinates.
-         return;
-      }
-
-      oRoom = Send(who,@GetOwner);
-
-      iFine_Row = Send(who,@GetFineRow);
-      iFine_Col = Send(who,@GetFineCol);
-
-      % Center, then clockwise from 12 o'clock
-      oElement = Create(&Web,#MaxHoldTime=iMaxHoldTime,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&Web,#MaxHoldTime=iMaxHoldTime,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow-1,#new_col=iCol,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&Web,#MaxHoldTime=iMaxHoldTime,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow-1,#new_col=iCol+1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&Web,#MaxHoldTime=iMaxHoldTime,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol+1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&Web,#MaxHoldTime=iMaxHoldTime,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow+1,#new_col=iCol+1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&Web,#MaxHoldTime=iMaxHoldTime,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow+1,#new_col=iCol,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&Web,#MaxHoldTime=iMaxHoldTime,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow+1,#new_col=iCol-1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&Web,#MaxHoldTime=iMaxHoldTime,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow,#new_col=iCol-1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
-
-      oElement = Create(&Web,#MaxHoldTime=iMaxHoldTime,#Caster=who,
-                        #Duration=iDuration);
-      Send(oRoom,@NewHold,#what=oElement,#new_row=iRow-1,#new_col=iCol-1,
-           #fine_row=iFine_Row,#fine_col=iFine_Col);
+      Send(self,@SpawnElement,#seed=lSeeda,#who=Nth(seed,1),#xoffset=0,#yoffset=-3,#walltype=&Web);
+      Send(self,@SpawnElement,#seed=lSeedb,#who=Nth(seed,1),#xoffset=2,#yoffset=-2,#walltype=&Web);
+      Send(self,@SpawnElement,#seed=lSeedc,#who=Nth(seed,1),#xoffset=3,#yoffset=0,#walltype=&Web);
+      Send(self,@SpawnElement,#seed=lSeedd,#who=Nth(seed,1),#xoffset=2,#yoffset=2,#walltype=&Web);
+      Send(self,@SpawnElement,#seed=lSeede,#who=Nth(seed,1),#xoffset=0,#yoffset=3,#walltype=&Web);
+      Send(self,@SpawnElement,#seed=lSeedf,#who=Nth(seed,1),#xoffset=-2,#yoffset=2,#walltype=&Web);
+      Send(self,@SpawnElement,#seed=lSeedg,#who=Nth(seed,1),#xoffset=-3,#yoffset=0,#walltype=&Web);
+      Send(self,@SpawnElement,#seed=lSeedh,#who=Nth(seed,1),#xoffset=-2,#yoffset=-2,#walltype=&Web);
 
       propagate;
    }
 
-   DoHold(what = $, otarget = $, idurationsecs = $, report=TRUE)
+   DoHold(what = $, otarget = $, duration = $, report=TRUE)
    "Holds target for durationsecs seconds."
    {
       local i;
             
       % Can cast spell if the 1 target item is a user
-      if iDurationSecs = $
+      if duration = $
       {
-         iDurationSecs = 10;
+         duration = 10000;
       }
       
       if otarget = $
@@ -228,7 +122,7 @@ messages:
          return FALSE;
       }      
 
-      Send(oTarget,@StartEnchantment,#what=self,#time=idurationsecs*1000,
+      Send(oTarget,@StartEnchantment,#what=self,#time=duration,
            #report=report,#state=report);
 
       if IsClass(oTarget,&Player)

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -133,7 +133,7 @@ properties:
    piLOS = LOS_OLD
 
    % How many summoned objects can be in a room
-   piPlayerSummonedObjectLimit = 18
+   piPlayerSummonedObjectLimit = 100
 
    % Minimum number of HP you have to have to vote for or become
    % Justicar

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -3199,6 +3199,7 @@ messages:
       Send(self,@CreateOneSpellIfNew,#num=SID_RESIST_POISON,#class=&ResistPoison);
       Send(self,@CreateOneSpellIfNew,#num=SID_ILLUSIONARY_FIREWALL,#class=&IllusionaryFirewall);
       Send(self,@CreateOneSpellIfNew,#num=SID_FIREWALL,#class=&Firewall);
+      Send(self,@CreateOneSpellIfNew,#num=SID_FLAME_WAVE,#class=&FlameWave);
       Send(self,@CreateOneSpellIfNew,#num=SID_GAZE_OF_THE_BASILISK,#class=&Paralyze);
 
       Send(self,@CreateOneSpellIfNew,#num=SID_SPORE_BURST,#class=&SporeBurst);


### PR DESCRIPTION
This introduces a new way to handle wall elements and spells casting such walls. Instead of telling each wall element where it needs to go at the point of time the spell is cast, the spell will instead create seeds - initial wall elements - that can then create additional seeded wall elements on their own. To create a line of fire, only a single element needs to be created, which will then spread according to its direction, speed and other properties.

This allows dynamic creation of firewalls based on spellpower with minimal effort and can easily create spells such as flamewaves etc.

At this point, I have stuck to two basic patters: A straight line in front of the caster and a spiraling AE around the caster. Go ahead and try all the different wall spells and don't forget to use different levels of spellpower when casting.
