### PR TITLE
Handle monster ET kills correctly; give attackers a success message when illusioned as a monster and performing a hit side effect such as poison.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -382,6 +382,9 @@ properties:
    poEvilTwin = $
    poEvilTwinOriginal = $
    poEvilTwinCaster = $
+   
+   % Apparition object (caster)
+   poApparitionCaster = $
 
    % Should this monster stick around through a call to DestroyDisposable()?
    pbDontDispose = FALSE
@@ -611,6 +614,8 @@ messages:
       if poEvilTwinOriginal <> $
       {
          Send(poEvilTwinOriginal,@RemoveEvilTwin);
+         poEvilTwinOriginal = $;
+         poEvilTwinCaster = $;
       }
 
       % If this monster has an Evil Twin, delete it too.
@@ -633,13 +638,17 @@ messages:
       if poApparitionOriginal <> $
       {
          Send(poApparitionOriginal,@RemoveApparition,#what=self);
+         poApparitionOriginal = $;
+         poApparitionCaster = $;
       }
+
       % Under rare conditions delete is called twice in succession
       if poBrain <> $
       {
          Send(poBrain,@MobDelete,#mob=self,#state=piState);
-         poBrain = $ ;
+         poBrain = $;
       }
+
       Send(self,@ClearBehavior);
       Send(self,@ClearBasicTimers);
 
@@ -3463,6 +3472,8 @@ messages:
 
    KilledSomething(what=$,use_weapon=$)
    {
+      local oIllusionCaster;
+
       if what = $
       {
          Debug("Bad info in killedsomething().");
@@ -3501,12 +3512,23 @@ messages:
       % the caster of the evil twin acts as the master for
       % tracking the results of monster kills, but not any
       % accidental player kills (or player minion kills).
+      % Handle apparitions the same way.
+      if poApparitionCaster <> $
+      {
+         oIllusionCaster = poApparitionCaster;
+      }
       if poEvilTwinCaster <> $
+      {
+         oIllusionCaster = poEvilTwinCaster;
+      }
+
+      if oIllusionCaster <> $
+         OR poApparitionCaster <> $
          AND IsClass(what,&Monster)
          AND (Send(what,@GetMaster) = $
             OR IsClass(Send(what,@GetMaster),&Monster))
       {
-         return Send(poEvilTwinCaster,@KilledSomething,#what=what,
+         return Send(oIllusionCaster,@KilledSomething,#what=what,
                      #use_weapon=use_weapon);
       }
 
@@ -6038,6 +6060,14 @@ messages:
    {
       poEvilTwinOriginal = what;
       poEvilTwinCaster = who;
+
+      return;
+   }
+
+   ApparitionCaster(who=$)
+   "If this monster is an apparition, keep track of the caster."
+   {
+      poApparitionCaster = who;
 
       return;
    }

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -3513,6 +3513,8 @@ messages:
       % tracking the results of monster kills, but not any
       % accidental player kills (or player minion kills).
       % Handle apparitions the same way.
+      oIllusionCaster = $;
+
       if poApparitionCaster <> $
       {
          oIllusionCaster = poApparitionCaster;
@@ -3523,7 +3525,6 @@ messages:
       }
 
       if oIllusionCaster <> $
-         OR poApparitionCaster <> $
          AND IsClass(what,&Monster)
          AND (Send(what,@GetMaster) = $
             OR IsClass(Send(what,@GetMaster),&Monster))

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -381,6 +381,7 @@ properties:
    % Evil twin objects
    poEvilTwin = $
    poEvilTwinOriginal = $
+   poEvilTwinCaster = $
 
    % Should this monster stick around through a call to DestroyDisposable()?
    pbDontDispose = FALSE
@@ -3496,6 +3497,19 @@ messages:
                      #use_weapon=use_weapon);
       }
 
+      % If this is a monster evil twin, and it has no master,
+      % the caster of the evil twin acts as the master for
+      % tracking the results of monster kills, but not any
+      % accidental player kills (or player minion kills).
+      if poEvilTwinCaster <> $
+         AND IsClass(what,&Monster)
+         AND (Send(what,@GetMaster) = $
+            OR IsClass(Send(what,@GetMaster),&Monster))
+      {
+         return Send(poEvilTwinCaster,@KilledSomething,#what=what,
+                     #use_weapon=use_weapon);
+      }
+
       % If we don't have a master, proceed as normal.
       Send(Send(what,@GetOwner),@SomethingKilled,#what=self,#victim=what);
 
@@ -6020,9 +6034,10 @@ messages:
    }
 
    % If this monster is an Evil Twin, this keeps track of the original target.
-   EvilTwinOrignial(what=$)
+   EvilTwinOrignial(what=$,who=$)
    {
       poEvilTwinOriginal = what;
+      poEvilTwinCaster = who;
 
       return;
    }

--- a/kod/object/active/holder/nomoveon/battler/monster/dethspid.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dethspid.kod
@@ -31,6 +31,8 @@ resources:
       "transformed in return for longevity.  All the old tales, however, "
       "warn travellers to beware of this malignant creature's extraordinarily "
       "poisonous bite."
+   dspider_illusion_poisoned = \
+      "%s%s reels as poison from your attack courses through %s veins."
 
    DeathSpider_dead_icon_rsc = spidmagX.bgf
    DeathSpider_dead_name_rsc = "dead spider"
@@ -130,7 +132,7 @@ messages:
       propagate;
    }
 
-   HitSideEffect(what = $)
+   HitSideEffect(what = $, who = $)
    {
       local oSpell;
 
@@ -139,6 +141,13 @@ messages:
          oSpell = Send(SYS,@FindSpellByNum,#num=SID_POISON);
          Send(oSpell,@MakePoisoned,#who=what,
                #lossrate=POISON_LOSSRATE,#duration=POISON_DURATION);
+      }
+
+      if who <> $
+      {
+         Send(who,@MsgSendUser,#message_rsc=dspider_illusion_poisoned,
+               #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName),
+               #parm3=Send(what,@GetHisHer));
       }
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/monster/dethspid.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dethspid.kod
@@ -141,13 +141,13 @@ messages:
          oSpell = Send(SYS,@FindSpellByNum,#num=SID_POISON);
          Send(oSpell,@MakePoisoned,#who=what,
                #lossrate=POISON_LOSSRATE,#duration=POISON_DURATION);
-      }
-
-      if who <> $
-      {
-         Send(who,@MsgSendUser,#message_rsc=dspider_illusion_poisoned,
-               #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName),
-               #parm3=Send(what,@GetHisHer));
+      
+         if who <> $
+         {
+            Send(who,@MsgSendUser,#message_rsc=dspider_illusion_poisoned,
+                  #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName),
+                  #parm3=Send(what,@GetHisHer));
+         }
       }
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/monster/duskrat.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/duskrat.kod
@@ -34,6 +34,8 @@ resources:
    duskrat_poisoned_add_rsc = \
       "As the poison travels to your head, you begin "
       "to feel a little light-headed.  The room spins around you."
+   duskrat_illusion_poisoned = \
+      "%s%s reels as poison from your attack courses through %s veins."
 
    duskrat_dead_icon_rsc = ratX.bgf
    duskrat_dead_name_rsc = "dead dusk rat"
@@ -150,7 +152,7 @@ messages:
       propagate;
    }
 
-   HitSideEffect(what=$)
+   HitSideEffect(what=$,who=$)
    {
       local oSpell;
 
@@ -165,6 +167,13 @@ messages:
             Send(what,@EffectSendUserDuration,#effect=EFFECT_WAVER,
                   #duration=10000);
             Send(what,@MsgSendUser,#message_rsc=duskrat_poisoned_add_rsc);
+         }
+         
+         if who <> $
+         {
+            Send(who,@MsgSendUser,#message_rsc=duskrat_illusion_poisoned,
+                  #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName),
+                  #parm3=Send(what,@GetHisHer));
          }
       }
 

--- a/kod/object/active/holder/nomoveon/battler/monster/evilent.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/evilent.kod
@@ -206,7 +206,7 @@ messages:
       propagate;
    }
 
-   HitSideEffect(what = $)
+   HitSideEffect(what = $, who=$)
    {
       local oSpell;
 
@@ -214,7 +214,14 @@ messages:
       if NOT Send(what,@IsEnchanted,#what=oSpell)
          AND Random(1,PALSY_CHANCE) = 1
       {
-         Send(oSpell,@DoSpell,#what=self,#oTarget=what,#iSpellPower=50);
+         if who <> $
+         {
+            Send(oSpell,@CastSpell,#who=who,#lTargets=[what],#iSpellPower=50);
+         }
+         else
+         {
+            Send(oSpell,@DoSpell,#what=self,#oTarget=what,#iSpellPower=50);
+         }
       }
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/monster/scorpion.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/scorpion.kod
@@ -115,13 +115,13 @@ messages:
          oSpell = Send(SYS,@FindSpellByNum,#num=SID_POISON);
          Send(oSpell,@MakePoisoned,#who=what,
                #lossrate=piPoison_Loss_Rate,#duration=piPoison_Duration);
-      }
 
-      if who <> $
-      {
-         Send(who,@MsgSendUser,#message_rsc=scorpion_illusion_poisoned,
-               #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName),
-               #parm3=Send(what,@GetHisHer));
+         if who <> $
+         {
+            Send(who,@MsgSendUser,#message_rsc=scorpion_illusion_poisoned,
+                  #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName),
+                  #parm3=Send(what,@GetHisHer));
+         }
       }
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/monster/scorpion.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/scorpion.kod
@@ -20,9 +20,11 @@ resources:
    scorpion_name_rsc = "giant scorpion"
    scorpion_icon_rsc = scorp.bgf
    scorpion_desc_rsc = \
-   "The scorpion's deadly stinger rises high in the air "
-   "and its hard plated body protects it from all but the "
-   "strongest attacks."
+      "The scorpion's deadly stinger rises high in the air "
+      "and its hard plated body protects it from all but the "
+      "strongest attacks."
+   scorpion_illusion_poisoned = \
+      "%s%s reels as poison from your attack courses through %s veins."
 
    scorpion_dead_icon_rsc = scorpX.bgf
    scorpion_dead_name_rsc = "dead scorpion"
@@ -104,7 +106,7 @@ messages:
       propagate;
    }
 
-   HitSideEffect(what=$)
+   HitSideEffect(what=$,who=$)
    {
       local oSpell;
 
@@ -114,7 +116,14 @@ messages:
          Send(oSpell,@MakePoisoned,#who=what,
                #lossrate=piPoison_Loss_Rate,#duration=piPoison_Duration);
       }
-      
+
+      if who <> $
+      {
+         Send(who,@MsgSendUser,#message_rsc=scorpion_illusion_poisoned,
+               #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName),
+               #parm3=Send(what,@GetHisHer));
+      }
+
       return;
    }
 

--- a/kod/object/active/holder/nomoveon/battler/monster/skel/daemskel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/skel/daemskel.kod
@@ -84,7 +84,7 @@ messages:
       return;
    }
 
-     HitSideEffect(what = $, who = $)
+   HitSideEffect(what = $, who = $)
    {
       local oSpell;
 

--- a/kod/object/active/holder/nomoveon/battler/monster/skel/daemskel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/skel/daemskel.kod
@@ -84,7 +84,7 @@ messages:
       return;
    }
 
-     HitSideEffect(what = $)
+     HitSideEffect(what = $, who = $)
    {
       local oSpell;
 
@@ -92,14 +92,28 @@ messages:
       if NOT Send(what,@IsEnchanted,#what=oSpell)
          AND Random(1,PALSY_CHANCE) = 1
       {
-         Send(oSpell,@DoSpell,#what=self,#oTarget=what,#iSpellPower=50);
+         if who <> $
+         {
+            Send(oSpell,@CastSpell,#who=who,#lTargets=[what],#iSpellPower=50);
+         }
+         else
+         {
+            Send(oSpell,@DoSpell,#what=self,#oTarget=what,#iSpellPower=50);
+         }
       }
 
       oSpell = Send(SYS,@FindSpellByNum,#num=SID_DEMENT);
       if NOT Send(what,@IsEnchanted,#what=oSpell) 
          AND Random(1,DEMENTIA_CHANCE) = 1
       {
-         Send(oSpell,@DoSpell,#what=self,#oTarget=what,#iSpellPower=50);
+         if who <> $
+         {
+            Send(oSpell,@CastSpell,#who=who,#lTargets=[what],#iSpellPower=50);
+         }
+         else
+         {
+            Send(oSpell,@DoSpell,#what=self,#oTarget=what,#iSpellPower=50);
+         }
       }
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/monster/spdrquen.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/spdrquen.kod
@@ -28,6 +28,8 @@ resources:
    spiderqueen_desc_rsc = \
       "The huge egg sac of the queen spider makes her slow and heavy, but "
       "dark intelligence shines in her many red eyes."
+   qspider_illusion_poisoned = \
+      "%s%s reels as poison from your attack courses through %s veins."
 
    spiderqueen_dead_icon_rsc = spdrquX.bgf
    spiderqueen_dead_name_rsc = "dead queen spider"
@@ -124,7 +126,7 @@ messages:
       return;
    }
 
-   HitSideEffect(what = $)
+   HitSideEffect(what = $, who = $)
    {
       local oSpell, oSpell2;
 
@@ -133,13 +135,28 @@ messages:
          oSpell = Send(SYS,@FindSpellByNum,#num=SID_POISON);
          Send(oSpell,@MakePoisoned,#who=what,#lossrate=POISON_LOSSRATE,
                #duration=POISON_DURATION);
+
+         if who <> $
+         {
+            Send(who,@MsgSendUser,#message_rsc=qspider_illusion_poisoned,
+                  #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName),
+                  #parm3=Send(what,@GetHisHer));
+         }
       }
 
       if Random(1,4) = 1
       {
          oSpell2 = Send(SYS,@FindSpellByNum,#num=SID_SPIDER_WEB);
-         Send(oSpell2,@CastSpell,#who=self,
-               #ltargets=[poTarget],#ispellpower=100);
+         if who <> $
+         {
+            Send(oSpell2,@CastSpell,#who=who,
+                  #lTargets=[what],#ispellpower=30);
+         }
+         else
+         {
+            Send(oSpell2,@CastSpell,#who=self,
+                  #lTargets=[poTarget],#ispellpower=100);
+         }
       }
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/monster/spider.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/spider.kod
@@ -135,13 +135,13 @@ messages:
          oSpell = Send(SYS,@FindSpellByNum,#num=SID_POISON);
          Send(oSpell,@MakePoisoned,#who=what,
                #lossrate=POISON_LOSSRATE,#duration=POISON_DURATION);
-      }
 
-      if who <> $
-      {
-         Send(who,@MsgSendUser,#message_rsc=spider_illusion_poisoned,
-               #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName),
-               #parm3=Send(what,@GetHisHer));
+         if who <> $
+         {
+            Send(who,@MsgSendUser,#message_rsc=spider_illusion_poisoned,
+                  #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName),
+                  #parm3=Send(what,@GetHisHer));
+         }
       }
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/monster/spider.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/spider.kod
@@ -25,6 +25,8 @@ resources:
    spider_desc_rsc = \
       "This strangely delicate creature moves with stealth and strikes "
       "with deadly precision."
+   spider_illusion_poisoned = \
+      "%s%s reels as poison from your attack courses through %s veins."
 
    spider_dead_icon_rsc = spiderX.bgf
    spider_dead_name_rsc = "dead spider"
@@ -124,7 +126,7 @@ messages:
       propagate;
    }
 
-   HitSideEffect(what = $)
+   HitSideEffect(what = $, who = $)
    {
       local oSpell;
 
@@ -133,6 +135,13 @@ messages:
          oSpell = Send(SYS,@FindSpellByNum,#num=SID_POISON);
          Send(oSpell,@MakePoisoned,#who=what,
                #lossrate=POISON_LOSSRATE,#duration=POISON_DURATION);
+      }
+
+      if who <> $
+      {
+         Send(who,@MsgSendUser,#message_rsc=spider_illusion_poisoned,
+               #parm1=Send(what,@GetDef),#parm2=Send(what,@GetName),
+               #parm3=Send(what,@GetHisHer));
       }
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/monster/thrasher.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/thrasher.kod
@@ -155,7 +155,7 @@ messages:
       return;
    }
 
-   HitSideEffect(what = $)
+   HitSideEffect(what = $, who = $)
    {
       local oSpell;
 
@@ -163,7 +163,14 @@ messages:
       if NOT Send(what,@IsEnchanted,#what=oSpell)
          AND Random(1,PALSY_CHANCE) = 1
       {
-         Send(oSpell,@DoSpell,#what=self,#oTarget=what,#iSpellPower=90);
+         if who <> $
+         {
+            Send(oSpell,@CastSpell,#who=who,#lTargets=[what],#iSpellPower=90);
+         }
+         else
+         {
+            Send(oSpell,@DoSpell,#what=self,#oTarget=what,#iSpellPower=90);
+         }
       }
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5130,7 +5130,7 @@ messages:
       oMonster = Send(self,@GetIllusionForm);
       if (oMonster <> $)
       {
-         Send(oMonster,@HitSideEffect,#what=what);
+         Send(oMonster,@HitSideEffect,#what=what,#who=self);
       }
 
       Send(self,@DoHitMessageSound,#what=what,#damage=damage,#stroke_obj=stroke_obj);

--- a/kod/object/passive/spell/SUMMTWIN.KOD
+++ b/kod/object/passive/spell/SUMMTWIN.KOD
@@ -154,7 +154,7 @@ messages:
          % Should be a monster. Make a low HP copy of it.
          oTwin = Create((GetClass(oTarget)));
          Send(oTwin,@SetIllusion,#value=TRUE);
-         Send(oTwin,@EvilTwinOrignial,#what=oTarget);
+         Send(oTwin,@EvilTwinOrignial,#what=oTarget,#who=who);
       }
 
       Send(oTarget,@AddEvilTwin,#what=oTwin);

--- a/kod/object/passive/spell/apparitn.kod
+++ b/kod/object/passive/spell/apparitn.kod
@@ -148,9 +148,10 @@ messages:
          }
       }
 
-      % These two functions allow monsters to keep track of Apparitions.
+      % These three functions allow monsters to keep track of Apparitions.
       Send(oTarget,@AddApparition,#what=oApparition);
       Send(oApparition,@AddApparitionOriginal,#what=oTarget);
+      Send(oApparition,@ApparitionCaster,#who=who);
 
       Send(oApparition,@SetIllusion,#value=TRUE);
 

--- a/kod/object/passive/spell/sweep.kod
+++ b/kod/object/passive/spell/sweep.kod
@@ -252,9 +252,8 @@ messages:
       Post(oRoom,@SomeoneSaid,#what=who,#string=rRant,#type=SAY_MESSAGE,
            #parm1=Send(who,@GetDef),#parm2=Send(who,@GetName));
 
-      propagate;
+      return;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -6597,22 +6597,6 @@ messages:
       return iList;
    }
 
-   FixPlayersOverLearnCount()
-   "This assumes all 'bugged' players are due to having level 1 Riija."
-   {
-      local i, iList;
-
-      iList = Send(self,@FindPlayersOverLearnCount);
-
-      for i in iList
-      {
-         Send(i,@StripSpellsOfSchool,#school=SS_RIIJA);
-         Debug("Removed Riija from ",i,Send(i,@GetTrueName));
-      }
-
-      return;
-   }
-
    AdminListPlayersOverHP(hp=$)
    {
       local i;


### PR DESCRIPTION
Casting ET on a monster generates a copy of that monster, not a true
evil twin. This fix will allow kills made by those copies to count
correctly as kills by the master, if the victim is another monster with
no master (or a monster master).

Add hit side effect messages for ill form/morphed players.
Will give a success message to the attacker when a hit side effect is
performed on a victim (e.g. dusk rat poison, daemon skel enfeeble).