### PR TITLE
Adjust spell vigor costs.

### DIFF
--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -161,7 +161,7 @@ classvars:
 
    % Some spells and skills do not check your exertion.
    vbCheck_Exertion = TRUE    
-   viSpellExertion = 2
+   viSpellExertion = 1
 
    viSpell_Num = $
    viSchool = $

--- a/kod/object/passive/spell/SUMMTWIN.KOD
+++ b/kod/object/passive/spell/SUMMTWIN.KOD
@@ -39,7 +39,7 @@ classvars:
    viMana = 10
    viMeditate_ratio = 50
 
-   viSpellExertion = 20
+   viSpellExertion = 4
    viCast_time = 500
    viHarmful = TRUE
    viOutlaw = TRUE

--- a/kod/object/passive/spell/animate.kod
+++ b/kod/object/passive/spell/animate.kod
@@ -49,7 +49,7 @@ classvars:
    viSpell_level = 4
    viMana = 20
 
-   viSpellExertion = 10
+   viSpellExertion = 3
    viCast_time = 10000
    viChance_To_Increase = 20
    viMeditate_ratio = 40

--- a/kod/object/passive/spell/apparitn.kod
+++ b/kod/object/passive/spell/apparitn.kod
@@ -51,7 +51,7 @@ classvars:
    viSpell_level = 4
    viMana = 15
 
-   viSpellExertion = 12
+   viSpellExertion = 3
    viChance_To_Increase = 25
    viMeditate_ratio = 30
    vrSucceed_wav = summonapparition_sound

--- a/kod/object/passive/spell/atakspel/illwound.kod
+++ b/kod/object/passive/spell/atakspel/illwound.kod
@@ -36,9 +36,9 @@ classvars:
    viSpell_num = SID_ILLUSIONARY_WOUNDS
    viSchool = SS_RIIJA
    viSpell_level = 3
-   viMana = 10
+   viMana = 7
 
-   viSpellExertion = 3
+   viSpellExertion = 2
 
    vrSucceed_wav = illusionarywounds_sound
 

--- a/kod/object/passive/spell/atakspel/vampdrn.kod
+++ b/kod/object/passive/spell/atakspel/vampdrn.kod
@@ -41,7 +41,7 @@ classvars:
 
    viSpell_level = 3
    viMana = 10
-   viSpellExertion = 4
+   viSpellExertion = 1
 
    viAttack_spell = ATCK_SPELL_ALL + ATCK_SPELL_UNHOLY
 

--- a/kod/object/passive/spell/brittle.kod
+++ b/kod/object/passive/spell/brittle.kod
@@ -41,7 +41,7 @@ classvars:
    viSchool = SS_FAREN
    viSpell_level = 4
    viMana = 8
-   viSpellExertion = 4
+   viSpellExertion = 3
 
    viMeditate_ratio = 50
 

--- a/kod/object/passive/spell/brthlife.kod
+++ b/kod/object/passive/spell/brthlife.kod
@@ -49,7 +49,7 @@ classvars:
    viSchool = SS_SHALILLE
    viSpell_level = 1
    viMana = 3
-   viSpellExertion = 2
+   viSpellExertion = 0
    viChance_To_Increase = 20
    viMeditate_ratio = 10
   

--- a/kod/object/passive/spell/creasphm.kod
+++ b/kod/object/passive/spell/creasphm.kod
@@ -37,7 +37,7 @@ classvars:
    viSchool = SS_SHALILLE
    viSpell_level = 3
    viMana = 15
-   viSpellExertion = 5
+   viSpellExertion = 2
    viCast_time = 5000
    viMeditate_ratio = 30
 

--- a/kod/object/passive/spell/cursewp.kod
+++ b/kod/object/passive/spell/cursewp.kod
@@ -44,7 +44,7 @@ classvars:
 
    viSpell_level =4
    viMana = 25
-   viSpellExertion = 40
+   viSpellExertion = 3
    viCast_time = 20000
    vrSucceed_wav = CurseWeapon_sound
 

--- a/kod/object/passive/spell/debuff/blind.kod
+++ b/kod/object/passive/spell/debuff/blind.kod
@@ -46,7 +46,7 @@ classvars:
    viChance_To_Increase = 15
    viMeditate_ratio = 50
 
-   viSpellExertion = 6
+   viSpellExertion = 3
 
    viOutlaw = TRUE
    viHarmful = TRUE

