### PR TITLE
Add timers in descriptions for Second Wind, Cryst Mana and Phase.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1426,6 +1426,11 @@ messages:
       return;
    }
 
+   GetSecondWindTimer()
+   {
+      return ptSecondWind;
+   }
+
    GetVigorRestThreshold()
    {
       return piVigor_rest_threshold;
@@ -13950,6 +13955,11 @@ messages:
       Send(self,@ComputeMaxMana);
 
       return;
+   }
+
+   GetManaSurgeTimer()
+   {
+      return ptCrystalizeManaSurgeTimer;
    }
 
    RechargeAllRods()

--- a/kod/object/passive/skill.kod
+++ b/kod/object/passive/skill.kod
@@ -29,14 +29,16 @@ resources:
    
    skill_sound_fail = spelfail.wav
 
-   skill_desc_rsc = "SCHOOL : %s         LEVEL : %i \n\n%s%s%i%s"
-   skill_desc_no_train_rsc = "SCHOOL : %s         LEVEL : %i \n\n%s"
+   skill_desc_rsc = "SCHOOL : %s         LEVEL : %i \n\n%s%q%s%i%s"
+   skill_desc_no_train_rsc = "SCHOOL : %s         LEVEL : %i \n\n%s%q"
    skill_school_fencing = "Weaponcraft"
    skill_school_brawling = "Brawling"
    skill_school_thievery = "Thievery"
 
    Skill_meditate_ratio_one_rsc = "\n\nIt will cost you "
    Skill_meditate_ratio_two_rsc = " training points to improve in this skill."
+
+   skill_nothing = " "
 
 classvars:
 
@@ -116,9 +118,9 @@ messages:
       return oSchool;
    }
 
-   ShowDesc()
+   ShowDesc(who=$)
    {
-      local rSchool;
+      local rSchool, rStats;
 
       rSchool = skill_school_fencing;
 
@@ -132,17 +134,37 @@ messages:
          rSchool = skill_school_thievery;
       }
       
+      rStats = Send(self,@GetStatsDesc,#who=who);
+      if rStats = $
+      {
+         rStats = CreateString();
+         SetString(rStats,skill_nothing);
+      }
+
       if piMeditate_ratio = 0
       {
-         AddPacket(4,skill_desc_no_train_rsc,4,rSchool,4,viSkill_Level,4,vrDesc);
+         AddPacket(4,skill_desc_no_train_rsc,4,rSchool,
+                  4,viSkill_Level,4,vrDesc,4,rStats);
       }
       else
       {
-         AddPacket(4,skill_desc_rsc,4,rSchool,4,viSkill_Level,4,vrDesc);
-         AddPacket(4,Skill_meditate_ratio_one_rsc,4,piMeditate_ratio,4,Skill_meditate_ratio_two_rsc);
+         AddPacket(4,skill_desc_rsc,4,rSchool,4,viSkill_Level,
+                   4,vrDesc,4,rStats);
+         AddPacket(4,Skill_meditate_ratio_one_rsc,4,piMeditate_ratio,
+                   4,Skill_meditate_ratio_two_rsc);
       }
 
       return;
+   }
+
+   GetStatsDesc()
+   {
+      local sString;
+
+      sString = CreateString();
+      SetString(sString,skill_nothing);
+
+      return sString;
    }
 
    GetValue()

--- a/kod/object/passive/skill/secwind.kod
+++ b/kod/object/passive/skill/secwind.kod
@@ -134,6 +134,66 @@ messages:
    {
       return viShow_enchantment_icon & 0x02;
    }
