### PR TITLE
Elemental resist/hp adjustment.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/elemental.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/elemental.kod
@@ -41,7 +41,7 @@ classvars:
    viSpeed = SPEED_AVERAGE
    viAttributes = 0
    viLevel = 200
-   viDifficulty = 7
+   viDifficulty = 8
    viVisionDistance = 28
 
    % Attack range of 192, or 3 row/col.
@@ -64,10 +64,11 @@ messages:
 
    Constructed()
    {
-      plResistances = [ [-ATCK_SPELL_COLD, -50 ],
-                        [-ATCK_SPELL_ALL, 90 ],
-                        [ATCK_WEAP_BLUDGEON, -100],
-                        [ATCK_WEAP_ALL, 90 ] ];
+      if plResistances = $
+      {
+         plResistances = [ [-ATCK_SPELL_ALL, 90 ],
+                           [ATCK_WEAP_ALL, 90 ] ];
+      }
 
       propagate;
    }
@@ -105,14 +106,14 @@ messages:
          return;
       }
 
-      % if no body animation
+      % If no body animation.
       propagate;
    }
    
    CanMorphTo()
    {
-      return false;
-   } 
+      return FALSE;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/monster/elemental/eaeleme.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/elemental/eaeleme.kod
@@ -40,7 +40,7 @@ classvars:
    viTreasure_type = TID_EARTH_ELE
 
    viAttack_Spell = ATCK_SPELL_QUAKE
-   
+
 properties:
 
    piAnimation = ANIM_NONE
@@ -49,11 +49,15 @@ messages:
 
    Constructed()
    {
-      plResistances = [ [-ATCK_SPELL_COLD, -50 ],
-                        [-ATCK_SPELL_FIRE, -50 ],
-                        [-ATCK_SPELL_ALL, 80 ],
-                        [ATCK_WEAP_BLUDGEON, -100],
-                        [ATCK_WEAP_ALL, 90 ] ];
+      if plResistances = $
+      {
+         plResistances = [ [-ATCK_SPELL_ACID, -70 ],
+                           [-ATCK_SPELL_COLD, -25 ],
+                           [-ATCK_SPELL_FIRE, -25 ],
+                           [-ATCK_SPELL_ALL, 50 ],
+                           [ATCK_WEAP_BLUDGEON, -50],
+                           [ATCK_WEAP_ALL, 50 ] ];
+      }
 
       propagate;
    }

--- a/kod/object/active/holder/nomoveon/battler/monster/elemental/eaeleme/eaelech.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/elemental/eaeleme/eaelech.kod
@@ -35,8 +35,8 @@ classvars:
    viTreasure_type = TID_NONE
    viSpeed = SPEED_FAST
 
-   viLevel = 230
-   viDifficulty = 8
+   viLevel = 250
+   viDifficulty = 9
 
    viCashmin = 3000
    viCashmax = 12000
@@ -44,7 +44,7 @@ classvars:
 properties:
 
    piAnimation = ANIM_NONE
-   
+
    piSpellpower = 99
    piMax_Mana = 20
 