--- a/kod/object/passive/spell/debuff/dazzle.kod
+++ b/kod/object/passive/spell/debuff/dazzle.kod
@@ -43,7 +43,7 @@ classvars:
    viChance_To_Increase = 15
    viMeditate_ratio = 30
 
-   viSpellExertion = 6
+   viSpellExertion = 3
 
    viOutlaw = TRUE
    viHarmful = TRUE

--- a/kod/object/passive/spell/debuff/forget.kod
+++ b/kod/object/passive/spell/debuff/forget.kod
@@ -58,7 +58,7 @@ classvars:
    viSpell_level = 2
    viSchool = SS_RIIJA
    viMana = 20
-   viSpellExertion = 10
+   viSpellExertion = 2
    viCast_time = 0
    viChance_to_increase = 20
    viMeditate_ratio = 40

--- a/kod/object/passive/spell/debuff/hold.kod
+++ b/kod/object/passive/spell/debuff/hold.kod
@@ -38,7 +38,7 @@ classvars:
    viSchool = SS_QOR
    viSpell_level = 4
 
-   viSpellExertion = 8
+   viSpellExertion = 2
    viMana = 15
 
    viHarmful = TRUE

--- a/kod/object/passive/spell/debuff/seduce.kod
+++ b/kod/object/passive/spell/debuff/seduce.kod
@@ -56,7 +56,7 @@ classvars:
    viChance_To_Increase = 15
    viMeditate_ratio = 100
 
-   viSpellExertion = 14
+   viSpellExertion = 3
 
    vrSucceed_wav = seduce_sound
 

--- a/kod/object/passive/spell/debuff/vertigo.kod
+++ b/kod/object/passive/spell/debuff/vertigo.kod
@@ -48,7 +48,7 @@ classvars:
    viSchool = SS_RIIJA
    viSpell_level = 3
    viMana = 12
-   viSpellExertion = 10
+   viSpellExertion = 2
 
    viChance_to_increase = 15
    viMeditate_ratio = 30

--- a/kod/object/passive/spell/dispillu.kod
+++ b/kod/object/passive/spell/dispillu.kod
@@ -41,7 +41,7 @@ classvars:
    viSchool = SS_KRAANAN
    viSpell_level = 4
    viMana = 20
-   viSpellExertion = 15
+   viSpellExertion = 3
    viMeditate_ratio = 30
 
 properties:

--- a/kod/object/passive/spell/distill.kod
+++ b/kod/object/passive/spell/distill.kod
@@ -51,7 +51,7 @@ classvars:
    viSpell_level = 3
    viSchool = SS_JALA
    viMana = 20
-   viSpellExertion = 25
+   viSpellExertion = 4
    viCast_time = 30000
    viChance_To_Increase = 20
    viMeditate_ratio = 50

--- a/kod/object/passive/spell/fdeath.kod
+++ b/kod/object/passive/spell/fdeath.kod
@@ -40,7 +40,7 @@ classvars:
    viManaDrain = 5     % Drain is amount used every viDrainTime milliseconds
    viDrainTime = 5000    % Drain some mana every viDrainTime milliseconds
    viSpell_num = SID_FEIGN_DEATH
-   viSpellExertion = 10
+   viSpellExertion = 1
    viChance_To_Increase = 40
    viMeditate_ratio = 20
 

--- a/kod/object/passive/spell/finlrite.kod
+++ b/kod/object/passive/spell/finlrite.kod
@@ -51,7 +51,7 @@ classvars:
    viSchool = SS_SHALILLE
    viSpell_level = 5
    viMana = 20
-   viSpellExertion = 15
+   viSpellExertion = 4
 
    % This will disallow people from trucing, and then killing undead.
    viHarmful = TRUE   

--- a/kod/object/passive/spell/flash.kod
+++ b/kod/object/passive/spell/flash.kod
@@ -37,7 +37,7 @@ classvars:
    viSchool = SS_RIIJA
    viSpell_level = 1
    viMana = 15
-   viSpellExertion=3
+   viSpellExertion = 1
    viChance_To_Increase = 15
    viMeditate_ratio = 20
 

--- a/kod/object/passive/spell/forsight.kod
+++ b/kod/object/passive/spell/forsight.kod
@@ -59,7 +59,7 @@ classvars:
    viSpell_level = 2
    viSchool = SS_RIIJA
    viMana = 5
-   viSpellExertion = 4
+   viSpellExertion = 0
    viCast_time = 0
    viChance_to_increase = 10
    viMeditate_ratio = 20

