### PR TITLE
Add messages to start/end rain effect. Add KOD code for a sandstorm weather effect, separate from the spell (just particle effect, no aim/damage side effects).

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -1065,6 +1065,8 @@
    ROOM_RAINING       = 0x10000
    % Is it snowing here?
    ROOM_SNOWING       = 0x20000
+   % Is there a sandstorm (weather, not spell) happening?
+   ROOM_SANDSTORM     = 0x40000
 
    % Terrain constants, used to tell what type of terrain the room is.
    TERRAIN_GUILDHALL = 0x0000001

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -7808,6 +7808,15 @@ messages:
          AddPacket(1,BP_EFFECT,2,EFFECT_CLEARWEATHER);
          SendPacket(poSession);
 
+         % If we came from a room with a sandstorm weather effect we
+         % clear it here, unless we're affected by the Sandstorm spell.
+         if NOT Send(self,@IsAffectedByRadiusEnchantment,
+                     #byClass=&Sandstorm)
+         {
+            AddPacket(1,BP_EFFECT,2,EFFECT_CLEARSAND);
+            SendPacket(poSession);
+         }
+
          % Then send the needed effect.
          AddPacket(1,BP_EFFECT);
          AddPacket(2,Send(poOwner,@GetRoomWeather));

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3710,9 +3710,17 @@ messages:
       }
       else
       {
+         % Rain takes precedence over sandstorm.
          if piRoom_flags & ROOM_RAINING
          {
             effect = EFFECT_RAINING;
+         }
+         else
+         {
+            if piRoom_flags & ROOM_SANDSTORM
+            {
+               effect = EFFECT_SAND;
+            }
          }
       }
 
@@ -3725,6 +3733,12 @@ messages:
       if NOT pbWeatherEffects
       {
          return;
+      }
+
+      % If there's a sandstorm effect here, clear it.
+      if Send(self,@CheckRoomFlag,#flag=ROOM_SANDSTORM)
+      {
+         Send(self,@EndSandstorm);
       }
 
       if bOnGround
@@ -3800,6 +3814,12 @@ messages:
          return;
       }
 