@@ -53,11 +53,12 @@ messages:
    Constructed()
    {
       plSpellBook = [ [SID_EARTHQUAKE,3,100] ];
-   
-      plResistances = [ [-ATCK_SPELL_COLD, -40 ],
-                        [-ATCK_SPELL_ACID, -70 ],
+
+      plResistances = [ [-ATCK_SPELL_ACID, -70 ],
+                        [-ATCK_SPELL_COLD, -25 ],
+                        [-ATCK_SPELL_FIRE, -25 ],
                         [-ATCK_SPELL_ALL, 50 ],
-                        [ATCK_WEAP_BLUDGEON, -60],
+                        [ATCK_WEAP_BLUDGEON, -50],
                         [ATCK_WEAP_ALL, 50 ] ];
 
       propagate;

--- a/kod/object/active/holder/nomoveon/battler/monster/elemental/fieleme.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/elemental/fieleme.kod
@@ -40,7 +40,7 @@ classvars:
    viTreasure_type = TID_FIRE_ELE
 
    viAttack_Spell = ATCK_SPELL_FIRE
-   
+
 properties:
 
    piAnimation = ANIM_NONE
@@ -49,13 +49,16 @@ messages:
 
    Constructed()
    {
-      plResistances = [ [-ATCK_SPELL_COLD, -50 ],
-                        [-ATCK_SPELL_ALL, 90 ],
-                        [ATCK_WEAP_BLUDGEON, -100],
-                        [ATCK_WEAP_ALL, 90 ] ];
+      if plResistances = $
+      {
+         plResistances = [ [-ATCK_SPELL_COLD, -60 ],
+                           [-ATCK_SPELL_ALL, 70 ],
+                           [ATCK_WEAP_THRUST, -50],
+                           [ATCK_WEAP_ALL, 60 ] ];
+      }
 
       propagate;
    }
-   
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/monster/elemental/fieleme/fielech.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/elemental/fieleme/fielech.kod
@@ -28,15 +28,15 @@ classvars:
    vrDesc = fielem_champion_desc_rsc
    vrDead_name = fielem_champion_dead_name_rsc
 
-   vbNamedMob = TRUE   
+   vbNamedMob = TRUE
    viIndefinite = ARTICLE_NONE
    viDefinite = ARTICLE_NONE
 
    viTreasure_type = TID_NONE
    viSpeed = SPEED_FAST
 
-   viLevel = 230
-   viDifficulty = 8
+   viLevel = 250
+   viDifficulty = 9
 
    viCashmin = 3000
    viCashmax = 12000
@@ -51,14 +51,13 @@ messages:
    {
       plSpellBook = [ [SID_FIRE_STORM,3,100] ];
    
-      plResistances = [ [-ATCK_SPELL_COLD, -70 ],
-                        [-ATCK_SPELL_SHOCK, -40 ],
-                        [-ATCK_SPELL_ALL, 50 ],
-                        [ATCK_WEAP_THRUST, -60],
-                        [ATCK_WEAP_ALL, 50 ] ];
+      plResistances = [ [-ATCK_SPELL_COLD, -80 ],
+                        [-ATCK_SPELL_ALL, 90 ],
+                        [ATCK_WEAP_THRUST, -50],
+                        [ATCK_WEAP_ALL, 60 ] ];
 
       propagate;
    }
-   
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/monster/elemental/iceleme.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/elemental/iceleme.kod
@@ -40,7 +40,7 @@ classvars:
    viTreasure_type = TID_ICE_ELE
 
    viAttack_Spell = ATCK_SPELL_COLD
-   
+
 properties:
 
    piAnimation = ANIM_NONE
@@ -49,11 +49,13 @@ messages:
 
    Constructed()
    {
-      plResistances = [ [-ATCK_SPELL_FIRE, -50 ],
-                        [-ATCK_SPELL_QUAKE, -50 ],
-                        [-ATCK_SPELL_ALL, 80 ],
-                        [ATCK_WEAP_BLUDGEON, -100],
-                        [ATCK_WEAP_ALL, 90 ] ];
+      if plResistances = $
+      {
+         plResistances = [ [-ATCK_SPELL_FIRE, -60 ],
+                           [-ATCK_SPELL_ALL, 70 ],
+                           [ATCK_WEAP_SLASH, -50],
+                           [ATCK_WEAP_ALL, 60 ] ];
+      }
 
       propagate;
    }

--- a/kod/object/active/holder/nomoveon/battler/monster/elemental/iceleme/icelech.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/elemental/iceleme/icelech.kod
@@ -35,8 +35,8 @@ classvars:
    viTreasure_type = TID_NONE
    viSpeed = SPEED_FAST
 
-   viLevel = 230
-   viDifficulty = 8
+   viLevel = 250
+   viDifficulty = 9
 
    viCashmin = 3000
    viCashmax = 12000
@@ -52,15 +52,14 @@ messages:
    Constructed()
    {
       plSpellBook = [ [SID_ICE_NOVA,3,100] ];
-   
-      plResistances = [ [-ATCK_SPELL_FIRE, -70 ],
-                        [-ATCK_SPELL_QUAKE, -40 ],
-                        [-ATCK_SPELL_ALL, 50 ],
-                        [ATCK_WEAP_SLASH, -60],
-                        [ATCK_WEAP_ALL, 50 ] ];
+
+      plResistances = [ [-ATCK_SPELL_FIRE, -80 ],
+                        [-ATCK_SPELL_ALL, 90 ],
+                        [ATCK_WEAP_SLASH, -50],
+                        [ATCK_WEAP_ALL, 60 ] ];
 
       propagate;
    }
-   
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/nomoveon/battler/monster/elemental/neeleme.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/elemental/neeleme.kod
@@ -49,12 +49,15 @@ messages:
 
    Constructed()
    {
-      plResistances = [ [-ATCK_SPELL_QUAKE, -70 ],
-                        [-ATCK_SPELL_HOLY, -40 ],
-                        [-ATCK_SPELL_UNHOLY, -40 ],
-                        [-ATCK_SPELL_ALL, 50 ],
-                        [ATCK_WEAP_PIERCE, -60],
-                        [ATCK_WEAP_ALL, 50 ] ];
+      if plResistances = $
+      {
+         plResistances = [ [-ATCK_SPELL_QUAKE, -70 ],
+                           [-ATCK_SPELL_HOLY, -20 ],
+                           [-ATCK_SPELL_UNHOLY, -20 ],
+                           [-ATCK_SPELL_ALL, 50 ],
+                           [ATCK_WEAP_PIERCE, -60],
+                           [ATCK_WEAP_ALL, 50 ] ];
+      }
 
       propagate;
    }

--- a/kod/object/active/holder/nomoveon/battler/monster/elemental/neeleme/neelech.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/elemental/neeleme/neelech.kod
@@ -35,12 +35,12 @@ classvars:
    viTreasure_type = TID_NONE
    viSpeed = SPEED_FAST
 
-   viLevel = 230
-   viDifficulty = 8
+   viLevel = 250
+   viDifficulty = 9
 
    viCashmin = 3000
    viCashmax = 12000
-   
+
 properties:
 
    piAnimation = ANIM_NONE
@@ -49,9 +49,7 @@ messages:
 
    Constructed()
    {
-      plResistances = [ [-ATCK_SPELL_QUAKE, -70 ],
-                        [-ATCK_SPELL_HOLY, -40 ],
-                        [-ATCK_SPELL_UNHOLY, -40 ],
+      plResistances = [ [-ATCK_SPELL_QUAKE, -60 ],
                         [-ATCK_SPELL_ALL, 50 ],
                         [ATCK_WEAP_PIERCE, -60],
                         [ATCK_WEAP_ALL, 50 ] ];


### PR DESCRIPTION
Adjusted elemental resistances, fixed Constructed issue with overwriting resistances, raised champions from level 230 to 250 and difficulty 8 to 9. Raised normal elementals from difficulty 7 to 8.

To address the individual resistances:
Earth Champion and Earth Elemental have 50% resist to all spells and all weapons. Weak to acid by 70%. Weak to cold and fire by 25%. Weak to bludgeon by 50%.

Nerudite Champion has 50% resist to all spells and all weapons. Has 60% weakness to quake, and 60% weakness to pierce.
Nerudite Elemental has 50% resist to all spells and all weapons. Has 70% weakness to quake, 60% weakness to pierce, and 20% weakness to holy and unholy.

Fire Champion has 90% resist to all spells, 60% to all weapons. Has 80% weakness to cold, and 50% weakness to thrust.
Fire Elemental has 70% resist to all spells, 60% to all weapons. Has 60% weakness to cold, and 50% weakness to thrust.

Ice Champion has 90% resist to all spells, 60% to all weapons. Has 80% weakness to fire, and 50% weakness to slash.
Ice elemental has 70% resist to all spells, 60% to all weapons. Has 60% weakness to fire, and 50% weakness to slash.

To sum up: Earth elementals are 'easiest', can be fought using acid and blunt weapons easily, and with cold/fire if necessary. Nerudite are slightly harder but can still be fought with quake or pierce damage. Fire and ice elementals are hardest and have more innate spell/weapon resist, but can be fought with the opposite element or thrust and slash weapons respectively. As discussed in IRC the resists are lower but difficulty (and level on the champions) is higher.

Keen, please let me know if this is what you meant in the earlier discussion :)