--- a/kod/object/passive/spell/holysymb.kod
+++ b/kod/object/passive/spell/holysymb.kod
@@ -47,7 +47,7 @@ classvars:
    viSchool = SS_SHALILLE
    viSpell_level = 1
    viMana = 8
-   viSpellExertion = 15
+   viSpellExertion = 1
 
    viCast_time = 2000
    viChance_To_Increase = 15

--- a/kod/object/passive/spell/illform.kod
+++ b/kod/object/passive/spell/illform.kod
@@ -41,7 +41,7 @@ classvars:
    viSpell_level = 3
    viSchool = SS_RIIJA
    viMana = 15
-   viSpellExertion = 20
+   viSpellExertion = 2
    viCast_time = 6000
    viChance_to_increase = 40
    viMeditate_ratio = 30

--- a/kod/object/passive/spell/itemench/artifice.kod
+++ b/kod/object/passive/spell/itemench/artifice.kod
@@ -43,7 +43,7 @@ classvars:
 
    viSpell_level = 5
    viMana = 10
-   viSpellExertion = 10
+   viSpellExertion = 2
    viCast_time = 4000
 
 properties:

--- a/kod/object/passive/spell/itemench/enchwp.kod
+++ b/kod/object/passive/spell/itemench/enchwp.kod
@@ -51,7 +51,7 @@ classvars:
    viMana = 17
 
    viCast_time = 15000
-   viSpellExertion = 20
+   viSpellExertion = 3
 
 properties:
 

--- a/kod/object/passive/spell/itemench/glow.kod
+++ b/kod/object/passive/spell/itemench/glow.kod
@@ -51,7 +51,7 @@ classvars:
 
    viSpell_level = 1
    viMana = 10
-   viSpellExertion = 10
+   viSpellExertion = 2
 
    viChance_To_Increase = 20
 

--- a/kod/object/passive/spell/itemench/holywp.kod
+++ b/kod/object/passive/spell/itemench/holywp.kod
@@ -49,7 +49,7 @@ classvars:
 
    viSpell_level = 2
    viMana = 17
-   viSpellExertion = 20
+   viSpellExertion = 3
    viCast_time = 15000
 
 properties:

--- a/kod/object/passive/spell/itemench/identify.kod
+++ b/kod/object/passive/spell/itemench/identify.kod
@@ -37,7 +37,7 @@ classvars:
    viSchool = SS_SHALILLE
    viSpell_level = 3
    viMana = 10
-   viSpellExertion = 15
+   viSpellExertion = 3
    viCast_time = 10000
    vrSucceed_wav = identify_sound
    viChance_To_Increase = 15

--- a/kod/object/passive/spell/itemench/reveal.kod
+++ b/kod/object/passive/spell/itemench/reveal.kod
@@ -39,7 +39,7 @@ classvars:
    viSchool = SS_SHALILLE
    viSpell_level = 5
    viMana = 30
-   viSpellExertion = 20
+   viSpellExertion = 3
    viChance_to_increase = 30
    viCast_time = 15000
 

--- a/kod/object/passive/spell/itemench/shroud.kod
+++ b/kod/object/passive/spell/itemench/shroud.kod
@@ -40,7 +40,7 @@ classvars:
 
    viSpell_level = 3
    viMana = 10
-   viSpellExertion = 10
+   viSpellExertion = 3
    viCast_time = 6000
 
    viChance_To_Increase = 25

--- a/kod/object/passive/spell/itemench/unholywp.kod
+++ b/kod/object/passive/spell/itemench/unholywp.kod
@@ -50,7 +50,7 @@ classvars:
 
    viSpell_level = 2
    viMana = 17
-   viSpellExertion = 20
+   viSpellExertion = 3
    viCast_time = 15000
 
 properties:

--- a/kod/object/passive/spell/morph.kod
+++ b/kod/object/passive/spell/morph.kod
@@ -54,7 +54,7 @@ classvars:
    viSpell_level = 5
    viSchool = SS_RIIJA
    viMana = 20
-   viSpellExertion = 10
+   viSpellExertion = 4
    viCast_time = 20000
    viChance_to_increase = 35
    viMeditate_ratio = 50

--- a/kod/object/passive/spell/mysttch.kod
+++ b/kod/object/passive/spell/mysttch.kod
@@ -58,7 +58,7 @@ classvars:
    viSchool = SS_FAREN
    viSpell_level = 1
    viMana = 3
-   viSpellExertion = 2
+   viSpellExertion = 1
    viChance_To_Increase = 20
    viMeditate_ratio = 10
   

