### PR TITLE
Allow punctuation, disallow numbers and function keys in Keybind.

### DIFF
--- a/keybind/m59BindForm.cs
+++ b/keybind/m59BindForm.cs
@@ -196,7 +196,7 @@ namespace m59bind
             m59BindProgram.GetIni(configFile, "config", "dynamiclighting", "true");
             m59BindProgram.GetIni(configFile, "config", "softwarerenderer", "false");
 
-            configChanged = false;
+            configChanged = true;
         }
 
         /// <summary>

--- a/keybind/m59BindForm.cs
+++ b/keybind/m59BindForm.cs
@@ -380,9 +380,8 @@ namespace m59bind
             if ((e.KeyValue >= 48 && e.KeyValue <= 57)
                 || (e.KeyValue >= 96 && e.KeyValue <= 105))
             {
-                returnString = "";
-
-                return returnString;
+                e.Handled = true;
+                return keyPrompt;
             }
 
             switch (e.KeyCode)
@@ -511,9 +510,9 @@ namespace m59bind
                 case Keys.F10:
                 case Keys.F11:
                 case Keys.F12:
-                    returnString = "";
                     // These are used for aliases.
-                    return returnString;
+                    e.Handled = true;
+                    return keyPrompt;
                 default:
                     returnString = "";
                     returnString += e.KeyData.ToString().ToLower().Substring(0, 1);

--- a/keybind/m59BindForm.cs
+++ b/keybind/m59BindForm.cs
@@ -376,8 +376,66 @@ namespace m59bind
         {
             string returnString;
 
+            // Don't allow assigning of numbers.
+            if ((e.KeyValue >= 48 && e.KeyValue <= 57)
+                || (e.KeyValue >= 96 && e.KeyValue <= 105))
+            {
+                returnString = "";
+
+                return returnString;
+            }
+
             switch (e.KeyCode)
             {
+                case Keys.Add:
+                    returnString = "add";
+                    break;
+                case Keys.Subtract:
+                    returnString = "subtract";
+                    break;
+                  case Keys.Divide:
+                    returnString = "divide";
+                    break;
+               case Keys.Multiply:
+                    returnString = "multiply";
+                    break;
+               case Keys.OemBackslash:
+                    returnString = "\\";
+                    break;
+              case Keys.OemCloseBrackets:
+                    returnString = "]";
+                    break;
+               case Keys.OemOpenBrackets:
+                    returnString = "[";
+                    break;
+               case Keys.OemPeriod:
+                    returnString = ".";
+                    break;
+               case Keys.OemPipe:
+                    returnString = "|";
+                    break;
+               case Keys.OemQuestion:
+                    returnString = "?";
+                    break;
+               case Keys.OemQuotes:
+                    returnString = "'";
+                    break;
+               case Keys.OemSemicolon:
+                    returnString = ";";
+                    break;
+               case Keys.Oemcomma:
+                    returnString = ",";
+                    break;
+               case Keys.Oemplus:
+                    returnString = "+";
+                    break;
+               case Keys.Oemtilde:
+                    returnString = "`";
+                    break;
+               case Keys.OemMinus:
+               case Keys.Separator:
+                    returnString = "-";
+                    break;
                 case Keys.Alt:
                 case Keys.Menu:
                 case Keys.LMenu:
@@ -389,6 +447,9 @@ namespace m59bind
                 case Keys.LControlKey:
                 case Keys.RControlKey:
                     returnString = "ctrl";
+                    break;
+                case Keys.Escape:
+                    returnString = "esc";
                     break;
                 case Keys.ShiftKey:
                 case Keys.LShiftKey:
@@ -435,6 +496,9 @@ namespace m59bind
                 case Keys.Space:
                     returnString = "space";
                     break;
+                case Keys.Back:
+                    returnString = "backspace";
+                    break;
                 case Keys.F1:
                 case Keys.F2:
                 case Keys.F3:
@@ -448,8 +512,8 @@ namespace m59bind
                 case Keys.F11:
                 case Keys.F12:
                     returnString = "";
-                    returnString += e.KeyData.ToString().Substring(0, 2);
-                    break;
+                    // These are used for aliases.
+                    return returnString;
                 default:
                     returnString = "";
                     returnString += e.KeyData.ToString().ToLower().Substring(0, 1);
@@ -519,6 +583,7 @@ namespace m59bind
                 case Keys.Delete:
                 case Keys.Enter:
                 case Keys.Space:
+                case Keys.Escape:
                     e.IsInputKey = true;
                     break;
             }
@@ -801,7 +866,7 @@ namespace m59bind
         // Look Up Keybind
         private void buttonLookUp_KeyDown(object sender, KeyEventArgs e)
         {
-            buttonBackward.Text = handleKeyDown(e);
+            buttonLookUp.Text = handleKeyDown(e);
         }
 
         private void buttonLookUp_MouseDown(object sender, MouseEventArgs e)


### PR DESCRIPTION
Added punctuation symbols to the Switch statement for assigning keys.
Also added backspace and escape as options, disallowed numbers (old
keybind didn't allow these, they don't seem to work either) and Function
keys (these are used in aliases.

Fixed a bug caused by the Look Up field setting the Backward field.