### PR TITLE
Add stat bar for bulk

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -6386,12 +6386,11 @@ messages:
       {	  
          AddPacket(1,BP_INVENTORY_ADD);
          Send(self,@ToCliObject,#what=what,#show_type=SHOW_INVENTORY);
-         SendPacket(poSession);		 
-
+         SendPacket(poSession);
+         
+         Post(self,@DrawCapacity);
+         Post(self,@DrawBulk);
       }
-      
-      Post(self,@DrawCapacity);
-      Post(self,@DrawBulk);      
       
       propagate;
    }
@@ -6402,11 +6401,10 @@ messages:
       {
          AddPacket(1,BP_INVENTORY_REMOVE,4,what);
          SendPacket(poSession);
+         Post(self,@DrawCapacity);
+         Post(self,@DrawBulk);    
       }
 
-      Post(self,@DrawCapacity);
-      Post(self,@DrawBulk);      
-      
       propagate;
    }
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -142,6 +142,7 @@ resources:
    user_stat_aim = "Aim"
    user_stat_karma = "Karma"
    user_stat_capacity = "Weight Carried"
+   user_stat_bulk = "Bulk Carried"
    user_stat_offense = "Offense"
    user_stat_defense = "Defense"
    user_stat_armor = "Armor"
@@ -2434,6 +2435,7 @@ messages:
          Send(what,@SendInventoryAnimation);
          Send(what,@SendInventoryOverlays);
          Post(self,@DrawCapacity);
+         Post(self,@DrawBulk);
       }
 
       if show_type = SHOW_NORMAL
@@ -2784,7 +2786,7 @@ messages:
 
       if group = 2
       {
-         AddPacket(1,BP_STAT_GROUP, 1,group, 1,25);
+         AddPacket(1,BP_STAT_GROUP, 1,group, 1,26);
 
          Send(self,@SendStatMight);
          Send(self,@SendStatIntellect);
@@ -2794,6 +2796,7 @@ messages:
          Send(self,@SendStatAim);
          Send(self,@SendStatKarma);
          Send(self,@SendStatTraining);
+         Send(self,@SendStatBulk);
          Send(self,@SendStatCapacity);
          Send(self,@SendStatOffense);
          Send(self,@SendStatDefense);
@@ -6388,6 +6391,7 @@ messages:
       }
       
       Post(self,@DrawCapacity);
+      Post(self,@DrawBulk);      
       
       propagate;
    }
@@ -6401,6 +6405,7 @@ messages:
       }
 
       Post(self,@DrawCapacity);
+      Post(self,@DrawBulk);      
       
       propagate;
    }
@@ -7310,6 +7315,40 @@ messages:
       return;
    }
    