--- a/kod/object/passive/spell/persench/Eagleyes.kod
+++ b/kod/object/passive/spell/persench/Eagleyes.kod
@@ -59,7 +59,7 @@ classvars:
    viSchool = SS_KRAANAN
    viSpell_level = 4
    viMana = 5
-   viSpellExertion = 10
+   viSpellExertion = 3
 
    viCast_time = 2000
    viChance_To_Increase = 20

--- a/kod/object/passive/spell/persench/anon.kod
+++ b/kod/object/passive/spell/persench/anon.kod
@@ -46,7 +46,7 @@ classvars:
    viSpell_level = 1
 
    viMana = 15
-   viSpellExertion = 10
+   viSpellExertion = 1
    viChance_To_Increase = 40
    viMeditate_ratio = 20
    viCast_time = 5000

--- a/kod/object/passive/spell/persench/deflect.kod
+++ b/kod/object/passive/spell/persench/deflect.kod
@@ -49,7 +49,7 @@ classvars:
 
    viPersonal_ench = True
 
-   viSpellExertion = 10
+   viSpellExertion = 4
    vrName = Deflect_name_rsc
    vrIcon = Deflect_icon_rsc
    vrDesc = Deflect_desc_rsc

--- a/kod/object/passive/spell/persench/detevil.kod
+++ b/kod/object/passive/spell/persench/detevil.kod
@@ -49,7 +49,7 @@ classvars:
    viSchool = SS_SHALILLE
    viSpell_level = 1
    viMana = 10
-   viSpellExertion = 5
+   viSpellExertion = 0
 
    viCast_time = 3000
    viChance_To_Increase = 15

--- a/kod/object/passive/spell/persench/detgood.kod
+++ b/kod/object/passive/spell/persench/detgood.kod
@@ -50,7 +50,7 @@ classvars:
    viSchool = SS_QOR
    viSpell_level = 1
    viMana = 10
-   viSpellExertion = 5
+   viSpellExertion = 0
 
    viCast_time = 3000
    viChance_To_Increase = 15

--- a/kod/object/passive/spell/persench/dethlink.kod
+++ b/kod/object/passive/spell/persench/dethlink.kod
@@ -52,7 +52,7 @@ classvars:
    viMana = 20
    viSchool = SS_QOR
    viSpell_level = 5
-   viSpellExertion = 10
+   viSpellExertion = 3
 
    viChance_To_Increase = 20
    viMeditate_ratio = 50

--- a/kod/object/passive/spell/persench/detinvis.kod
+++ b/kod/object/passive/spell/persench/detinvis.kod
@@ -42,7 +42,7 @@ classvars:
    viSchool = SS_KRAANAN
    viSpell_level = 3
    viMana = 15
-   viSpellExertion = 5
+   viSpellExertion = 3
 
    viCast_time = 3000
    viChance_To_Increase = 15

--- a/kod/object/passive/spell/persench/eavesdrp.kod
+++ b/kod/object/passive/spell/persench/eavesdrp.kod
@@ -46,7 +46,7 @@ classvars:
    viSchool = SS_RIIJA
    viSpell_level = 2
    viMana = 8
-   viSpellExertion = 4
+   viSpellExertion = 1
 
    viManaDrain = 1       % Drain is amount used every so often
    

--- a/kod/object/passive/spell/persench/freeact.kod
+++ b/kod/object/passive/spell/persench/freeact.kod
@@ -59,7 +59,7 @@ classvars:
    viSchool = SS_KRAANAN
    viSpell_level = 3
    viMana = 10
-   viSpellExertion = 5
+   viSpellExertion = 3
 
    viCast_time = 2000
    viChance_To_Increase = 15

--- a/kod/object/passive/spell/persench/invis.kod
+++ b/kod/object/passive/spell/persench/invis.kod
@@ -50,7 +50,7 @@ classvars:
    viSchool = SS_QOR
    viSpell_level = 5
    viMana = 12
-   viSpellExertion = 8
+   viSpellExertion = 3
    viMeditate_ratio = 75
 
    vrSucceed_wav = invisibility_sound

--- a/kod/object/passive/spell/persench/respois.kod
+++ b/kod/object/passive/spell/persench/respois.kod
@@ -48,7 +48,7 @@ classvars:
    viSchool = SS_KRAANAN
    viSpell_level = 2
    viMana = 10
-   viSpellExertion = 5
+   viSpellExertion = 1
 
    viCast_time = 2000
    viChance_To_Increase = 15

