### PR TITLE
Don't take utility spells in StripSpellsOfSchool.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -13052,7 +13052,8 @@ messages:
       {
          iSpellNum = Send(self,@DecodeSpellNum,#compound=i);
          oSpell = Send(SYS,@FindSpellByNum,#num=iSpellNum);
-         if All OR Send(oSpell,@GetSchool) = school
+         if (All OR Send(oSpell,@GetSchool) = school)
+            AND Send(oSpell,@CanForget)
          {
             Send(self,@RemoveSpell,#num=iSpellNum);
          }


### PR DESCRIPTION
This shouldn't be taking spells that can't be forgotten (e.g. Blink, Phase etc).