### PR TITLE
Fix for players getting the temp safe angel without being killed by a player.

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2202,35 +2202,36 @@
 
    % First set of flags (in piFlags)
    % A mask of flags that are unaffected by ResetPlayerFlagList
-   PFLAG_MASK              = 0xC63D7E
+   PFLAG_MASK              = 0x1C63D7E
 
-   PFLAG_INVISIBLE         = 0x000001
-   PFLAG_MURDERER          = 0x000002
-   PFLAG_SAFETY            = 0x000004
-   PFLAG_OUTLAW            = 0x000008
-   PFLAG_DID_DAMAGE        = 0x000010
-   PFLAG_TOOK_DAMAGE       = 0x000020
-   PFLAG_DODGED            = 0x000040
-   PFLAG_TRANCE            = 0x000080
-   PFLAG_HAUNTED           = 0x000100
-   PFLAG_MANA_FOCUS        = 0x000200
-   PFLAG_PKILL_ENABLE      = 0x000400
-   PFLAG_TUTORIAL          = 0x000800
-   PFLAG_PKILL_LOCK        = 0x001000
+   PFLAG_INVISIBLE         = 0x0000001
+   PFLAG_MURDERER          = 0x0000002
+   PFLAG_SAFETY            = 0x0000004
+   PFLAG_OUTLAW            = 0x0000008
+   PFLAG_DID_DAMAGE        = 0x0000010
+   PFLAG_TOOK_DAMAGE       = 0x0000020
+   PFLAG_DODGED            = 0x0000040
+   PFLAG_TRANCE            = 0x0000080
+   PFLAG_HAUNTED           = 0x0000100
+   PFLAG_MANA_FOCUS        = 0x0000200
+   PFLAG_PKILL_ENABLE      = 0x0000400
+   PFLAG_TUTORIAL          = 0x0000800
+   PFLAG_PKILL_LOCK        = 0x0001000
    % Taking part in factions?
-   PFLAG_INTRIGUING        = 0x002000
-   PFLAG_NO_FIGHT          = 0x004000
-   PFLAG_NO_MAGIC          = 0x008000
-   PFLAG_NO_MOVE           = 0x010000
-   PFLAG_LOG               = 0x020000
+   PFLAG_INTRIGUING        = 0x0002000
+   PFLAG_NO_FIGHT          = 0x0004000
+   PFLAG_NO_MAGIC          = 0x0008000
+   PFLAG_NO_MOVE           = 0x0010000
+   PFLAG_LOG               = 0x0020000
    % Setting for the player's temp safety
-   PFLAG_TEMP_SAFETY       = 0x040000
-   PFLAG_ANONYMOUS         = 0x080000
-   PFLAG_FORGOTTEN         = 0x100000
-   PFLAG_MORPHED           = 0x200000
+   PFLAG_TEMP_SAFETY       = 0x0040000
+   PFLAG_ANONYMOUS         = 0x0080000
+   PFLAG_FORGOTTEN         = 0x0100000
+   PFLAG_MORPHED           = 0x0200000
    % this player has moved since he's entered the room.
-   PFLAG_MOVED_SINCE_ENTRY = 0x400000
-   PFLAG_GROUPING          = 0x800000
+   PFLAG_MOVED_SINCE_ENTRY = 0x0400000
+   PFLAG_GROUPING          = 0x0800000
+   PFLAG_KILLED_BY_PLAYER  = 0x1000000
 
    % Second set of player flags (in piFlags2)
    % A mask of flags that are unaffected by ResetPlayerFlagList

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -9077,7 +9077,16 @@ messages:
          }
          else
          {
-            oItemAtt = Send(sys,@FindItemAttByNum,#num=IA_PKPOINTER);
+            oItemAtt = Send(SYS,@FindItemAttByNum,#num=IA_PKPOINTER);
+
+            if what <> $
+            {
+               % We've been killed by a player, so set the PKed flag for
+               % the temp safety angel to trigger later, provided we meet
+               % all the requirements. Check for not $ here - fastest way
+               % to implement this without performing another IsClass check.
+               piFlags = piFlags | PFLAG_KILLED_BY_PLAYER;
+            }
          }
 
          lReagentBagContents = Send(self,@GetReagentBagContents);
@@ -9234,9 +9243,17 @@ messages:
 
    ApplyDeathPenalties()
    {
-      local iAmount, bLostHealth, i;
+      local iAmount, bLostHealth, i, bTempSafe;
 
-      if Send(self,@GetDeathRiftProtection) = TRUE
+      bTempSafe = FALSE;
+
+      if (piFlags & PFLAG_KILLED_BY_PLAYER)
+      {
+         bTempSafe = TRUE;
+         piFlags = piFlags & ~PFLAG_KILLED_BY_PLAYER;
+      }
+
+      if Send(self,@GetDeathRiftProtection)
       {
          % Leaving the Underworld while protected, no penalties. Protection
          % is removed in NewOwner to allow them to log off without penalties.
@@ -9255,7 +9272,7 @@ messages:
       bLostHealth = FALSE;
 
       % Lose your revenant, satisfied if you took a real death.
-      if piDeathCost >= Send(Send(SYS, @GetSettings), @GetDefaultDeathCost)
+      if piDeathCost >= Send(Send(SYS,@GetSettings),@GetDefaultDeathCost)
       {
          % As an outlaw, justice was met by dying. But, not if it's a cheap death!
          Send(self,@SetPlayerFlag,#flag=PFLAG_OUTLAW,#value=FALSE);
@@ -9283,18 +9300,19 @@ messages:
          else
          {
             % If you're not new, chance to lose a hp!
-            if random(1,100) <= piDeathCost
+            if Random(1,100) <= piDeathCost
             {
                Send(self,@GainBaseMaxHealth,#amount=-1);
                bLostHealth = TRUE;
             }
 
             % Under 100HP and killed by a player? Receive a temporary angel.
-            if bLostHealth=TRUE
-               AND piBase_max_health<=99
-               AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
-               AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
-               AND Send(self,@CheckPlayerFlag,#flag=PFLAG_TEMP_SAFETY)
+            if bLostHealth
+               AND bTempSafe
+               AND piBase_max_health <= 99
+               AND NOT ((piFlags & PFLAG_MURDERER)
+                  OR (piFlags & PFLAG_OUTLAW))
+               AND (piFlags & PFLAG_TEMP_SAFETY)
                AND Send(self,@FindUsing,#class=&SoldierShield) = $
                AND ptTempSafe = $
             {


### PR DESCRIPTION
Forgot to add a check for the victim actually dying by another player.
Added a new PFLAG, PFLAG_KILLED_BY_PLAYER which is set if the killer is
a player. Flag is removed when penalties are applied, at which time a
boolean is set to activate the temp angel.