--- a/kod/object/passive/spell/persench/shadform.kod
+++ b/kod/object/passive/spell/persench/shadform.kod
@@ -43,7 +43,7 @@ classvars:
    viSpell_level = 1
    viSchool = SS_RIIJA
    viMana = 5
-   viSpellExertion = 5
+   viSpellExertion = 1
    viCast_time = 3000
 
    vrSucceed_wav = shadowform_wave_rsc

--- a/kod/object/passive/spell/persench/touchatk.kod
+++ b/kod/object/passive/spell/persench/touchatk.kod
@@ -62,7 +62,7 @@ classvars:
    viSpell_num = 0
    viStroke = 0
 
-   viSpellExertion = 2
+   viSpellExertion = 1
 
    viChance_To_Increase = 10
    viMeditate_ratio = 20

--- a/kod/object/passive/spell/persench/touchatk/acidtch.kod
+++ b/kod/object/passive/spell/persench/touchatk/acidtch.kod
@@ -59,9 +59,9 @@ classvars:
 
    viSchool = SS_QOR
    viSpell_num = SID_ACID_TOUCH
-   viSpellExertion = 3
+   viSpellExertion = 1
    viSpell_level = 2
-   viMana = 10
+   viMana = 4
 
    viMin_Damage = 4        %% touch spells typically do good damage    
    viMax_Damage = 8       %% but are unaffected by weapon or strength bonuses

--- a/kod/object/passive/spell/persench/touchatk/flametch.kod
+++ b/kod/object/passive/spell/persench/touchatk/flametch.kod
@@ -66,8 +66,8 @@ classvars:
    viSchool = SS_FAREN
    viSpell_num = SID_TOUCH_OF_FLAME
    viSpell_level = 2
-   viSpellExertion = 2
-   viMana = 9
+   viSpellExertion = 1
+   viMana = 4
 
    viMin_Damage = 4
    viMax_Damage = 9

--- a/kod/object/passive/spell/persench/touchatk/holytch.kod
+++ b/kod/object/passive/spell/persench/touchatk/holytch.kod
@@ -64,9 +64,9 @@ classvars:
 
    viSchool = SS_SHALILLE
    viSpell_num = SID_HOLY_TOUCH
-   viSpellExertion = 3
+   viSpellExertion = 1
    viSpell_level = 2
-   viMana = 12
+   viMana = 4
 
    % It's alright if Holy Touch has high base damage.
    % It gets no intrinsic proficiency damage, instead doing double base against undead.

--- a/kod/object/passive/spell/persench/touchatk/icyfing.kod
+++ b/kod/object/passive/spell/persench/touchatk/icyfing.kod
@@ -60,9 +60,9 @@ classvars:
 
    viSchool = SS_FAREN
    viSpell_num = SID_ICY_FINGERS
-   viSpellExertion = 2
+   viSpellExertion = 1
    viSpell_level = 2
-   viMana = 6
+   viMana = 4
 
    viMin_Damage = 5         %% touch spells typically do good damage    
    viMax_Damage = 8         %% but are unaffected by weapon or strength bonuses

--- a/kod/object/passive/spell/persench/touchatk/zap.kod
+++ b/kod/object/passive/spell/persench/touchatk/zap.kod
@@ -57,9 +57,9 @@ classvars:
 
    viSchool = SS_FAREN
    viSpell_num = SID_ZAP
-   viSpellExertion = 2
+   viSpellExertion = 1
    viSpell_level = 1
-   viMana = 6
+   viMana = 4
    viMeditate_ratio = 10
 
    viMin_Damage = 5         %% touch spells typically do good damage    

--- a/kod/object/passive/spell/radiusench/jala/invigor.kod
+++ b/kod/object/passive/spell/radiusench/jala/invigor.kod
@@ -57,7 +57,7 @@ classvars:
    
    viPeriodicEffect = TRUE
    
-   viSpellExertion = 10      
+   viSpellExertion = 1
    viChance_To_Increase = 20
    viMeditate_ratio = 10
 

--- a/kod/object/passive/spell/radiusench/jala/jig.kod
+++ b/kod/object/passive/spell/radiusench/jala/jig.kod
@@ -52,7 +52,7 @@ classvars:
    viManaDrain = 10
    viDrainTime = 5000
    viSpell_num = SID_JIG
-   viSpellExertion = 10      
+   viSpellExertion = 3
    viChance_To_Increase = 40
    viMeditate_ratio = 20
    viSpell_level = 4

