### PR TITLE
Survival arena bug fixes/code improvement, add resource restoration on level completion, bug fixes for ET deletion.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -162,6 +162,9 @@ properties:
    % Evil twin object
    poEvilTwin = $
 
+   % List of active evil twins (i.e. ETs we've created).
+   plEvilTwins = $
+
    % Apparition list and target
    plApparitionList = $
    poApparitionOriginal = $
@@ -213,6 +216,27 @@ messages:
                Send(i,@Delete);
             }
          }
+         plControlledMinions = $;
+      }
+
+      % If this Battler has created any evil twins, delete them.
+      if plEvilTwins <> $
+      {
+         for i in plEvilTwins
+         {
+            Send(i,@Delete);
+         }
+         plEvilTwins = $;
+      }
+
+      % If this Battler has Apparitions attacking it, delete them.
+      if plApparitionList <> $
+      {
+         for i in plApparitionList
+         {
+            Send(i,@Delete);
+         }
+         plApparitionList = $;
       }
 
       propagate;
@@ -1517,10 +1541,11 @@ messages:
    % This section deals with illusions cast by/on the battler
 
    AddEvilTwin(what=$)
+   "If something casts evil twin on us, we store it here."
    {
-      if poEvilTwin=$
+      if poEvilTwin = $
       {
-         poEvilTwin=what;
+         poEvilTwin = what;
 
          return TRUE;
       }
@@ -1550,10 +1575,39 @@ messages:
       return FALSE;
    }
 
+   EvilTwinsCreated(what=$)
+   "If we cast evil twin on something, we add the ET to our "
+   "list of created evil twins."
+   {
+      if what <> $
+      {
+         plEvilTwins = Cons(what,plEvilTwins);
+      }
+
+      return;
+   }
+
+   RemoveCreatedEvilTwin(what=$)
+   "Remove an evil twin from our list of created evil twins."
+   {
+      local i;
+
+      if plEvilTwins <> $
+         AND FindListElem(plEvilTwins,what)
+      {
+         plEvilTwins = DelListElem(plEvilTwins,what);
+      }
+
+      return;
+   }
+
    % If Apparition is cast on the monster, this list keeps track of it.
    AddApparition(what=$)
    {
-      plApparitionList = Cons(what,plApparitionList);
+      if what <> $
+      {
+         plApparitionList = Cons(what,plApparitionList);
+      }
 
       return;
    }
@@ -1586,7 +1640,7 @@ messages:
 
       return;
    }
-   
+
    GetBoostedLevel()
    {
       return 0;

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -632,6 +632,9 @@ messages:
       {
          Send(poEvilTwinOriginal,@RemoveEvilTwin);
          poEvilTwinOriginal = $;
+
+         % Tell the caster it was deleted too.
+         Send(poEvilTwinCaster,@RemoveCreatedEvilTwin,#what=self);
          poEvilTwinCaster = $;
       }
 
@@ -639,16 +642,6 @@ messages:
       if poEvilTwin <> $
       {
          Post(poEvilTwin,@Delete);
-      }
-
-      % If this monster has Apparitions attacking it, delete them.
-      if plApparitionList <> $
-      {
-         for k in plApparitionList
-         {
-            Send(k,@Delete);
-         }
-         plApparitionList = $;
       }
 
       % If this monster is an Apparition, tell the original it was deleted.

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -6166,6 +6166,20 @@ messages:
       return FALSE;
    }
 
+   IsMinion()
+   "Returns TRUE for seduced and animated mobs, reflections, "
+   "evil twins and apparitions."
+   {
+      if poMaster <> $
+         OR poApparitionCaster <> $
+         OR poEvilTwinCaster <> $
+      {
+         return TRUE;
+      }
+
+      return FALSE;
+   }
+
    % This section deals with minion code.
    CommandMinionAttack(oMaster=$,oTarget=$)
    {

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -5667,7 +5667,7 @@ messages:
       local i,j,oReagent,iNumberItems,oTreasure,oTreasure_type,tokengen,
             iSafetyCntr,lTreasureItems,iNumberOfItemsDropped,
             iNumberOfItemsLooted,iRandomCashAmount,oMoney,iGetResult,
-            bCapacityFailure,bRangeFailure;
+            bCapacityFailure,bRangeFailure,iSurvivalLoot;
 
       % Apparitions, etc, provide no treasure
       if pbIllusion
@@ -5699,12 +5699,13 @@ messages:
             % Random number of treasure items are dropped based on viLevel
             %  and viDifficulty.  The higher these values are, the more items
             %  that may be dropped.
+            iSurvivalLoot = piBoostedLevel
+              / Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalLoot);
+
             iNumberItems = 1 + (viLevel/55) + Random(0,viDifficulty/3)
-                             + (piBoostedLevel/4
-              * Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalLoot));
-            iNumberItems = Bound(iNumberItems,$,6 + (piBoostedLevel/4
-              * Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalLoot)));
-            iNumberItems = (Send(Send(SYS, @GetSettings), @GetItemFactor)*iNumberItems)/100;
+                              + iSurvivalLoot;
+            iNumberItems = Bound(iNumberItems,$,6 + iSurvivalLoot);
+            iNumberItems = (Send(Send(SYS,@GetSettings),@GetItemFactor)*iNumberItems)/100;
             iNumberItems = Bound(iNumberItems,1,$);
          }
       
