### PR TITLE
Add settings for default group time and rolling for toughers on kill. Defaults are the current live values.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8782,12 +8782,12 @@ messages:
                
                gain = 1;
 
-               % No roll for kills by others. This puts tension on group size.
-               % As group sizes increase, getting kills oneself becomes 
-               % difficult. Groups that are too large create their own 
-               % advancement problems organically. Also, this keeps advancement
-               % based on the player himself. His own kill rate matters the most.
+               % We still roll for a tougher if we killed the monster but
+               % didn't take damage or dodge, if we helped kill the monster,
+               % or if it was a group member kill and the setting for group
+               % member toughers is set to TRUE.
                if NOT group_member_kill
+                  OR Send(Send(SYS,@GetSettings),@GetGroupTougherSetting)
                {
                   roll = TRUE;
                }

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -4823,28 +4823,32 @@ messages:
          AND IsClass(victim,&Monster)
       {
          % Tusked Skeletons are our base case.
-         % With level 100 and difficulty 6, they are the last mob that dies quickly.
-         % We'll give them and everything below 60 second group times.
-         % Everything above them needs drastically more time as players progress.
-         % Special case made for Thrashers, due to the extreme nature of their room.
-         
-         piGroupTime = 60000;
-         
+         % With level 100 and difficulty 6, they are the last mob that
+         % dies quickly. We'll give them and everything below 60 second
+         % group times (default). Everything above them needs drastically
+         % more time as players progress. Special case made for Thrashers,
+         % due to the extreme nature of their room.
+
+         piGroupTime = Send(Send(SYS,@GetSettings),@GetDefaultGroupTime);
+
          % 2 additional seconds per mob level point above 100
          % Max +100 seconds for 150 hp mobs
-         piGroupTime = piGroupTime + bound(((Send(victim,@GetLevel)-100) * 1000 * 2),0,$);
-         
+         piGroupTime = piGroupTime
+                        + Bound(((Send(victim,@GetLevel)-100) * 1000 * 2),0,$);
+
          % 10 additional seconds per difficulty point above 6
          % Max +30 seconds for difficulty 9 mobs
-         piGroupTime = piGroupTime + bound(((Send(victim,@GetDifficulty)-6) * 1000 * 10),0,$);
-         
-         % Special cases
-         % Extra 2 minutes for thrashers (for 4 minutes 50 seconds total - nobody is muling thrashers)
-         If IsClass(victim,&Thrasher)
+         piGroupTime = piGroupTime
+                        + Bound(((Send(victim,@GetDifficulty)-6) * 1000 * 10),0,$);
+
+         % Special case: Extra 2 minutes for thrashers for 4 minutes
+         % 50 seconds total - nobody is muling thrashers)
+         if IsClass(victim,&Thrasher)
          {
-            piGroupTime = piGroupTime + bound((60 * 1000 * 2),0,$);
+            piGroupTime = piGroupTime + Bound((60 * 1000 * 2),0,$);
          }
       }
+
       return;
    }
    

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -83,6 +83,11 @@ properties:
    %  specific information on what this number means.
    piMaxLearnPoints = 16
 
+   % Do building group member kills allow tougher rolls?
+   pbGroupToughers = FALSE
+
+   % The default time for building group membership.
+   piDefaultGroupTime = 60000
 
    %
    % Spell settings
@@ -368,6 +373,16 @@ messages:
    GetMaxLearnPoints()
    {
       return piMaxLearnPoints;
+   }
+
+   GetGroupTougherSetting()
+   {
+      return pbGroupToughers;
+   }
+
+   GetDefaultGroupTime()
+   {
+      return piDefaultGroupTime;
    }
 
    %


### PR DESCRIPTION
Player requested: allow rolling toughers on group member kill, but halve default group time to compensate.

EDIT: changed this so that the defaults are the current live values (60 sec group time, FALSE for toughers on group kill).