--- a/kod/object/passive/spell/radiusench/jala/melcholy.kod
+++ b/kod/object/passive/spell/radiusench/jala/melcholy.kod
@@ -60,7 +60,7 @@ classvars:
    viDrainTime = 5000
    viBaseRange = 3
 
-   viSpellExertion = 2      
+   viSpellExertion = 1
    viChance_To_Increase = 25
    viMeditate_ratio = 20
 

--- a/kod/object/passive/spell/radiusench/jala/mirth.kod
+++ b/kod/object/passive/spell/radiusench/jala/mirth.kod
@@ -60,7 +60,7 @@ classvars:
    viDrainTime = 5000
    viBaseRange = 3
 
-   viSpellExertion = 2      
+   viSpellExertion = 1
    viChance_To_Increase = 25
    viMeditate_ratio = 20
 

--- a/kod/object/passive/spell/radiusench/jala/rejuven.kod
+++ b/kod/object/passive/spell/radiusench/jala/rejuven.kod
@@ -56,7 +56,7 @@ classvars:
    
    viPeriodicEffect = TRUE
    
-   viSpellExertion = 10      
+   viSpellExertion = 3
    viChance_To_Increase = 20
    viMeditate_ratio = 50
 

--- a/kod/object/passive/spell/radiusench/jala/restorat.kod
+++ b/kod/object/passive/spell/radiusench/jala/restorat.kod
@@ -57,7 +57,7 @@ classvars:
    
    viPeriodicEffect = TRUE
    
-   viSpellExertion = 10      
+   viSpellExertion = 3
    viChance_To_Increase = 20
    viMeditate_ratio = 20
 

--- a/kod/object/passive/spell/radiusench/truce.kod
+++ b/kod/object/passive/spell/radiusench/truce.kod
@@ -57,7 +57,7 @@ classvars:
    viSpell_num = SID_TRUCE
    viSchool = SS_SHALILLE
    viMana = 20
-   viSpellExertion = 10
+   viSpellExertion = 3
    viSpell_level = 4
    viChance_To_Increase = 15
    viMeditate_ratio = 30

--- a/kod/object/passive/spell/roomench/qorbane.kod
+++ b/kod/object/passive/spell/roomench/qorbane.kod
@@ -48,7 +48,7 @@ classvars:
    viSchool = SS_SHALILLE
    viMana = 15
    viSpell_level = 4
-   viSpellExertion = 5
+   viSpellExertion = 3
    viCast_time = 5000
    viChance_To_Increase = 40
    viMeditate_ratio = 30

--- a/kod/object/passive/spell/roomench/shalbane.kod
+++ b/kod/object/passive/spell/roomench/shalbane.kod
@@ -47,7 +47,7 @@ classvars:
    viSchool = SS_QOR
    viMana = 15
    viSpell_level = 4
-   viSpellExertion = 5
+   viSpellExertion = 3
    viCast_time = 5000
    viChance_To_Increase = 40
    viMeditate_ratio = 30

--- a/kod/object/passive/spell/seance.kod
+++ b/kod/object/passive/spell/seance.kod
@@ -48,7 +48,7 @@ classvars:
    viSchool = SS_SHALILLE
    viSpell_level = 1
    viMana = 12
-   viSpellExertion = 5
+   viSpellExertion = 0
    viMeditate_ratio = 20
   
    viFlash = FLASH_GOOD

--- a/kod/object/passive/spell/summrefl.kod
+++ b/kod/object/passive/spell/summrefl.kod
@@ -47,7 +47,7 @@ classvars:
    viMana = 15
    viMeditate_ratio = 30
 
-   viSpellExertion = 10
+   viSpellExertion = 4
    viCast_time = 1000
 
    vrSucceed_wav = summonreflection_sound

--- a/kod/object/passive/spell/sweep.kod
+++ b/kod/object/passive/spell/sweep.kod
@@ -49,7 +49,7 @@ classvars:
    viSchool = SS_FAREN
    viSpell_level = 1
    viMana = 8
-   viSpellExertion = 8
+   viSpellExertion = 1
    viCast_time = 10000
 
    viChance_To_Increase = 20

--- a/kod/object/passive/spell/teleportspell/deathrift.kod
+++ b/kod/object/passive/spell/teleportspell/deathrift.kod
@@ -46,7 +46,7 @@ classvars:
    viSchool = SS_QOR
    viSpell_level = 6
    viMana = 20
-   viSpellExertion = 50
+   viSpellExertion = 15
    viCast_time = 60000
 
    viChance_To_Increase = 10