+      % If there's a sandstorm effect here, clear it.
+      if Send(self,@CheckRoomFlag,#flag=ROOM_SANDSTORM)
+      {
+         Send(self,@EndSandstorm);
+      }
+
       Send(self,@SetRoomFlag,#flag=ROOM_RAINING,#value=TRUE);
       Send(self,@WeatherChanged);
 
@@ -3813,6 +3833,46 @@ messages:
          Send(self,@SetRoomFlag,#flag=ROOM_RAINING,#value=FALSE);
          Send(self,@WeatherChanged);
 
+      }
+
+      return;
+   }
+
+   StartSandstorm()
+   {
+      % Check if we can have weather effects here.
+      if NOT pbWeatherEffects
+      {
+         return;
+      }
+
+      Send(self,@SetRoomFlag,#flag=ROOM_SANDSTORM,#value=TRUE);
+      Send(self,@WeatherChanged);
+
+      return;
+   }
+
+   EndSandstorm()
+   {
+      local i, each_obj;
+
+      if Send(self,@CheckRoomFlag,#flag=ROOM_SANDSTORM)
+      {
+         Send(self,@SetRoomFlag,#flag=ROOM_SANDSTORM,#value=FALSE);
+
+         for i in plActive
+         {
+            each_obj = Send(self,@HolderExtractObject,#data=i);
+            if IsClass(each_obj,&User)
+            {
+               if NOT Send(each_obj,@IsAffectedByRadiusEnchantment,
+                           #byClass=&Sandstorm)
+               {
+                  Send(each_obj,@EffectSendUser,#what=each_obj,
+                        #effect=EFFECT_CLEARSAND);
+               }
+            }
+         }
       }
 
       return;

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3792,6 +3792,32 @@ messages:
       return;
    }
 
+   StartRain()
+   {
+      % Check if we can have weather effects here.
+      if NOT pbWeatherEffects
+      {
+         return;
+      }
+
+      Send(self,@SetRoomFlag,#flag=ROOM_RAINING,#value=TRUE);
+      Send(self,@WeatherChanged);
+
+      return;
+   }
+
+   EndRain()
+   {
+      if Send(self,@CheckRoomFlag,#flag=ROOM_RAINING)
+      {
+         Send(self,@SetRoomFlag,#flag=ROOM_RAINING,#value=FALSE);
+         Send(self,@WeatherChanged);
+
+      }
+
+      return;
+   }
+
    StartChaosNight()
    {
       %% set the room flags so the only safe place in the world is the inns.

--- a/kod/object/active/holder/room/barlqrm/barhall.kod
+++ b/kod/object/active/holder/room/barlqrm/barhall.kod
@@ -107,6 +107,12 @@ messages:
          return;
       }
 
+      % If there's a sandstorm weather effect here, clear it.
+      if Send(self,@CheckRoomFlag,#flag=ROOM_SANDSTORM)
+      {
+         Send(self,@EndSandstorm);
+      }
+
       if bOnGround
       {
          if pbSnowGroundTexture

--- a/kod/object/active/holder/room/castle2a.kod
+++ b/kod/object/active/holder/room/castle2a.kod
@@ -144,6 +144,12 @@ messages:
          return;
       }
 
+      % If there's a sandstorm weather effect here, clear it.
+      if Send(self,@CheckRoomFlag,#flag=ROOM_SANDSTORM)
+      {
+         Send(self,@EndSandstorm);
+      }
+
       if bOnGround
       {
          if pbSnowGroundTexture

--- a/kod/object/active/holder/room/ghall/guildh13.kod
+++ b/kod/object/active/holder/room/ghall/guildh13.kod
@@ -362,6 +362,12 @@ messages:
          return;
       }
 
+      % If there's a sandstorm weather effect here, clear it.
+      if Send(self,@CheckRoomFlag,#flag=ROOM_SANDSTORM)
+      {
+         Send(self,@EndSandstorm);
+      }
+
       if bOnGround
       {
          if pbSnowGroundTexture

--- a/kod/object/active/holder/room/kocarm/koctav.kod
+++ b/kod/object/active/holder/room/kocarm/koctav.kod
@@ -117,6 +117,12 @@ messages:
          return;
       }
 
+      % If there's a sandstorm weather effect here, clear it.
+      if Send(self,@CheckRoomFlag,#flag=ROOM_SANDSTORM)
+      {
+         Send(self,@EndSandstorm);
+      }
+
       if bOnGround
       {
          if pbSnowGroundTexture

--- a/kod/object/active/holder/room/monsroom/g9.kod
+++ b/kod/object/active/holder/room/monsroom/g9.kod
@@ -1070,6 +1070,12 @@ messages:
          return;
       }
 
+      % If there's a sandstorm weather effect here, clear it.
+      if Send(self,@CheckRoomFlag,#flag=ROOM_SANDSTORM)
+      {
+         Send(self,@EndSandstorm);
+      }
+
       if bOnGround
       {
          if pbSnowGroundTexture

--- a/kod/object/active/holder/room/temprii.kod
+++ b/kod/object/active/holder/room/temprii.kod
@@ -568,6 +568,12 @@ messages:
          return;
       }
 
+      % If there's a sandstorm weather effect here, clear it.
+      if Send(self,@CheckRoomFlag,#flag=ROOM_SANDSTORM)
+      {
+         Send(self,@EndSandstorm);
+      }
+
       if bOnGround
       {
          if pbSnowGroundTexture

--- a/kod/object/active/holder/room/tosrm/tosarena.kod
+++ b/kod/object/active/holder/room/tosrm/tosarena.kod
@@ -781,6 +781,12 @@ messages:
          return;
       }
 
+      % If there's a sandstorm weather effect here, clear it.
+      if Send(self,@CheckRoomFlag,#flag=ROOM_SANDSTORM)
+      {
+         Send(self,@EndSandstorm);
+      }
+
       if bOnGround
       {
          if pbSnowGroundTexture


### PR DESCRIPTION
Still want to get a sound effect for rain before we use it live, but these messages will allow the rain effect to be turned on/off easily.

Added a sandstorm room flag for a sandstorm weather effect, separate from the spell. Does not cause damage or aim loss, just displays the particle effect for now. Has a bug (technically the spell has the bug) where if you leave a room with a (spell) sandstorm and arrive in one with the weather effect, the spell wearing off (in the new room - the bug) removes the weather effect. Will likely update the spell to check for the weather effect.