### PR TITLE
Use correct drawing effect for phased players; lower vigor drain to previous levels; stop ETs following the caster to new screens instead of staying with the victim.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -1127,7 +1127,9 @@ messages:
             AND Send(poMaster,@GetOwner) <> $
          {
             if ((piRow - iRow) <= 3
-               AND (piCol - iCol) <= 3)
+               AND (piCol - iCol) <= 3
+               AND NOT (IsClass(self,&EvilTwin)
+                  AND (NOT Send(self,@IsEnchanted,#byClass=&Seduce))))
                OR IsClass(self,&Reflection) % Flecs follow.
                OR Send(self,@IsUndead) % So do undead (Animate).
             {

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -3219,7 +3219,7 @@ messages:
       {
          % Reduce speed value to old value, 5/6ths current value, then
          % square it.
-         iExertion = (speed * 5)/6;
+         iExertion = (speed * 3)/5;
          iExertion = iExertion * iExertion;
          iExertion = EXERTION_PER_MOVE * iExertion;
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -8263,6 +8263,12 @@ messages:
          iFlags = iFlags | DRAWFX_INVISIBLE;
       }
 
+      if Send(self,@IsPhasedOut)
+      {
+         iFlags = iFlags & ~DRAWFX_MASK;
+         iFlags = iFlags | DRAWFX_DITHERINVIS;
+      }
+
       return iFlags;
    }
 


### PR DESCRIPTION
Phased players were being drawn using any effect the player already had active. They will now be drawn with the appropriate transparency effect.

Vigor drain was set too high due to the changes to walk/run speed in move.c, which is modified to arrive at the amount of vigor drain for moving. The amount removed should now match the pre-update (and also 101/102) values.

Added a check to SomethingLeft in monster.kod so non-seduced ETs don't follow the caster to a new screen due to the proximity check.