### PR TITLE
Fix wall elements not causing monsters to aggro.

### DIFF
--- a/kod/object/active/wallelem/asburstc.kod
+++ b/kod/object/active/wallelem/asburstc.kod
@@ -21,11 +21,14 @@ resources:
 
    ActiveSporeCloud_name_rsc = "thick fog"
    ActiveSporeCloud_icon_rsc = poisoncl.bgf
-   ActiveSporeCloud_desc_rsc = "You choke just looking at the thick putrid fog."
+   ActiveSporeCloud_desc_rsc = \
+      "You choke just looking at the thick putrid fog."
 
    ActiveSporeCloud_dissipates = "The spore clouds drift away on the wind."
-   ActiveSporeCloud_poisoned = "You suddenly feel sick as you inhale the vapors of the fog."
-   ActiveSporeCloud_unaffected = "Strangely, the noxious cloud does not affect you."
+   ActiveSporeCloud_poisoned = \
+      "You suddenly feel sick as you inhale the vapors of the fog."
+   ActiveSporeCloud_unaffected = \
+      "Strangely, the noxious cloud does not affect you."
 
    ActiveSporeCloud_poison_snd = psncough.wav
 
@@ -50,7 +53,7 @@ properties:
    piBonus = 1
 
 messages:
-   
+
    Constructor(caster=$,duration=$,range=$)
    {
       if range <> $
@@ -69,18 +72,19 @@ messages:
       oSpell = Send(SYS,@FindSpellByNum,#num=SID_HOLD);
 
       Send(oSpell,@DoHold,#what=self,#otarget=what,
-           #iDurationSecs=BASE_HOLD_DURATION+piBonus);
+            #iDurationSecs=BASE_HOLD_DURATION+piBonus);
+      Send(poOwner,@SomethingAttacked,#what=poCaster,#victim=what,
+            #use_weapon=self,#stroke_obj=self);
 
       propagate;
-   }   
+   }
 
    SendAnimation()
    {
       AddPacket(1,ANIMATE_CYCLE, 4,random(240,280), 2,1, 2,5);
-      
+
       return;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/wallelem/poisfogc.kod
+++ b/kod/object/active/wallelem/poisfogc.kod
@@ -26,14 +26,18 @@ resources:
 
    PoisonFogCloud_name_rsc = "thick fog"
    PoisonFogCloud_icon_rsc = poisoncl.bgf
-   PoisonFogCloud_desc_rsc = "You choke just looking at the thick putrid fog."
+   PoisonFogCloud_desc_rsc = \
+      "You choke just looking at the thick putrid fog."
 
-   PoisonFogCloud_poisoned = "You suddenly feel sick as you inhale the vapors of the fog."
+   PoisonFogCloud_poisoned = \
+      "You suddenly feel sick as you inhale the vapors of the fog."
 
    PoisonFogCloud_poison_snd = psncough.wav
 
-   PoisonFog_dissipates = "Some of the poison fog fades, then clears."
-   PoisonFog_unaffected = "You hold your breath and the noxious cloud does not affect you."
+   PoisonFog_dissipates = \
+      "Some of the poison fog fades, then clears."
+   PoisonFog_unaffected = \
+      "You hold your breath and the noxious cloud does not affect you."
 
 classvars:
 
@@ -91,7 +95,8 @@ messages:
 
             Send(oSpell,@MakePoisoned,#who=what,#lossrate=POISON_LOSSRATE,
                  #duration=POISON_DURATION);
-            
+            Send(poOwner,@SomethingAttacked,#what=poCaster,#victim=what,
+                  #use_weapon=self,#stroke_obj=self);
             if IsClass(poCaster,&Player)
             {
                Send(poCaster,@SetPlayerFlag,#flag=PFLAG_DID_DAMAGE,#value=TRUE);

--- a/kod/object/active/wallelem/wallfire.kod
+++ b/kod/object/active/wallelem/wallfire.kod
@@ -100,14 +100,18 @@ messages:
             iDamage = Send(what,@AssessDamage,#what=poCaster,#damage=Random(0,iDamage),
                            #aspell=ATCK_SPELL_ALL,#absolute=TRUE,#report=FALSE,
                            #report_resistance=FALSE,#precision=TRUE);
+            Send(poOwner,@SomethingAttacked,#what=poCaster,#victim=what,
+                  #use_weapon=self,#stroke_obj=self);
             Send(what,@StartEnchantment,#what=oIllusWounds,#time=iDuration,#lastcall=TRUE,
-                 #state=iDamage,#addicon=FALSE);
+                  #state=iDamage,#addicon=FALSE);
          }
       }
       else
       {
          iDamage = Send(what,@AssessDamage,#what=poCaster,#damage=Random(0,piMaxDamage),
                         #aspell=ATCK_SPELL_ALL+ATCK_SPELL_FIRE,#report=FALSE,#report_resistance=FALSE);
+         Send(poOwner,@SomethingAttacked,#what=poCaster,#victim=what,
+               #use_weapon=self,#stroke_obj=self);
       }
 
       if iDamage = $

--- a/kod/object/active/wallelem/wallltng.kod
+++ b/kod/object/active/wallelem/wallltng.kod
@@ -85,6 +85,9 @@ messages:
       iDamage = Send(what,@AssessDamage,#what=poCaster,#damage=Random(0,iMaxDamage),
                      #aspell=ATCK_SPELL_ALL+ATCK_SPELL_SHOCK,#report=FALSE,#report_resistance=FALSE);
 
+      Send(poOwner,@SomethingAttacked,#what=poCaster,#victim=what,
+            #use_weapon=self,#stroke_obj=self);
+
       if iDamage = $
       {
          Send(poCaster,@KilledSomething,#what=what,#use_weapon=self);

--- a/kod/object/active/wallelem/web.kod
+++ b/kod/object/active/wallelem/web.kod
@@ -26,7 +26,8 @@ resources:
    web_stick3 = "Is there something stuck to your boot or are you stuck to IT?"
    web_stick5 = "You find yourself helplessly stuck to the spider web!"
 
-   web_dissipates = "A piece of the web withers and disappears before your eyes."
+   web_dissipates = \
+      "A piece of the web withers and disappears before your eyes."
 
    web_stick_snd = frying.wav
 
@@ -65,7 +66,7 @@ messages:
                              &Lich, &LupoggKing, &Yeti, &Ghost,
                              &DragonFly, &DragonFlyQueen, &EvilFairy, &Fairy,
                              &DarkAngel, &Kriipa, &XeoAir, &XeoFire,
-                             &Revenant
+                             &Revenant, &Elemental
                            ];
      
       propagate;
@@ -123,8 +124,10 @@ messages:
 
       if iHoldTime > 0
       {
-         Send(oSpell,@DoHold,#what=poCaster,#oTarget=what,#iDurationSecs=iHoldTime,
-              #report=FALSE);
+         Send(oSpell,@DoHold,#what=poCaster,#oTarget=what,
+               #iDurationSecs=iHoldTime,#report=FALSE);
+         Send(poOwner,@SomethingAttacked,#what=poCaster,#victim=what,
+               #use_weapon=self,#stroke_obj=self);
       }
 
       if isClass(what,&User)


### PR DESCRIPTION
Wall elements have long been a way for players to attack monsters
without the monster doing anything. The correct code is now called when
a player attacks a monster using a wall element.

Also added golems to the list of monster unaffected by spider web
(they're huge and heavy, no way would they be stuck here).