### PR TITLE
Don't add item-cast spells to passive improvement list.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -3024,7 +3024,7 @@ messages:
    }
 
    StartEnchantment(what=$,who=$,time=$,state=$,lastcall=TRUE,
-                     addicon=TRUE,ltype=$)
+                     addicon=TRUE,ltype=$,bItemCast=FALSE)
    "Adds <what> to our enchantments, and creates a timer that will cause it "
    "to end."
    {
@@ -3061,6 +3061,7 @@ messages:
       % to our passive improvement list. ltype has the form:
       % [oSpell,Defensive,Offensive,Resistance]
       if who = self
+         AND NOT bItemCast
       {
          plPassiveImprovement = Cons(ltype,plPassiveImprovement);
       }

--- a/kod/object/passive/spell/persench.kod
+++ b/kod/object/passive/spell/persench.kod
@@ -159,7 +159,7 @@ messages:
       propagate;
    }
 
-   CastSpell(who=$,iSpellPower=0,lTargets=$)
+   CastSpell(who=$,iSpellPower=0,lTargets=$,bItemCast=FALSE)
    {
 
       local oTarget, lType;
@@ -197,7 +197,8 @@ messages:
       Send(oTarget,@StartEnchantment,#what=self,
             #state=Send(self,@GetStateValue,#iSpellpower=iSpellpower,#who=who,
             #target=oTarget),#time=Send(self,@GetDuration,#iSpellPower=iSpellPower),
-            #lastcall=Send(self,@GetLastCall),#addicon=Send(self,@GetAddicon),#who=who,#ltype=lType);
+            #lastcall=Send(self,@GetLastCall),#addicon=Send(self,@GetAddicon),
+            #who=who,#ltype=lType,#bItemCast=bItemCast);
 
       % GetStateValue is sometimes (eg used for pre-enchantment behaviors,
       % who is the caster, target is the target (sometimes the same as who).

--- a/kod/util/qormas.kod
+++ b/kod/util/qormas.kod
@@ -997,9 +997,12 @@ messages:
 
    OnLogonTimer()
    {
-      Send(self,@ProcessLogon,#who=Nth(plLogonQueue,Length(plLogonQueue)));
-      plLogonQueue = DelListElem(plLogonQueue,
-                                 Nth(plLogonQueue,Length(plLogonQueue)));
+      if plLogonQueue <> $
+      {
+         Send(self,@ProcessLogon,#who=Nth(plLogonQueue,Length(plLogonQueue)));
+         plLogonQueue = DelListElem(plLogonQueue,
+                              Nth(plLogonQueue,Length(plLogonQueue)));
+      }
 
       return;
    }


### PR DESCRIPTION
Buffs cast from potions were being added to the player's passive improvement list. This check prevents that from happening (spell items already send bItemCast to CastSpell, it just wasn't being passed to StartEnchantment).