### PR TITLE
Lower vigor drain from narthyl worms.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/nrthlwrm.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/nrthlwrm.kod
@@ -15,8 +15,8 @@ constants:
    include blakston.khd
 
    SEC_PER_FRAME = 150
-   EXERTION_DAMAGE_MIN = 3
-   EXERTION_DAMAGE_MAX = 7
+   EXERTION_DAMAGE_MIN = 0
+   EXERTION_DAMAGE_MAX = 3
 
 resources:
 


### PR DESCRIPTION
Vigor drain caused by narthyl worm hits was far too high with safe spots removed and the possibility of multiple aggro. Lowered the vigor loss min bound from 3 to 0, and the max from 7 to 3. In testing vigor still noticeably drops, but no longer requires the player to rest or be constantly too full to eat.