+   DrawBulk()
+   {
+      if pbLogged_on
+      {
+         AddPacket(1,BP_STAT,1,2);
+         Send(self,@SendStatBulk);
+         SendPacket(poSession);
+      }
+
+      return;
+   }
+   
+   SendStatBulk()
+   {
+      local iBulk, iBulkMax;
+      
+      iBulk = Send(self,@GetBulkHold);
+      
+      % GetBulkMax returns NIL in dm.kod, 3100 is capacity at 70 might
+      if IsClass(self,&DM)
+      {
+         iBulkMax = 3100;
+      }
+      else
+      {
+         iBulkMax = Send(self,@GetBulkMax);
+      }
+      
+      AddPacket(1,10, 4,user_stat_bulk, 1,STAT_VALUE, 1,STAT_INTEGER,
+                4,iBulk, 4,0, 4,iBulkMax, 4,iBulk);
+      
+      return;
+   }
+   
    DrawOffense()
    {
       if pbLogged_on
@@ -7328,7 +7367,7 @@ messages:
       
       iOffense_send = Send(self,@GetOffense);
       
-      AddPacket(1,10, 4,user_stat_offense, 1,STAT_VALUE, 1,STAT_INTEGER,
+      AddPacket(1,11, 4,user_stat_offense, 1,STAT_VALUE, 1,STAT_INTEGER,
                 4,iOffense_send, 4,0, 4,1000, 4,iOffense_send);
 
       return;
@@ -7352,7 +7391,7 @@ messages:
       
       iDefense_send = Send(self,@GetDefense);
       
-      AddPacket(1,11, 4,user_stat_defense, 1,STAT_VALUE, 1,STAT_INTEGER,
+      AddPacket(1,12, 4,user_stat_defense, 1,STAT_VALUE, 1,STAT_INTEGER,
                 4,iDefense_send, 4,0, 4,1000, 4,iDefense_send);
 
       return;
@@ -7376,7 +7415,7 @@ messages:
       
       iArmor_send = Send(self,@SumDamageReduction);
       
-      AddPacket(1,12, 4,user_stat_armor, 1,STAT_VALUE, 1,STAT_INTEGER,
+      AddPacket(1,13, 4,user_stat_armor, 1,STAT_VALUE, 1,STAT_INTEGER,
                 4,iArmor_send, 4,0, 4,15, 4,iArmor_send);
 
       return;
@@ -7407,13 +7446,13 @@ messages:
          {
             if Nth(i,1) = ATCK_WEAP_ALL
             {
-               AddPacket(1,13, 4,user_resist_weapons, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
+               AddPacket(1,14, 4,user_resist_weapons, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
                bWeaponAll = TRUE;
             }
          }
          if NOT bWeaponAll
          {
-            AddPacket(1,13, 4,user_resist_weapons, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
+            AddPacket(1,14, 4,user_resist_weapons, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
          }
       }
       if num = 2
@@ -7422,13 +7461,13 @@ messages:
          {
             if Nth(i,1) = ATCK_WEAP_THRUST
             {
-               AddPacket(1,14, 4,user_resist_thrust, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
+               AddPacket(1,16, 4,user_resist_thrust, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
                bWeaponThrust = TRUE;
             }
          }
          if NOT bWeaponThrust
          {
-            AddPacket(1,14, 4,user_resist_thrust, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
+            AddPacket(1,16, 4,user_resist_thrust, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
          }
       }
       if num = 3
@@ -7437,13 +7476,13 @@ messages:
          {
             if Nth(i,1) = ATCK_WEAP_BLUDGEON
             {
-               AddPacket(1,15, 4,user_resist_bludgeon, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
+               AddPacket(1,16, 4,user_resist_bludgeon, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
                bWeaponBludgeon = TRUE;
             }
          }
          if NOT bWeaponBludgeon
          {
-            AddPacket(1,15, 4,user_resist_bludgeon, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
+            AddPacket(1,16, 4,user_resist_bludgeon, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
          }
       }
       if num = 4
@@ -7452,13 +7491,13 @@ messages:
          {
             if Nth(i,1) = ATCK_WEAP_SLASH
             {
-               AddPacket(1,16, 4,user_resist_slash, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
+               AddPacket(1,17, 4,user_resist_slash, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
                bWeaponSlash = TRUE;
             }
          }
          if NOT bWeaponSlash
          {
-            AddPacket(1,16, 4,user_resist_slash, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
+            AddPacket(1,17, 4,user_resist_slash, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
          }
       }
       if num = 5
@@ -7467,13 +7506,13 @@ messages:
          {
             if Nth(i,1) = ATCK_WEAP_PIERCE
             {
-               AddPacket(1,17, 4,user_resist_pierce, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
+               AddPacket(1,18, 4,user_resist_pierce, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
                bWeaponPierce = TRUE;
             }
          }
          if NOT bWeaponPierce
          {
-            AddPacket(1,17, 4,user_resist_pierce, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
+            AddPacket(1,18, 4,user_resist_pierce, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
          }
       }
       if num = 6
@@ -7482,13 +7521,13 @@ messages:
          {
             if Nth(i,1) = -ATCK_SPELL_ALL
             {
-               AddPacket(1,18, 4,user_resist_magic, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
+               AddPacket(1,19, 4,user_resist_magic, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
                bSpellAll = TRUE;
             }
          }
          if NOT bSpellAll
          {
-            AddPacket(1,18, 4,user_resist_magic, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
+            AddPacket(1,19, 4,user_resist_magic, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
          }
       }
       if num = 7
@@ -7497,13 +7536,13 @@ messages:
          {
             if Nth(i,1) = -ATCK_SPELL_FIRE
             {
-               AddPacket(1,19, 4,user_resist_fire, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
+               AddPacket(1,20, 4,user_resist_fire, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
                bSpellFire = TRUE;
             }
          }
          if NOT bSpellFire
          {
-            AddPacket(1,19, 4,user_resist_fire, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
+            AddPacket(1,20, 4,user_resist_fire, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
          }
       }
       if num = 8
@@ -7512,13 +7551,13 @@ messages:
          {
             if Nth(i,1) = -ATCK_SPELL_SHOCK
             {
-               AddPacket(1,20, 4,user_resist_shock, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
+               AddPacket(1,21, 4,user_resist_shock, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
                bSpellShock = TRUE;
             }
          }
          if NOT bSpellShock
          {
-            AddPacket(1,20, 4,user_resist_shock, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
+            AddPacket(1,21, 4,user_resist_shock, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
          }
       }
       if num = 9
@@ -7527,13 +7566,13 @@ messages:
          {
             if Nth(i,1) = -ATCK_SPELL_COLD
             {
-               AddPacket(1,21, 4,user_resist_cold, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
+               AddPacket(1,22, 4,user_resist_cold, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
                bSpellCold = TRUE;
             }
          }
          if NOT bSpellCold
          {
-            AddPacket(1,21, 4,user_resist_cold, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
+            AddPacket(1,22, 4,user_resist_cold, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
          }
       }
       if num = 10
@@ -7542,13 +7581,13 @@ messages:
          {
             if Nth(i,1) = -ATCK_SPELL_ACID
             {
-               AddPacket(1,22, 4,user_resist_acid, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
+               AddPacket(1,23, 4,user_resist_acid, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
                bSpellAcid = TRUE;
             }
          }
          if NOT bSpellAcid
          {
-            AddPacket(1,22, 4,user_resist_acid, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
+            AddPacket(1,23, 4,user_resist_acid, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
          }
       }
       if num = 11
@@ -7557,13 +7596,13 @@ messages:
          {
             if Nth(i,1) = -ATCK_SPELL_HOLY
             {
-               AddPacket(1,23, 4,user_resist_holy, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
+               AddPacket(1,24, 4,user_resist_holy, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
                bSpellHoly = TRUE;
             }
          }
          if NOT bSpellHoly
          {
-            AddPacket(1,23, 4,user_resist_holy, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
+            AddPacket(1,24, 4,user_resist_holy, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
          }
       }
       if num = 12
@@ -7572,13 +7611,13 @@ messages:
          {
             if Nth(i,1) = -ATCK_SPELL_UNHOLY
             {
-               AddPacket(1,24, 4,user_resist_unholy, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
+               AddPacket(1,25, 4,user_resist_unholy, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
                bSpellUnholy = TRUE;
             }
          }
          if NOT bSpellUnholy
          {
-            AddPacket(1,24, 4,user_resist_unholy, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
+            AddPacket(1,25, 4,user_resist_unholy, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
          }
       }
       if num = 13
@@ -7587,13 +7626,13 @@ messages:
          {
             if Nth(i,1) = -ATCK_SPELL_QUAKE
             {
-               AddPacket(1,25, 4,user_resist_quake, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
+               AddPacket(1,26, 4,user_resist_quake, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
                bSpellQuake = TRUE;
             }
          }
          if NOT bSpellQuake
          {
-            AddPacket(1,25, 4,user_resist_quake, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
+            AddPacket(1,26, 4,user_resist_quake, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
          }
       }
 


### PR DESCRIPTION
Players previously could not see their carried bulk.  It was possible for the user to have a full inventory due to max bulk when their weight carrying capacity had not been exceeded.