--- a/kod/object/passive/spell/teleportspell/elusion.kod
+++ b/kod/object/passive/spell/teleportspell/elusion.kod
@@ -55,7 +55,7 @@ classvars:
    viSchool = SS_RIIJA
    viSpell_level = 6
    viMana = 20
-   viSpellExertion = 50
+   viSpellExertion = 15
 
    viChance_To_Increase = 10
    viMeditate_ratio = 50

--- a/kod/object/passive/spell/utility/conveyance.kod
+++ b/kod/object/passive/spell/utility/conveyance.kod
@@ -18,16 +18,16 @@ resources:
    Conveyance_name_rsc = "conveyance"
    Conveyance_icon_rsc = iboonint.bgf
    Conveyance_desc_rsc = \
-     "Sends a stack of items to your closest personal vault.  "
-	 "Requires only the fee for depositing items."
- 
+      "Sends a stack of items to your closest personal vault.  "
+      "Requires only the fee for depositing items."
+
    Conveyance_cant = "You cannot cast conveyance on %s%s."
    Conveyance_not_enough_cash = "You don't have enough shillings to convey %s%s."
    Conveyance_not_enough_space = "Your vault does not have enough space!"
    Conveyance_not_holding = "You cannot cast conveyance on an item you are not holding!"
 
    Conveyance_cast = "A small portal whips into existence, pulling %s%s to your vault."
-     
+
 classvars:
 
    vrName = Conveyance_name_rsc

--- a/kod/object/passive/spell/walspell/brmblwll.kod
+++ b/kod/object/passive/spell/walspell/brmblwll.kod
@@ -44,7 +44,7 @@ classvars:
 
    viChance_To_Increase = 25
    viMeditate_ratio = 20
-   viSpellExertion = 10
+   viSpellExertion = 2
    viCast_time = 4000
    vrSucceed_wav = BrambleWall_sound
 

--- a/kod/object/passive/spell/walspell/firewall.kod
+++ b/kod/object/passive/spell/walspell/firewall.kod
@@ -37,7 +37,7 @@ classvars:
    viSchool = SS_FAREN
    viSpell_level = 4
    viMana = 15
-   viSpellExertion = 10
+   viSpellExertion = 3
    viMeditate_ratio = 30
 
    viCast_time = 1000

--- a/kod/object/passive/spell/walspell/ifirewal.kod
+++ b/kod/object/passive/spell/walspell/ifirewal.kod
@@ -40,7 +40,7 @@ classvars:
    viSchool = SS_RIIJA
    viSpell_level = 3
    viMana = 15
-   viSpellExertion = 10
+   viSpellExertion = 3
    viMeditate_ratio = 30
 
    viCast_time = 1000

--- a/kod/object/passive/spell/walspell/ltngwall.kod
+++ b/kod/object/passive/spell/walspell/ltngwall.kod
@@ -40,7 +40,7 @@ classvars:
    viSchool = SS_FAREN
    viSpell_level = 6
    viMana = 20
-   viSpellExertion = 10
+   viSpellExertion = 3
 
    viChance_To_Increase = 25
    viMeditate_ratio = 75

--- a/kod/object/passive/spell/walspell/rngflame.kod
+++ b/kod/object/passive/spell/walspell/rngflame.kod
@@ -40,7 +40,7 @@ classvars:
    viSchool = SS_FAREN
    viSpell_level = 5
    viMana = 15
-   viSpellExertion = 10
+   viSpellExertion = 3
    viMeditate_ratio = 50
 
    vrSucceed_wav = RingOfFlames_sound

--- a/kod/object/passive/spell/walspell/sporbrst.kod
+++ b/kod/object/passive/spell/walspell/sporbrst.kod
@@ -40,7 +40,7 @@ classvars:
    viSchool = SS_FAREN
    viSpell_level = 6
    viMana = 20
-   viSpellExertion = 30
+   viSpellExertion = 5
    viCast_time = 5000
    viMeditate_ratio = 75
 

--- a/kod/object/passive/spell/walspell/summfog.kod
+++ b/kod/object/passive/spell/walspell/summfog.kod
@@ -46,7 +46,7 @@ classvars:
    viMana = 6
    viMeditate_ratio = 10
 
-   viSpellExertion = 4
+   viSpellExertion = 1
    viCast_time = 2000
    vrSucceed_wav = SummonFog_sound
    viChance_To_Increase = 20

--- a/kod/object/passive/spell/walspell/summpfog.kod
+++ b/kod/object/passive/spell/walspell/summpfog.kod
@@ -39,7 +39,7 @@ classvars:
    viSchool = SS_QOR
    viSpell_level = 3
    viMana = 20