@@ -5769,10 +5770,8 @@ messages:
             corpse = $;
          }
 
-         oMoney = Create(&Money,#corpse=corpse,
-                                #number=iRandomCashAmount+
-               (piBoostedLevel*50*
-                Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalCash)));
+         oMoney = Create(&Money,#corpse=corpse,#number=iRandomCashAmount + (piBoostedLevel
+                     * Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalCash)));
 
          Send(Send(SYS,@GetStatistics),@MoneyCreated,#amount=Send(oMoney,@GetNumber));
          lTreasureItems = cons(oMoney,lTreasureItems);

--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -131,7 +131,15 @@ messages:
    {
       if poOriginal <> $
       {
+         % Clear the original's chasing evil twin property.
          Send(poOriginal,@RemoveEvilTwin);
+      }
+
+      if poCaster <> $
+      {
+         % Let the caster know to remove us from their list of
+         % created ETs.
+         Send(poCaster,@RemoveCreatedEvilTwin,#what=self);
       }
 
       if (poOwner <> $)

--- a/kod/object/active/holder/nomoveon/battler/monster/nrthlwrm.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/nrthlwrm.kod
@@ -92,10 +92,14 @@ messages:
 
    DoSlash()
    {
-      piAnimation = ANIM_ATTACK;
-      Send(poOwner,@SomethingChanged,#what=self);
-      piAnimation = ANIM_NONE;
-      ptRestartAnimation = CreateTimer(self,@RestartAnimation,SEC_PER_FRAME*5);
+      if poOwner <> $
+      {
+         piAnimation = ANIM_ATTACK;
+         Send(poOwner,@SomethingChanged,#what=self);
+         piAnimation = ANIM_NONE;
+         ptRestartAnimation = CreateTimer(self,@RestartAnimation,
+                                    SEC_PER_FRAME*5);
+      }
 
       return;
    }
@@ -103,7 +107,11 @@ messages:
    RestartAnimation()
    {
       ptRestartAnimation = $;
-      Send(poOwner,@SomethingChanged,#what=self);
+
+      if poOwner <> $
+      {
+         Send(poOwner,@SomethingChanged,#what=self);
+      }
 
       return;
    }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -2205,6 +2205,16 @@ messages:
          Send(i,@UserLogoff);
       }
 
+      % If this player has created any evil twins, delete them.
+      if plEvilTwins <> $
+      {
+         for i in plEvilTwins
+         {
+            Send(i,@Delete);
+         }
+         plEvilTwins = $;
+      }
+
       % client assumes not resting upon login
       Send(self,@StopResting);
 
@@ -8884,34 +8894,14 @@ messages:
             oRoom, iRow, iCol, iFine_Row, iFine_Col, iAngle, oItem,
             iRoom, lInventoryContents, lReagentBagContents;
 
-      % Skill, spell and hp penalties are handled by ApplyDeathPenalties, which
-      % is called from LeaveHold() in the Underworld.  This is to allow time
-      % for Portal of Life to reduce penalties.  We get the default value of
-      % piDeathCost from SYS, so that we can adjust global death penalties.
-
-      if Send(self,@GetOwner) <> $
-         AND Send(Send(self,@GetOwner),@GetRoomNum) = RID_UNDERWORLD
+      % If this player has created any evil twins, delete them.
+      if plEvilTwins <> $
       {
-         return;
-      }
-      
-      if Send(self,@GetOwner) <> $
-         AND IsClass(Send(self,@GetOwner),&Room)
-         AND Send(Send(self,@GetOwner),@OverridesDeathFunction)
-      {
-         Send(Send(self,@GetOwner),@OverrideDeathFunction,#who=self,#what=what);
-         return;
-      }
-
-      % "Normal" value is 100.
-      piDeathCost = Send(Send(SYS,@GetSettings),@GetDefaultDeathCost);
-
-      % A player (probably) cannot die twice in two seconds in any valid way.
-      if GetTime() < (piLastDeathTime + 2)
-      {
-         Debug("Averted double-death of",vrName);
-
-         return;
+         for i in plEvilTwins
+         {
+            Send(i,@Delete);
+         }
+         plEvilTwins = $;
       }
 
       % If we have Apparitions attacking us, delete them.
@@ -8922,6 +8912,36 @@ messages:
             Send(j,@Delete);
          }
          plApparitionList = $;
+      }
+
+      if poOwner <> $
+         AND Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
+      {
+         return;
+      }
+
+      if poOwner <> $
+         AND IsClass(poOwner,&Room)
+         AND Send(poOwner,@OverridesDeathFunction)
+      {
+         Send(poOwner,@OverrideDeathFunction,#who=self,#what=what);
+
+         return;
+      }
+
+      % Skill, spell and hp penalties are handled by ApplyDeathPenalties, which
+      % is called from LeaveHold() in the Underworld.  This is to allow time
+      % for Portal of Life to reduce penalties.  We get the default value of
+      % piDeathCost from SYS, so that we can adjust global death penalties.
+      % "Normal" value is 100.
+      piDeathCost = Send(Send(SYS,@GetSettings),@GetDefaultDeathCost);
+
+      % A player (probably) cannot die twice in two seconds in any valid way.
+      if GetTime() < (piLastDeathTime + 2)
+      {
+         Debug("Averted double-death of",vrName);
+
+         return;
       }
 
       % Stop any rescue attempts that were going on.
@@ -14320,6 +14340,8 @@ messages:
 
    StartPhaseTimer()
    {
+      local i;
+
       if ptPhaseTimer = $
       {
          ptPhaseTimer = CreateTimer(self,@PhaseTimerEnd,piRemainingPhaseTime);
@@ -14331,8 +14353,18 @@ messages:
             DeleteTimer(ptRescue);
             ptRescue = $;
          }
+
+         % If this player has created any evil twins, delete them.
+         if plEvilTwins <> $
+         {
+            for i in plEvilTwins
+            {
+               Send(i,@Delete);
+            }
+            plEvilTwins = $;
+         }
       }
-      
+
       if ptPhaseVisualEffectTimer = $
       {
          ptPhaseVisualEffectTimer = CreateTimer(self,@PhaseVisualEffectTimer,2000);

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4333,11 +4333,11 @@ messages:
       }
       
       % No penalties for chaos zone battles
-      if Send(self,@GetOwner) <> $
+      if poOwner <> $
          AND Send(victim,@GetOwner) <> $
-         AND IsClass(Send(self,@GetOwner),&Room)
+         AND IsClass(poOwner,&Room)
          AND IsClass(Send(victim,@GetOwner),&Room)
-         AND Send(Send(self,@GetOwner),@GetChaosZone)
+         AND Send(poOwner,@GetChaosZone)
          AND Send(Send(victim,@GetOwner),@GetChaosZone)
       {
          return TRUE;
@@ -8493,7 +8493,7 @@ messages:
       {
          % Let players share XP if they're grouped, even if
          % they're not fighting the same mob.
-         if Send(Send(self,@GetOwner),@AreGroupedHere,#who=self,#what=what)
+         if Send(poOwner,@AreGroupedHere,#who=self,#what=what)
          {
             Post(self,@AdvancementCheck,#what=victim,#killing_blow=FALSE,
                   #group_member_kill=TRUE,#group_member=what);
@@ -8645,7 +8645,7 @@ messages:
             % appropriate monsters. This will roughly equal building 
             % with one other player in the room. Bonus requires that the 
             % player is fighting normally (no firewalls / distance killing)
-            lBuilderGroup = Send(Send(self,@GetOwner),@GetBuilderGroup);
+            lBuilderGroup = Send(poOwner,@GetBuilderGroup);
             if (lBuilderGroup = $
                   OR Length(lBuilderGroup) = 1
                   OR (FindListElem(lBuilderGroup,self) = 0
@@ -8663,8 +8663,8 @@ messages:
          % Give a bonus for Survival Rooms
          if Send(what,@GetBoostedLevel) > 0
          {
-            gain = gain + (Send(what,@GetBoostedLevel)/5
-                 * Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalXP));
+            gain = gain + (Send(what,@GetBoostedLevel)
+                 / Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalXP));
          }
 
          % If they're cheesing the situation by fighting wussy monsters
@@ -8690,7 +8690,7 @@ messages:
          {
             piTraining_points = piTraining_points + 1
                + (Send(what,@GetBoostedLevel)
-               * Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalTP));
+               / Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalTP));
          }
 
          % Let the player know how many training points they have, if they
@@ -13430,7 +13430,7 @@ messages:
 
    SetSkinColor(color = 1)
    {
-      local iColor, i, oRoom;
+      local iColor, i;
 
       % Arms (hands) and face are the only default things that need to
       % have skin colors associated with it.  Other items in use
@@ -13444,10 +13444,9 @@ messages:
          Send(i,@DoPlayerArt);
       }
 
-      oRoom = Send(self,@GetOwner);
-      if oRoom <> $
+      if poOwner <> $
       {
-         Send(oRoom,@SomethingChanged,#what=self);
+         Send(poOwner,@SomethingChanged,#what=self);
       }
 
       return;
@@ -13945,10 +13944,6 @@ messages:
    BindPlayerToCurrentLocation()
    "Saves the player's current location as a special teleport destination."
    {
-      local poOwner;
-
-      poOwner = Send(self,@GetOwner);
-
       if poOwner = $
       {
          return;
@@ -13967,10 +13962,6 @@ messages:
    SendPlayerToBoundLocation()
    "Sends the player to their saved teleport destination."
    {
-      local poOwner;
-
-      poOwner = Send(self,@GetOwner);
-
       if poOwner = $
          OR piBound_Room = $
          OR NOT Send(self,@IsLoggedOn)
@@ -14015,8 +14006,8 @@ messages:
    SetDeathRiftProtection(value=FALSE)
    {
       if value=TRUE
-         AND Send(self,@GetOwner) <> $
-         AND Send(Send(self,@GetOwner),@GetRoomNum) = RID_UNDERWORLD
+         AND poOwner <> $
+         AND Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
       {
          % Only allow Death Rift Protection for those already
          % logged on and in the Underworld
@@ -14054,14 +14045,10 @@ messages:
    "Players that linger too long will find themselves cast "
    "out of the Underworld."
    {
-      local oRoom;
-
       ptDeathRiftTimer = $;
 
-      oRoom = Send(self,@GetOwner);
-
-      if oRoom <> $
-         AND Send(oRoom,@GetRoomNum) = RID_UNDERWORLD
+      if poOwner <> $
+         AND Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
          AND Send(self,@GetDeathRiftProtection) = TRUE
       {
          Send(self,@AdminGoToSafety);
@@ -14086,9 +14073,7 @@ messages:
 
    LeaveBuilderGroup()
    {
-      local oRoom, i, each_obj;
-
-      oRoom = Send(self,@GetOwner);
+      local i, each_obj;
 
       if ptLeaveBuilderGroupTimer <> $
       {
@@ -14096,17 +14081,17 @@ messages:
          ptLeaveBuilderGroupTimer = $;
       }
 
-      if oRoom <> $
+      if poOwner <> $
       {
-         Send(oRoom,@RemoveFromBuilderGroup,#who=self);
-         Send(oRoom,@SomethingChanged,#what=self);
+         Send(poOwner,@RemoveFromBuilderGroup,#who=self);
+         Send(poOwner,@SomethingChanged,#what=self);
 
          % Let's see that we left the group
-         for i in Send(oRoom,@GetPlActive)
+         for i in Send(poOwner,@GetPlActive)
          {
-            each_obj = Send(oRoom,@HolderExtractObject,#data=i);
+            each_obj = Send(poOwner,@HolderExtractObject,#data=i);
             if IsClass(each_obj,&User)
-               AND Send(oRoom,@AreGroupedHere,#who=self,#what=each_obj)
+               AND Send(poOwner,@AreGroupedHere,#who=self,#what=each_obj)
             {
                Send(self,@SomethingChanged,#what=each_obj);
             }
@@ -14118,33 +14103,31 @@ messages:
 
    JoinBuilderGroup()
    {
-      local oRoom, i, each_obj;
-
-      oRoom = Send(self,@GetOwner);
+      local i, each_obj;
 
       % Refresh an active group membership
       if ptLeaveBuilderGroupTimer <> $
       {
          DeleteTimer(ptLeaveBuilderGroupTimer);
          ptLeaveBuilderGroupTimer = CreateTimer(self,@LeaveBuilderGroupTimer,
-                                       Send(Send(self,@GetOwner),@GetGroupTime));
+                                       Send(poOwner,@GetGroupTime));
 
          return;
       }
 
-      if oRoom <> $
+      if poOwner <> $
       {
-         Send(oRoom,@AddToBuilderGroup,#who=self);
-         Send(oRoom,@SomethingChanged,#what=self);
+         Send(poOwner,@AddToBuilderGroup,#who=self);
+         Send(poOwner,@SomethingChanged,#what=self);
          ptLeaveBuilderGroupTimer = CreateTimer(self,@LeaveBuilderGroupTimer,
-                                       Send(Send(self,@GetOwner),@GetGroupTime));
+                                       Send(poOwner,@GetGroupTime));
 
          % Let's see our new group
-         for i in Send(oRoom,@GetPlActive)
+         for i in Send(poOwner,@GetPlActive)
          {
-            each_obj = Send(oRoom,@HolderExtractObject,#data=i);
+            each_obj = Send(poOwner,@HolderExtractObject,#data=i);
             if IsClass(each_obj,&User)
-               AND Send(oRoom,@AreGroupedHere,#who=self,#what=each_obj)
+               AND Send(poOwner,@AreGroupedHere,#who=self,#what=each_obj)
             {
                Send(self,@SomethingChanged,#what=each_obj);
             }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -6629,7 +6629,7 @@ messages:
       if what = $
       {
          Debug(Send(self,@GetTrueName),self," got newhold of $. Owner is ",
-               Send(Send(self,@GetOwner),@GetName));
+               Send(poOwner,@GetName));
 
          return;
       }
@@ -8281,7 +8281,7 @@ messages:
 
          if pbLogged_on
          {
-            oCurrentRoom = Send(self,@GetOwner);
+            oCurrentRoom = poOwner;
             iCurrentRegion = Send(oCurrentRoom,@GetRegion);
 
             if iCurrentRegion = iLastSafeRegion

--- a/kod/object/active/holder/room/monsroom.kod
+++ b/kod/object/active/holder/room/monsroom.kod
@@ -202,7 +202,7 @@ messages:
    "Can generate a monster at a specific location, or you can let it be "
    "put at a gen point."
    {
-      local oOldOwner, iMRow, iMCol, lPos, iRoll;
+      local oOldOwner, iMRow, iMCol, lPos, iRoll, iCount;
       
       iMRow = iRow;
       iMCol = iCol;
@@ -232,8 +232,22 @@ messages:
       {
          if plGenerators = $
          {
+            iCount = 0;
             iMRow = Random(1,piRows);
             iMCol = Random(1,piCols);
+            while ((NOT Send(self,@ReqSomethingMoved,#what=oMonster,
+                     #new_row=iMRow,#new_col=iMCol))
+                  AND iCount < 15)
+            {
+               iMRow = Random(1,piRows);
+               iMCol = Random(1,piCols);
+               iCount = iCount + 1;
+            }
+            if iCount = 15
+            {
+               Debug("failed to place monster ",oMonster,Send(oMonster,@GetName),
+                     " in room ",self,Send(self,@GetName));
+            }
          }
          else
          {

--- a/kod/object/active/holder/room/monsroom/survivalroom.kod
+++ b/kod/object/active/holder/room/monsroom/survivalroom.kod
@@ -926,7 +926,7 @@ messages:
          {
             if Nth(i,1) = GOAL_KILLS
             {
-               Post(self,@AggroBosses);
+               Post(self,@AggroBosses,#victim=victim);
             }
             if Nth(i,1) = GOAL_BOSS
             {
@@ -965,6 +965,7 @@ messages:
                   oMonster = First(mob);
                   if IsClass(oMonster,&Monster)
                      AND (NOT Send(oMonster,@IsOwnedByPlayer))
+                     AND oMonster <> victim
                   {
                      oTarget = First(plParticipants);
                      Send(oMonster,@TargetSwitch,#what=oTarget,#iHatred=100);
@@ -977,7 +978,8 @@ messages:
                % Aggro one mob on the player.
                if plLevelGoals <> $
                {
-                  Send(self,@AggroOne,#who=(First(plParticipants)));
+                  Send(self,@AggroOne,#who=(First(plParticipants)),
+                        #victim=victim);
                }
             }
          }
@@ -1003,8 +1005,8 @@ messages:
 
       propagate;
    }
-   
-   AggroBosses()
+
+   AggroBosses(victim = $)
    {
       local oTarget, i, n, each_obj, count;
 
@@ -1017,7 +1019,13 @@ messages:
       for i in plActive
       {
          each_obj = Send(self,@HolderExtractObject,#data=i);
-         
+
+         if victim <> $
+            AND victim = each_obj
+         {
+            continue;
+         }
+
          for n in plBosses
          {
             if GetClass(each_obj) = n
@@ -1198,9 +1206,9 @@ messages:
       propagate;
    }
 
-   AggroOne(who = $)
+   AggroOne(who = $,victim = $)
    {
-      local i, iCount;
+      local i, iCount, oMonster;
 
       if (IsClass(who,&DM)
             AND Send(who,@PlayerIsImmortal))
@@ -1213,12 +1221,20 @@ messages:
 
       for i in plActive
       {
-         if IsClass(First(i),&Monster)
-            AND (NOT Send(First(i),@IsOwnedByPlayer))
+         oMonster = First(i);
+         if IsClass(oMonster,&Monster)
+            AND (NOT Send(oMonster,@IsOwnedByPlayer))
             AND Random(1,5) = 1
          {
-            Send(First(i),@TargetSwitch,#what=who,#iHatred=100);
-            Send(First(i),@EnterStateChase,#target=who,#actnow=True);
+            % If this is called from SomethingKilled, don't aggro
+            % the mob that was just killed.
+            if victim <> $
+               AND oMonster = victim
+            {
+               continue;
+            }
+            Send(oMonster,@TargetSwitch,#what=who,#iHatred=100);
+            Send(oMonster,@EnterStateChase,#target=who,#actnow=True);
             iCount = iCount + 1;
             
             if iCount >= 1

--- a/kod/object/active/holder/room/monsroom/survivalroom.kod
+++ b/kod/object/active/holder/room/monsroom/survivalroom.kod
@@ -1199,8 +1199,8 @@ messages:
             AND (NOT Send(First(i),@IsOwnedByPlayer))
             AND Random(1,5) = 1
          {
-            Post(First(i),@TargetSwitch,#what=who,#iHatred=100);
-            Post(First(i),@EnterStateChase,#target=who,#actnow=True);
+            Send(First(i),@TargetSwitch,#what=who,#iHatred=100);
+            Send(First(i),@EnterStateChase,#target=who,#actnow=True);
             iCount = iCount + 1;
             
             if iCount >= 1
@@ -1232,8 +1232,8 @@ messages:
             AND (NOT Send(First(i),@IsOwnedByPlayer))
             AND Random(1,5) = 1
          {
-            Post(First(i),@TargetSwitch,#what=who,#iHatred=100);
-            Post(First(i),@EnterStateChase,#target=who,#actnow=True);
+            Send(First(i),@TargetSwitch,#what=who,#iHatred=100);
+            Send(First(i),@EnterStateChase,#target=who,#actnow=True);
             iCount = iCount + 1;
             
             if iCount >= 5

--- a/kod/object/active/holder/room/monsroom/survivalroom.kod
+++ b/kod/object/active/holder/room/monsroom/survivalroom.kod
@@ -208,6 +208,9 @@ properties:
 
    % Last level that players can join the public/guild arenas
    piLastJoinLevel = 6
+   
+   % Boolean for resource restoration on level completion.
+   pbRestoreResources = TRUE
 
 messages:
 
@@ -245,8 +248,13 @@ messages:
       % Set the regroup time from the SurvivalRoomMaintenance default
       piRegroupTime = Send(Send(SYS,@GetSurvivalRoomMaintenance),
                            @GetRegroupTime);
+      % Set wall blitz time.
       piWallBlitzTime = Send(Send(SYS,@GetSurvivalRoomMaintenance),
                               @GetWallBlitzTime);
+      piLastJoinLevel = Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                              @GetLastJoinLevel);
+      pbRestoreResources = Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                              @GetRestoreResources);
 
       plRoundOneMonsters = [[&GiantRat, 14],
                             [&SpiderBaby, 14],
@@ -702,6 +710,16 @@ messages:
       {
          if IsClass(First(i),&User)
          {
+            if pbRestoreResources
+            {
+               Send(First(i),@SetHealth,#amount=Send(First(i),@GetMaxHealth));
+               Send(First(i),@EatSomething,#nutrition=200);
+               if NOT Send(First(i),@IsCrystalizeManaSurging)
+               {
+                  Send(First(i),@GainMana,#amount=Send(First(i),@GetMaxMana),
+                     #bCapped=TRUE);
+               }
+            }
             Send(First(i),@MsgSendUser,#message_rsc=next_level_in_seconds,
                                 #parm1 = piLevel,
                                 #parm2 = (piRegroupTime + iRewardTime)/1000);
@@ -815,19 +833,16 @@ messages:
       {
          propagate;
       }
-      
-      % Minions! Keep these checks instead of using IsOwnedByPlayer
-      % as we don't want monster minions to count either.
-      if (IsClass(victim,&Monster)
-         AND Send(victim,@GetMaster) <> $)
-         OR IsClass(victim,&Brambles)
-         OR Send(victim,@IsIllusion)
-      {
-         propagate;
-      }
 
       if IsClass(victim,&Monster)
       {
+         % These kills don't count towards the room goals.
+         if Send(victim,@IsMinion)
+            OR IsClass(victim,&Brambles)
+         {
+            propagate;
+         }
+
          cDeadClass = GetClass(victim);
          
          for respawnCheck in plMinibosses
@@ -1089,35 +1104,33 @@ messages:
                propagate;
             }
          }
-      }
 
-      if IsClass(what,&User)
-         AND (piHasBegun
-            AND piLevel > piLastJoinLevel)
-      {
-         Send(self,@SpectateUser,#who=what);
-         Post(what,@MsgSendUser,#message_rsc=spectator_only_msg);
-
-         propagate;
-      }
-
-      if IsClass(what,&User)
-         AND (NOT piHasBegun
-            OR piLevel <= piLastJoinLevel)
-      {
-         plParticipants = Cons(what,plParticipants);
-         plLivesPerPlayer = Cons([what,3],plLivesPerPlayer);
-
-         if Length(plParticipants) = 1
-            AND NOT piPublic
-            AND poGuildAssociation = $
+         if piHasBegun
+            AND piLevel > piLastJoinLevel
          {
-            piLevel = Send(what,@GetBaseMaxHealth) / 25;
-            piLevel = Bound(piLevel,1,$);
-         }
-         Post(what,@MsgSendUser,#message_rsc=welcome_message);
+            Send(self,@SpectateUser,#who=what);
+            Post(what,@MsgSendUser,#message_rsc=spectator_only_msg);
 
-         propagate;
+            propagate;
+         }
+
+         if (NOT piHasBegun)
+            OR piLevel <= piLastJoinLevel
+         {
+            plParticipants = Cons(what,plParticipants);
+            plLivesPerPlayer = Cons([what,3],plLivesPerPlayer);
+
+            if Length(plParticipants) = 1
+               AND NOT piPublic
+               AND poGuildAssociation = $
+            {
+               piLevel = Send(what,@GetBaseMaxHealth) / 25;
+               piLevel = Bound(piLevel,1,$);
+            }
+            Post(what,@MsgSendUser,#message_rsc=welcome_message);
+
+            propagate;
+         }
       }
 
       if IsClass(what,&Monster)
@@ -1128,8 +1141,12 @@ messages:
          AND (plMiniBosses = $
             OR (plMinibosses <> $
                AND FindListElem(plMinibosses,GetClass(what)) = 0))
-         AND (NOT Send(what,@IsOwnedByPlayer))
       {
+         if Send(what,@IsMinion)
+         {
+            propagate;
+         }
+
          if Length(plParticipants) = 1
          {
             oTarget = First(plParticipants);
@@ -1152,10 +1169,11 @@ messages:
             }
          }
 
-         if NOT piPublic
-            AND poGuildAssociation = $
+         if ((NOT piPublic)
+            AND poGuildAssociation = $)
          {
-            % Cut aggro to 1/5th in solo.
+            % Cut aggro to 1/5th in solo. Post these so they
+            % run after mob is set up in room.
             if Random(1,5) = 1
             {
                Post(what,@TargetSwitch,#what=oTarget,#iHatred=100);
@@ -1165,18 +1183,18 @@ messages:
          }
          else
          {
-            % Public arenas get full aggro.
+            % Public arenas get full aggro. Post these so they
+            % run after mob is set up in room.
             Post(what,@TargetSwitch,#what=oTarget,#iHatred=100);
             Post(what,@EnterStateChase,#target=oTarget,#actnow=True);
          }
+
+         if ptWallBlitzTimer = $
+         {
+            Send(what,@SetBehaviorFlag,#flag=AI_MOVE_WALKTHROUGH_WALLS);
+         }
       }
-      
-      if IsClass(what,&Monster)
-         AND ptWallBlitzTimer = $
-      {
-         Send(what,@SetBehaviorFlag,#flag=AI_MOVE_WALKTHROUGH_WALLS);
-      }
-      
+
       propagate;
    }
 

--- a/kod/object/passive/spell/SUMMTWIN.KOD
+++ b/kod/object/passive/spell/SUMMTWIN.KOD
@@ -153,11 +153,20 @@ messages:
       {
          % Should be a monster. Make a low HP copy of it.
          oTwin = Create((GetClass(oTarget)));
+         % Set the illusion boolean on the ET, so it doesn't drop loot.
          Send(oTwin,@SetIllusion,#value=TRUE);
+         % Set the ET's original to the target.
          Send(oTwin,@EvilTwinOrignial,#what=oTarget,#who=who);
       }
 
+      % Add this ET to the target's evil twin property, which keeps
+      % track of the current ET pursuing them.
       Send(oTarget,@AddEvilTwin,#what=oTwin);
+
+      % Also add this ET to the list of ETs created by the caster.
+      % If the caster dies or is otherwise deleted, we delete any
+      % ETs they've created.
+      Send(who,@EvilTwinsCreated,#what=oTwin);
 
       oRoom = Send(who,@GetOwner);
 

--- a/kod/util/survivalmaint.kod
+++ b/kod/util/survivalmaint.kod
@@ -46,6 +46,12 @@ properties:
    
    % Default time between wall blitzes (mobs walk through walls)
    piWallBlitzTime = 300000
+   
+   % Default last join level
+   piLastJoinLevel = 6
+
+   % Do we restore resources on level completion?
+   pbRestoreResources = TRUE
 
 messages:
 
@@ -340,6 +346,16 @@ messages:
    GetWallBlitzTime()
    {
       return piWallBlitzTime;
+   }
+
+   GetLastJoinLevel()
+   {
+      return piLastJoinLevel;
+   }
+
+   GetRestoreResources()
+   {
+      return pbRestoreResources;
    }
 
    ExcludeRID(iRID=RID_MAR_SMITHY)

--- a/kod/util/survivalmaint.kod
+++ b/kod/util/survivalmaint.kod
@@ -32,12 +32,14 @@ properties:
    piSoloSurvivalEnabled = FALSE
    piGuildSurvivalEnabled = FALSE
    
-   % Do survival arenas give these rewards?
-   piSurvivalXP = TRUE
-   piSurvivalCash = TRUE
-   piSurvivalTP = TRUE
-   piSurvivalLoot = TRUE
-   
+   % At what level multiple do these increase?
+   piSurvivalXPIncreaseLevel = 8
+   piSurvivalTPIncreaseLevel = 8
+   piSurvivalLootIncreaseLevel = 4
+
+   % How much extra cash on each monster kill per level?
+   piSurvivalCashPerLevel = 30
+
    % Don't use these rooms (list of RIDs)
    plExcludedRoomsList = $
 
@@ -325,22 +327,22 @@ messages:
    
    GetSurvivalXP()
    {
-      return piSurvivalXP;
+      return piSurvivalXPIncreaseLevel;
    }
    
    GetSurvivalCash()
    {
-      return piSurvivalCash;
+      return piSurvivalCashPerLevel;
    }
    
    GetSurvivalTP()
    {
-      return piSurvivalTP;
+      return piSurvivalTPIncreaseLevel;
    }
    
    GetSurvivalLoot()
    {
-      return piSurvivalLoot;
+      return piSurvivalLootIncreaseLevel;
    }
 
    GetWallBlitzTime()
@@ -388,13 +390,6 @@ messages:
    {
       local i;
 
-      if plSurvivalRooms = $
-      {
-         Debug("No survival arenas active.");
-
-         return;
-      }
-
       % Report highest levels reached.
       Debug("Highest Public Survival level reached is ",
                   Send(Send(SYS,@GetStatistics),@RecordPublicSurvivalLevel));
@@ -402,6 +397,13 @@ messages:
                   Send(Send(SYS,@GetStatistics),@RecordGuildSurvivalLevel));
       Debug("Highest Solo Survival level reached is ",
                   Send(Send(SYS,@GetStatistics),@RecordSoloSurvivalLevel));
+
+      if plSurvivalRooms = $
+      {
+         Debug("No survival arenas active.");
+
+         return;
+      }
 
       for i in plSurvivalRooms
       {


### PR DESCRIPTION
-Changed the Posting of TargetSwitch and EnterStateChase to Send in 
AggroSome/AggroOne - the monster is present on-screen already so 
Post isn't necessary.

-Add a loop to GenerateMonster in MonsterRoom which will attempt up to
15 times to spawn a monster in a random location if no plGenerators list
is present. Allows spawning of mobs in rooms with no plGenerators and a
lot of space where mobs can't move.
-Add IsMinion message to Monster to allow easier checking for minions
(both player and monster owned).
-Add resource restoration after each round is completed in survival
arena.
-Add properties for resource restoration and and last join level to
SurvivalRoomMaintenance so they can be modified for all survival arenas
created.
-Cleaned up some code and simplified some checks in SurvivalRoom

-Added a plEvilTwins list to Battlers so they can keep track of any ETs
they've created, so they can be deleted if the caster is deleted (or killed).
-Delete ETs a player has cast if they log off or phase.

-Changed survival arena rewards from on/off booleans to values we can
use to set amount of XP, TP, shillings and loot.
-Lowered default rewards from +1 XP/5 levels to +1XP/8 levels,
+1TP/level to +1TP/8 levels, +50 shils/kill level to +30shils/ kill
level.
-Fixed a bug in survival arena causing dead monsters to try and aggro.
-Cleaned up some GetOwner calls to self in Player and User.