### PR TITLE
Fix OF_ATTACKABLE flags for NPCs.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -5951,9 +5951,9 @@ messages:
 
       iFlags = viObject_flags | piDrawEffectFlag;
 
-      if NOT (piBehavior & AI_NPC)
+      if (piBehavior & AI_NPC)
       {
-         iFlags = iFlags | OF_ATTACKABLE;
+         iFlags = iFlags & ~OF_ATTACKABLE;
       }
 
       if Send(Self,@MobIsSeller)

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2470,6 +2470,10 @@ messages:
          OR IsClass(what,&EvilTwin)
       {
          what = Send(what,@GetMaster);
+         if what = self
+         {
+            return MM_PLAYER;
+         }
       }
 
       if IsClass(what,&Player)


### PR DESCRIPTION
The default from viObject_flags is OF_ATTACKABLE, NPCs should be removing this flag. This flag is now set in Battler.