-   viSpellExertion = 15
+   viSpellExertion = 3
 
    viCast_time = 2000
    vrSucceed_wav = SummonPoisonFog_sound

--- a/kod/object/passive/spell/walspell/summweb.kod
+++ b/kod/object/passive/spell/walspell/summweb.kod
@@ -40,7 +40,7 @@ classvars:
    viSchool = SS_FAREN
    viSpell_level = 3
    viMana = 15
-   viSpellExertion = 10
+   viSpellExertion = 3
    viCast_time = 3000
 
    vrSucceed_wav = SummonWeb_sound


### PR DESCRIPTION
To bring vigor usage by mages more in-line with that used by PFs, vigor cost on all spells has been lowered significantly.

Default spell vigor cost changed from 2 to 1.
Animate changed from 10 to 3 vigor.
Anonymity changed from 10 to 1 vigor.
Apparition changed from 12 to 3 vigor.
Artifice changed from 10 to 2 vigor.
Blind changed from 6 to 3 vigor.
Bramble Wall changed from 10 to 2 vigor.
Breath of Life changed from 2 to 0 vigor.
Brittle changed from 4 to 3 vigor.
Curse Weapon changed from 40 to 3 vigor.
Dazzle changed from 6 to 3 vigor.
Death Link changed from 10 to 3 vigor.
Death Rift changed from 50 to 15 vigor.
Deflect changed from 10 to 4 vigor.
Detect Evil and Detect Good changed from 5 to 0 vigor.
Detect Invisible changed from 5 to 3 vigor.
Dispel Illusion changed from 10 to 2 vigor.
Distill changed from 25 to 4 vigor.
Eagle Eyes changed from 10 to 3 vigor.
Eavesdrop changed from 4 to 1 vigor.
Elusion changed from 50 to 15 vigor.
Enchant Weapon changed from 20 to 3 vigor.
Evil Twin changed from 20 to 4 vigor.
Feign Death changed from 10 to 1 vigor.
Final Rites changed from 15 to 4 vigor.
Firewall changed from 10 to 3 vigor
Flash changed from 3 to 1 vigor.
Fog changed from 4 to 1 vigor.
Foresight changed from 4 to 0 vigor.
Forget changed from 10 to 2 vigor.
Free Action changed from 5 to 3 vigor.
Glow changed from 10 to 2 vigor (could probably drop this to 1 or 0).
Hold changed from 8 to 2 vigor.
Holy Weapon changed from 20 to 3 vigor.
Holy Symbol changed from 15 to 1 vigor.
Identify changed from 15 to 3 vigor.
Illusionary Firewall changed from 10 to 3 vigor.
Illusionary Form changed from 20 to 2 vigor.
Illusionary Wounds changed from 3 to 2 vigor, and from 10 to 7 mana.
Invigorate changed from 10 to 1 vigor.
Invisibility changed from 8 to 3 vigor.
Jig changed from 10 to 3 vigor.
Lightning Wall changed from 10 to 3 vigor.
Melancholy changed from 2 to 1 vigor.
Mirth changed from 2 to 1 vigor.
Morph changed from 10 to 4 vigor.
Mystic Touch changed from 2 to 1 vigor.
Poison Fog changed from 15 to 3 vigor.
Qorbane changed from 5 to 3 vigor
Reflection changed from 10 to 4 vigor.
Rejuvenate changed from 10 to 3 vigor.
Resist Poison changed from 5 to 1 vigor.
Restorate changed from 10 to 3 vigor.
Reveal changed from 20 to 3 vigor.
Ring of Flames changed from 10 to 3 vigor.
Seance changed from 5 to 0 vigor.
Seduce changed from 14 to 3 vigor.
Shadow Form changed from 5 to 1 vigor.
Shal'illebane changed from 5 to 3 vigor.
Shroud changed from 10 to 3 vigor.
Spider Web changed from 10 to 3 vigor.
Spiritual Hammer changed from 5 to 2 vigor.
Sporeburst changed from 30 to 5 vigor.
Sweep changed from 8 to 1 vigor.
Touch attacks all changed from 2 or 3 to 1 vigor, and from 6-12 to 4 mana.
Truce changed from 10 to 3 vigor.
Unholy Weapon changed from 20 to 3 vigor.
Vampiric Drain changed from 4 to 1 vigor (at 10 mana, it prob needs to be reduced).
Vertigo changed from 10 to 2 vigor.