### PR TITLE
Allow monsters to have minions. Convert Seduce and Animate for use by monsters.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -166,6 +166,10 @@ properties:
    plApparitionList = $
    poApparitionOriginal = $
 
+   % Store minions
+   plControlledMinions = $
+   ptMinionControlCheck = $
+
    % list of resistances, Each element is [value, type].
    plResistances = $
 
@@ -190,7 +194,30 @@ messages:
    {
       return FALSE;
    }
-  
+
+   Delete()
+   {
+      local i;
+
+      % Clear minion control list. Delete each of our minions
+      % unless they are reflections, which are handled separately.
+      % Deleted minions will remove themselves from our list, we
+      % just need to let them know they're to be deleted.
+      if plControlledMinions <> $
+      {
+         for i in plControlledMinions
+         {
+            if IsClass(i,&Monster)
+               AND NOT IsClass(i,&Reflection)
+            {
+               Send(i,@Delete);
+            }
+         }
+      }
+
+      propagate;
+   }
+
    ReqNewOwner(what = $)
    {
       return IsClass(what,&Room);
@@ -1392,6 +1419,93 @@ messages:
       }
       
       return 0;
+   }
+
+   % This section deals with minion control code.
+   % Player and Monster both have a copy of CommandMinionAttack.
+
+   NewControlledMinion(minion=$)
+   {
+      if ptMinionControlCheck = $
+      {
+         CreateTimer(self,@MinionControlCheck,2000);
+      }
+
+      plControlledMinions = Cons(minion,plControlledMinions);
+
+      return;
+   }
+
+   RemoveControlledMinion(what=$)
+   {
+      if plControlledMinions <> $
+      {
+         % Use FindListElem; there are rare cases where we have
+         % a valid minion that doesn't go on our control list.
+         if FindListElem(plControlledMinions,what)
+         {
+            plControlledMinions = DelListElem(plControlledMinions,what);
+         }
+      }
+
+      return;
+   }
+
+   GetControlledMinions()
+   {
+      return plControlledMinions;
+   }
+
+   CheckBattlerMinionCount()
+   {
+      local i,iMinionCount;
+
+      iMinionCount = 0;
+
+      for i in plControlledMinions
+      {
+         if NOT IsClass(i,&Reflection)
+         {
+            iMinionCount = iMinionCount + 1;
+         }
+      }
+
+      return iMinionCount;
+   }
+
+   MinionControlCheck()
+   {
+      local i;
+
+      if Length(plControlledMinions) > 0
+      {
+         for i in plControlledMinions
+         {
+            if Send(i,@GetMaster) <> self
+            {
+               Send(self,@RemoveControlledMinion,#what=i);
+
+               continue;
+            }
+
+            if Send(i,@GetTarget) = $
+            {
+               Send(i,@SetBehaviorFlag,#flag=AI_MOVE_FOLLOW_MASTER,
+                     #value=TRUE);
+            }
+         }
+         CreateTimer(self,@MinionControlCheck,2000);
+      }
+      else
+      {
+         if ptMinionControlCheck <> $
+         {
+            DeleteTimer(ptMinionControlCheck);
+         }
+         ptMinionControlCheck = $;
+      }
+
+      return;
    }
 
    % This section deals with illusions cast by/on the battler

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -624,10 +624,7 @@ messages:
       % Minion Management - upon dying they should leave your control list
       if poMaster <> $
       {
-         if IsClass(poMaster,&User)
-         {
-            Send(poMaster,@RemoveControlledMinion,#what=self);
-         }
+         Send(poMaster,@RemoveControlledMinion,#what=self);
       }
 
       % If this monster is an 'Evil Twin', tell the original it was deleted.
@@ -1781,6 +1778,9 @@ messages:
          }
       }
 
+      % If we have minions, see if they can attack too
+      Send(self,@CommandMinionAttack,#oMaster=self,#oTarget=what);
+
       % Face the target.
       Send(self,@MonsterOrient,#new_row=Send(what,@GetRow),
             #new_col=Send(what,@GetCol),#new_finerow=Send(what,@GetFineRow),
@@ -1920,6 +1920,9 @@ messages:
          return 0;
       }
 
+      % Attacks against a minion master will cause minions to defend the master
+      Send(self,@CommandMinionAttack,#oMaster=self,#oTarget=what);
+
       % check for any applicable resistances.
 
       if NOT absolute
@@ -1987,7 +1990,7 @@ messages:
          Post(what,@MsgPlayerHitResisted,#what=what,#resistance=iResist,
               #target=self,#color_rsc=monster_color_blue_rsc);
       }
-      
+
       return iDamage;
    }
 
@@ -3503,7 +3506,6 @@ messages:
 
       % If we have a master, they are responsible for our kills.
       if poMaster <> $
-         AND IsClass(poMaster,&Player)
       {
          if IsClass(what,&Player)
             AND IsClass(poMaster,&Player)
@@ -6102,6 +6104,48 @@ messages:
    "If this monster is an apparition, keep track of the caster."
    {
       poApparitionCaster = who;
+
+      return;
+   }
+
+   % This section deals with minion code.
+   CommandMinionAttack(oMaster=$,oTarget=$)
+   {
+      local oActive;
+
+      % If we have minions, we only want them to attack Battlers,
+      % not items or anything else that can damage us.
+      if plControlledMinions = $
+         OR oTarget = $
+         OR NOT IsClass(oTarget,&Battler)
+         OR IsClass(oTarget,&Revenant)
+      {
+         return;
+      }
+
+      % Lets not have the minions kill each other. Check if the target is
+      % a minion under our control.
+      if IsClass(oTarget,&Monster)
+         AND Send(oTarget,@GetMaster) = self
+      {
+         return;
+      }
+
+
+      for oActive in plControlledMinions
+      {
+         if IsClass(oActive,&Monster)
+            AND Send(oActive,@GetMaster) = self
+            AND Send(oActive,@GetTarget) <> oTarget
+         {
+            Send(oActive,@SetBehaviorFlag,
+                  #flag=AI_MOVE_FOLLOW_MASTER,#value=FALSE);
+            Send(oActive,@TargetSwitch,#what=oTarget,
+                  #iHatred=100);
+            Send(oActive,@EnterStateChase,#target=oTarget,
+                  #actnow=TRUE);
+         }
+      }
 
       return;
    }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -848,10 +848,6 @@ properties:
    poGuild = $
    piGuildRejoinTimestamp = 0
 
-   % store minions
-   plControlledMinions = $
-   ptMinionControlCheck = $
-
    % Evil twin object
    poEvilTwin = $
 
@@ -14184,13 +14180,8 @@ messages:
       return;
    }
 
-   % Can the user have controllable units
-   CanUserHaveMinions(who = $)
-   {
-      return TRUE;
-   }
-
-  CommandMinionAttack(oMaster=$,oTarget=$)
+   % This section deals with minion code.
+   CommandMinionAttack(oMaster=$,oTarget=$)
    {
       local oActive;
 
@@ -14228,90 +14219,6 @@ messages:
                      #actnow=TRUE);
             }
          }
-      }
-
-      return;
-   }
-
-   NewControlledMinion(minion=$)
-   {
-      if ptMinionControlCheck = $
-      {
-         CreateTimer(self,@MinionControlCheck,2000);
-      }
-
-      plControlledMinions = Cons(minion,plControlledMinions);
-
-      return;
-   }
-
-   RemoveControlledMinion(what=$)
-   {
-      if plControlledMinions <> $
-      {
-         % Use FindListElem; there are rare cases where we have
-         % a valid minion that doesn't go on our control list.
-         if FindListElem(plControlledMinions,what)
-         {
-            plControlledMinions = DelListElem(plControlledMinions,what);
-         }
-      }
-
-      return;
-   }
-
-   GetControlledMinions()
-   {
-      return plControlledMinions;
-   }
-
-   CheckPlayerMinionCount()
-   {
-      local i,iMinionCount;
-
-      iMinionCount = 0;
-
-      for i in plControlledMinions
-      {
-         if NOT IsClass(i,&Reflection)
-         {
-            iMinionCount = iMinionCount + 1;
-         }
-      }
-
-      return iMinionCount;
-   }
-
-   MinionControlCheck()
-   {
-      local i;
-
-      if Length(plControlledMinions) > 0
-      {
-         for i in plControlledMinions
-         {
-            if Send(i,@GetMaster) <> self
-            {
-               Send(self,@RemoveControlledMinion,#what=i);
-
-               continue;
-            }
-
-            if Send(i,@GetTarget) = $
-            {
-               Send(i,@SetBehaviorFlag,#flag=AI_MOVE_FOLLOW_MASTER,
-                     #value=TRUE);
-            }
-         }
-         CreateTimer(self,@MinionControlCheck,2000);
-      }
-      else
-      {
-         if ptMinionControlCheck <> $
-         {
-            DeleteTimer(ptMinionControlCheck);
-         }
-         ptMinionControlCheck = $;
       }
 
       return;

--- a/kod/object/passive/spell/animate.kod
+++ b/kod/object/passive/spell/animate.kod
@@ -107,12 +107,23 @@ messages:
          return FALSE;
       }
 
-      if Send(who,@CheckPlayerMinionCount)
-            >= Send(Send(SYS,@GetSettings),@GetPlayerMinionLimit)
+      if IsClass(who,&Player)
       {
-         Send(who,@MsgSendUser,#message_rsc=Animate_too_many_rsc);
+         if Send(who,@CheckBattlerMinionCount)
+               >= Send(Send(SYS,@GetSettings),@GetPlayerMinionLimit)
+         {
+            Send(who,@MsgSendUser,#message_rsc=Animate_too_many_rsc);
 
-         return FALSE;
+            return FALSE;
+         }
+      }
+      else
+      {
+         if Send(who,@CheckBattlerMinionCount)
+            >= Send(Send(SYS,@GetSettings),@GetMonsterMinionLimit)
+         {
+            return FALSE;
+         }
       }
 
       propagate;
@@ -126,8 +137,12 @@ messages:
       oTarget = First(lTargets);
       if oRoom <> Send(oTarget,@GetOwner)
       {
-         Send(who,@MsgSendUser,#message_rsc=spell_trance_break,#parm1=vrName);
-         Send(who,@WaveSendUser,#wave_rsc=spell_trance_break_sound);
+         if IsClass(who,&User)
+         {
+            Send(who,@MsgSendUser,#message_rsc=spell_trance_break,
+                  #parm1=vrName);
+            Send(who,@WaveSendUser,#wave_rsc=spell_trance_break_sound);
+         }
 
          return FALSE;
       }
@@ -145,8 +160,12 @@ messages:
 
       if oRoom <> Send(oTarget,@GetOwner)
       {
-         Send(who,@MsgSendUser,#message_rsc=spell_trance_break,#parm1=vrName);
-         Send(who,@WaveSendUser,#wave_rsc=spell_trance_break_sound);
+         if IsClass(who,&User)
+         {
+            Send(who,@MsgSendUser,#message_rsc=spell_trance_break,
+                  #parm1=vrName);
+            Send(who,@WaveSendUser,#wave_rsc=spell_trance_break_sound);
+         }
 
          return;
       }

--- a/kod/object/passive/spell/debuff/seduce.kod
+++ b/kod/object/passive/spell/debuff/seduce.kod
@@ -101,7 +101,8 @@ messages:
 
       if oMaster <> $
       {
-         if NOT Send(Send(who,@GetOwner),@IsArena)
+         if IsClass(who,&Player)
+            AND NOT Send(Send(who,@GetOwner),@IsArena)
             AND NOT Send(who,@CheckStatusAndSafety,#victim=oMaster,
                         #report=TRUE,#minion=TRUE)
          {
@@ -118,12 +119,23 @@ messages:
          }
       }
 
-      if Send(who,@CheckPlayerMinionCount) 
-            >= Send(Send(SYS,@GetSettings),@GetPlayerMinionLimit)
+      if IsClass(who,&Player)
       {
-         Send(who,@MsgSendUser,#message_rsc=seduce_too_many);
+         if Send(who,@CheckBattlerMinionCount)
+               >= Send(Send(SYS,@GetSettings),@GetPlayerMinionLimit)
+         {
+            Send(who,@MsgSendUser,#message_rsc=seduce_too_many);
 
-         return FALSE;
+            return FALSE;
+         }
+      }
+      else
+      {
+         if Send(who,@CheckBattlerMinionCount)
+               >= Send(Send(SYS,@GetSettings),@GetPlayerMinionLimit)
+         {
+            return FALSE;
+         }
       }
 
       propagate;
@@ -145,6 +157,33 @@ messages:
    DoSpell(what=$,oTarget=$,iDuration=0,iSpellPower=0)
    {
       local iRoll, oMaster;
+
+      if IsClass(what,&Monster)
+      {
+         % If a monster successfully casts this spell, we assume
+         % they're allowed to have whatever they're casting on
+         % as a minion.
+
+         oMaster = Send(oTarget,@GetMaster);
+         if oMaster <> $
+         {
+            Send(oMaster,@MsgSendUser,#message_rsc=seduce_stolen,
+                  #parm1=Send(what,@GetCapDef),#parm2=Send(what,@GetName),
+                  #parm3=Send(oTarget,@GetName));
+            % Since we don't necessarily want it going after the old master,
+            % use RemoveEnchantment instead of EndEnchantment
+            Send(oMaster,@RemoveControlledMinion,#what=oTarget);
+            Send(oTarget,@RemoveEnchantment,#what=self);
+         }
+
+         Post(oTarget,@StartEnchantment,#what=self,
+               #time=iDuration,#state=what);
+         Post(oTarget,@SetMaster,#oMaster=what);
+         Send(what,@NewControlledMinion,#minion=oTarget);
+         Post(oTarget,@ResetBehaviorFlags);
+         
+         propagate;
+      }
 
       % We determine our chances of success by adding together the caster's
       % HP/2, intellect and spellpower, and if this is larger than the
@@ -180,10 +219,7 @@ messages:
                #parm3=Send(oTarget,@GetName));
             % Since we don't necessarily want it going after the old master,
             % use RemoveEnchantment instead of EndEnchantment
-            if IsClass(oMaster,&Player)
-            {
-               Send(oMaster,@RemoveControlledMinion,#what=oTarget);
-            }
+            Send(oMaster,@RemoveControlledMinion,#what=oTarget);
             Send(oTarget,@RemoveEnchantment,#what=self);
          }
 

--- a/kod/object/passive/spell/summrefl.kod
+++ b/kod/object/passive/spell/summrefl.kod
@@ -109,11 +109,12 @@ messages:
       if IsClass(who,&Player)
       {
          Send(who,@MsgSendUser,#message_rsc=summonreflection_cast_rsc);
-         Send(who,@NewControlledMinion,#minion=oReflection);
       }
-
+      
+      Send(who,@NewControlledMinion,#minion=oReflection);
       Send(SYS,@AddReflection,#who=who,#oReflection=oReflection);
-      Send(oReflection,@SetBehaviorFlag,#flag=AI_MOVE_FOLLOW_MASTER,#value=TRUE);
+      Send(oReflection,@SetBehaviorFlag,#flag=AI_MOVE_FOLLOW_MASTER,
+            #value=TRUE);
 
       propagate;
    }

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -172,6 +172,7 @@ properties:
 
    % Number of minions allowed per caster.
    piPlayerMinionLimit = 4
+   piMonsterMinionLimit = 4
 
    % Minimum swings needed for a chance to improve a weaponcraft skill.
    piWeaponcraftImprovementMinimumSwings = 50
@@ -483,6 +484,11 @@ messages:
    GetPlayerMinionLimit()
    {
       return piPlayerMinionLimit;
+   }
+
+   GetMonsterMinionLimit()
+   {
+      return piMonsterMinionLimit;
    }
 
    GetSwingsPerImproveCheck()


### PR DESCRIPTION
Moved bulk of the minion control code from Player to Battler. Player and
Monster both have their own version of CommandMinionAttack due to the
extra checks needed for players. Minions for monsters function the same
as they do for players and recursion is also allowed - players can
theoretically have minions that have minions themselves.

Seduce and Animate have been modified so that monsters can also cast
them if necessary. If a monster casts Seduce, it is allowed to charm the
target.