-   
+
+   GetStatsDesc(who=$)
+   {
+      ClearTempString();
+
+      if who <> $
+         AND IsClass(who,&User)
+      {
+         Send(self,@CreateStatsDesc,#who=who);
+      }
+
+      return GetTempString();
+   }
+
+   CreateStatsDesc(who=$)
+   {
+      local iDuration, iMinutes, iSeconds, iTimer;
+
+      iTimer = Send(who,@GetSecondWindTimer);
+      if iTimer = $
+      {
+         return;
+      }
+
+      if IsTimer(iTimer)
+      {
+         iDuration = GetTimeRemaining(iTimer);
+      }
+      else
+      {
+         % Should be an integer.
+         iDuration = iTimer;
+      }
+
+      iDuration = iDuration / 1000;
+      iMinutes = iDuration / 60;
+      iSeconds = iDuration MOD 60;
+
+      AppendTempString("\n\n");
+      AppendTempString("Your current ");
+      AppendTempString(Send(self,@GetName));
+      AppendTempString(" enchantment will last for ");
+      if iMinutes > 0
+      {
+         AppendTempString(iMinutes);
+         if iMinutes = 1
+         {
+            AppendTempString(" minute and ");
+         }
+         else
+         {
+            AppendTempString(" minutes and ");
+         }
+      }
+
+      AppendTempString(iSeconds);
+      AppendTempString(" seconds.");
+
+      return GetTempString();
+   }
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/crysmana.kod
+++ b/kod/object/passive/spell/crysmana.kod
@@ -171,6 +171,66 @@ messages:
       return bound((spell_ability+1)/5,0,20);
    }
 
+   GetStatsDesc(who=$)
+   {
+      ClearTempString();
+
+      if who <> $
+         AND IsClass(who,&User)
+      {
+         Send(self,@CreateStatsDesc,#who=who);
+      }
+
+      return GetTempString();
+   }
+
+   CreateStatsDesc(who=$)
+   {
+      local iDuration, iMinutes, iSeconds, iTimer;
+
+      iTimer = Send(who,@GetManaSurgeTimer);
+      if iTimer = $
+      {
+         return;
+      }
+
+      if IsTimer(iTimer)
+      {
+         iDuration = GetTimeRemaining(iTimer);
+      }
+      else
+      {
+         % Should be an integer.
+         iDuration = iTimer;
+      }
+
+      iDuration = iDuration / 1000;
+      iMinutes = iDuration / 60;
+      iSeconds = iDuration MOD 60;
+
+      AppendTempString("\n\n");
+      AppendTempString("Your current ");
+      AppendTempString(Send(self,@GetName));
+      AppendTempString(" enchantment will last for ");
+      if iMinutes > 0
+      {
+         AppendTempString(iMinutes);
+         if iMinutes = 1
+         {
+            AppendTempString(" minute and ");
+         }
+         else
+         {
+            AppendTempString(" minutes and ");
+         }
+      }
+
+      AppendTempString(iSeconds);
+      AppendTempString(" seconds.");
+
+      return GetTempString();
+   }
+
    GetWaitTime(who=$)
    {
       local iWaitTime, iIntellect;

--- a/kod/object/passive/spell/utility/phase.kod
+++ b/kod/object/passive/spell/utility/phase.kod
@@ -553,6 +553,56 @@ messages:
    {
       return FALSE;
    }
- 
+
+   GetStatsDesc(who=$)
+   {
+      ClearTempString();
+
+      if who <> $
+         AND IsClass(who,&User)
+      {
+         Send(self,@CreateStatsDesc,#who=who);
+      }
+
+      return GetTempString();
+   }
+
+   CreateStatsDesc(who=$)
+   {
+      local iDuration, iMinutes, iSeconds;
+
+      % Always returns the remaining time as an integer.
+      iDuration = Send(who,@GetRemainingPhaseTime);
+      if iDuration = $
+      {
+         return;
+      }
+
+      iDuration = iDuration;
+      iDuration = iDuration / 1000;
+      iMinutes = iDuration / 60;
+      iSeconds = iDuration MOD 60;
+
+      AppendTempString("\n\n");
+      AppendTempString("You have ");
+      if iMinutes > 0
+      {
+         AppendTempString(iMinutes);
+         if iMinutes = 1
+         {
+            AppendTempString(" minute and ");
+         }
+         else
+         {
+            AppendTempString(" minutes and ");
+         }
+      }
+
+      AppendTempString(iSeconds);
+      AppendTempString(" seconds of phase time remaining.");
+
+      return GetTempString();
+   }
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Second Wind and Crystalize Mana will now show the time until the effect
wears off if the player clicks on the icon in their enchantment bar.

Clicking on the Phase icon will also tell the player how long they can
remain phased before taking penalties, and clicking on the spell
description will let them know how long they can phase for.