### PR TITLE
Grouping toggle

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8548,6 +8548,11 @@ messages:
                AND (monster_level + 5) > piBase_Max_health
                AND (Send(self,@CheckPlayerFlag,#flag=PFLAG_TOOK_DAMAGE)
                   OR Send(self,@CheckPlayerFlag,#flag=PFLAG_DODGED))
+               OR (lBuilderGroup = $
+                  AND NOT piWantToGroup)
+               OR (lBuilderGroup <> $
+                   AND FindListElem(lBuilderGroup,self) = 0
+                   AND NOT piWantToGroup)
             {
                gain = gain + 1;
             }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1078,6 +1078,9 @@ properties:
    ptPhaseVisualEffectTimer = $
    piRemainingPhaseTime = 60000 * 8
    ptCanPhaseTimer = $
+   
+   % Players can toggle grouping
+   piWantToGroup = TRUE
 
    % Put new reagents in your bag
    pbReagentBagAuto = TRUE
@@ -5534,6 +5537,7 @@ messages:
          if IsClass(what,&Monster)
             AND (use_weapon = $
                OR NOT IsClass(use_weapon,&ActiveWallElement))
+            AND piWantToGroup
          {
             Send(self,@JoinBuilderGroup);
          }
@@ -14369,6 +14373,17 @@ messages:
    {
       pbReagentBagAuto = value;
 
+      return;
+   }
+   
+   GetGrouping()
+   {
+      return piWantToGroup;
+   }
+   
+   SetGrouping(value=TRUE)
+   {
+      piWantToGroup = value;
       return;
    }
    

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -351,7 +351,10 @@ resources:
    autoloot_off_msg = "You stop picking up treasure as it drops."
 
    phased_out_cant_drop = "You can't drop items while phased out of existence."
-                               
+
+   grouping_on = "You will start joining builder groups in your vicinity."
+   grouping_off = "You will no longer join builder groups in your vicinity."
+
    reagentbag_auto_on = "You start putting new reagents in your bag."
    reagentbag_auto_off = "You stop putting new reagents in your bag."
 
@@ -4252,6 +4255,20 @@ messages:
          {
             Send(self,@SetReagentBagAuto,#value=FALSE);
             Send(self,@MsgSendUser,#message_rsc=reagentbag_auto_off);
+            return;
+         }
+
+         If StringContain(String,"grouping off")
+         {
+            Send(self,@SetGrouping,#value=FALSE);
+            Send(self,@MsgSendUser,#message_rsc=grouping_off);
+            return;
+         }
+
+         If StringContain(String,"grouping on")
+         {
+            Send(self,@SetGrouping,#value=TRUE);
+            Send(self,@MsgSendUser,#message_rsc=grouping_on);
             return;
          }
       }


### PR DESCRIPTION
Players can now opt out of grouping by saying "grouping off". Turn it
back on with "grouping on". This should help complaints of 2 person
teams with one bad member slowing down a player's building.

If you are opted out you will always get the solo builder bonus.