### PR TITLE
Lower lupogg king hold time. Update stats reset settings.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
@@ -93,22 +93,33 @@ classvars:
    vrSound_aware = lupoggking_sound_aware
    vrSound_death = lupoggking_sound_death
 
+   viHoldDurationMax = 25  % seconds
+   viHoldDurationMin = 15  % seconds
+
 properties:
 
    piAnimation = ANIM_NONE
    plAttackers = $  % [player,player....]
 
-   piHoldAttackChance = 12   % Chance he'll attack with a hold
-   piHoldCounterChance = 5   % Chance he'll counter a spell or arrow with a hold
-   piHoldDurationMax = 45  % seconds
-   piHoldDurationMin = 30  % seconds
+   piHoldAttackChance = 12 % Chance he'll attack with a hold
+   piHoldCounterChance = 5 % Chance he'll counter a spell or arrow with a hold
+   piHoldDurationMax = 25  % seconds
+   piHoldDurationMin = 15  % seconds
 
 messages:
 
    Constructed()
    {
-      pimax_Hit_Points = pimax_hit_Points * 3;
-      piHit_Points = pimax_hit_points*100;
+      % Give lupogg king more HP.
+      piMax_Hit_Points = piMax_Hit_Points * 3;
+      % piHit_Points uses high-precision numbers, so multiply by 100.
+      piHit_Points = piMax_Hit_Points * 100;
+
+      % Set hold duration from class variables. Allows modifying
+      % classvars for ALL lupogg kings, or modifying the property
+      % for one specific lupogg king.
+      piHoldDurationMin = viHoldDurationMin;
+      piHoldDurationMax = viHoldDurationMax;
 
       plResistances = [ [ATCK_WEAP_ALL, 40 ],
                         [ATCK_WEAP_PIERCE, 90 ],
@@ -136,7 +147,7 @@ messages:
          }
       }
 
-      plAttackers = cons(what,plAttackers);
+      plAttackers = Cons(what,plAttackers);
 
       propagate;
    }
@@ -178,7 +189,8 @@ messages:
    {
       piAnimation = ANIM_SPIT;
       Send(poOwner,@SomethingChanged,#what=self);
-      Send(poOwner,@SomethingShot,#who=self,#target=poTarget,#projectile = self);
+      Send(poOwner,@SomethingShot,#who=self,#target=poTarget,
+            #projectile=self);
       piAnimation = ANIM_NONE;
 
       return;

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -56,12 +56,12 @@ properties:
    % Stat reset options
    pbStatsResetEnabled = TRUE
    piStatsResetPenalty = -2
-   piFreeStatsResetCap = 49
+   piFreeStatsResetCap = 19
    piStatResetTokenLife = 2
 
    % Stat reset token has a 1 in (piStatResetTokenDropFactor / monster_level)
    % chance to drop, with monster_level bound between 50 and 150.
-   piStatResetTokenDropFactor = 150000
+   piStatResetTokenDropFactor = 500000
 
    % DefaultDeathCost:  Should always be a value between 1 and 100.  Lowering
    %  this will lower the odds of a dead player losing health and skill/spell


### PR DESCRIPTION
Lowered pogg king hold time from 30-45 sec to 15-25 sec. Added class
variables for hold time so we can modify them in-game easily.

Edited the default settings for free stats reset cap to 19HP (i.e. no
free stat resets) and ancient trinket drop rate to reflect the currently
used values on 103.