### PR TITLE
Spectator/phase crash fixes; eq/pogg king error fixes.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
@@ -321,9 +321,12 @@ messages:
             #wave_rsc=lupoggking_cast_sound);
       Send(self,@DoCast);
       Send(oSpell,@DoHold,#what=self,#oTarget=oTarget,#iDurationSecs=iRandom);
-      Send(oTarget,@MsgSendUser,#message_rsc=lupoggking_cast_spell);
-      Send(oTarget,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,
-            #duration=iRandom*1000,#xlat=SPIT_COLOR); 
+      if IsClass(oTarget,&User)
+      {
+         Send(oTarget,@MsgSendUser,#message_rsc=lupoggking_cast_spell);
+         Send(oTarget,@EffectSendUserDurationAndXlat,#effect=EFFECT_FLASHXLAT,
+               #duration=iRandom*1000,#xlat=SPIT_COLOR);
+      }
 
       % Do damage?
 

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4096,8 +4096,10 @@ messages:
 
       if Send(self,@IsInCannotInteractMode)
       {
-         Send(self,@MsgSendUser,#message_rsc=cannot_attack_phased_self_rsc);
-
+         if report
+         {
+            Send(self,@MsgSendUser,#message_rsc=cannot_attack_phased_self_rsc);
+         }
          return FALSE;
       }
 

--- a/kod/object/active/holder/room/monsroom/survivalroom.kod
+++ b/kod/object/active/holder/room/monsroom/survivalroom.kod
@@ -1037,6 +1037,7 @@ messages:
       {
          Send(self,@SpectateUser,#who=what);
          Post(what,@MsgSendUser,#message_rsc=spectator_only_msg);
+
          propagate;
       }
 

--- a/kod/object/passive/spell/atakspel/earthqua.kod
+++ b/kod/object/passive/spell/atakspel/earthqua.kod
@@ -108,6 +108,11 @@ messages:
    {
       local oRoom, i, each_obj, lFinalTargets;
 
+      if who = $
+      {
+         return;
+      }
+
       lFinalTargets = $;
 
       if IsClass(who,&Room)


### PR DESCRIPTION
Wrap MsgSendUser in AllowPlayerAttack with a report check to prevent sending this when APA is used for determining attackability (i.e. minimap dots).

Add sanity checks to EQ and lupogg king to prevent errors.