### PR TITLE
War event formatting and improvements.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -5514,6 +5514,60 @@ messages:
       return;
    }
 
+   SetForSaleFrenzy(override=FALSE)
+   "Used to give Innkeepers a frenzy sale list."
+   {
+      if Send(SYS,@GetChaosNight)
+         OR override
+      {
+         plFor_sale = [
+            [
+               Create(&ShockRing),
+               Create(&FireRing),
+               Create(&ColdRing),
+               Create(&AcidRing),
+               Create(&BerserkerRing),
+               Create(&RingInvisibility),
+               Create(&LeatherArmor),
+               Create(&ChainArmor),
+               Create(&ScaleArmor),
+               Create(&NeruditeArmor),
+               Create(&PlateArmor),
+               Create(&DiscipleRobe),
+               Create(&GuildShield),
+               Create(&NeruditeSword),
+               Create(&Mace),
+               Create(&Hammer),
+               Create(&Axe),
+               Create(&MysticSword),
+               Create(&Scimitar),
+               Create(&Longsword),
+               Create(&Longbow),
+               Create(&BattleBow),
+               Create(&HealWand),
+               Create(&Gauntlet),
+               Create(&JewelOfFroz),
+               Create(&Arrow,#number=150),
+               Create(&SilverArrow,#number=150),
+               Create(&NeruditeArrow,#number=150),
+               Create(&IceArrow,#number=150),
+               Create(&FireArrow,#number=150),
+               Create(&Helm),
+               Create(&Mint,#number=100),
+               Create(&NeruditeBow),
+               Create(&Gift),
+               Create(&Chaosfood,#number=100),
+               Create(&KarmaPotion,#karma=-10000),
+               Create(&KarmaPotion,#karma=10000)
+            ],
+            $,
+            $,
+         $];
+      }
+
+      return;
+   }
+
    AssembleVaultList(who=$)
    {
       local oVault, i, j;

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -3556,8 +3556,11 @@ messages:
          if i = what
          {
             plDefense_modifiers = DelListElem(plDefense_modifiers,i);
-            Post(self,@DrawDefense);
-            Post(self,@DrawArmor);
+            if pbLogged_on
+            {
+               Post(self,@DrawDefense);
+               Post(self,@DrawArmor);
+            }
             bFound = TRUE;
 
             return;
@@ -3929,7 +3932,11 @@ messages:
                Send(what,@NewUnused,#what=self);
             }
 
-            Post(self,@DrawResistances);
+            if pbLogged_on
+            {
+               Post(self,@DrawResistances);
+            }
+
             return TRUE;
          }
       }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -4047,6 +4047,23 @@ messages:
       % Frenzies!  Anything goes if allowed by the room!
       if Send(SYS,@GetChaosNight)
       {
+         if Send(Send(SYS,@GetWarEvent),@IsActive)
+         {
+            % If there's a war event going, disallow attacks between teammates.
+            if Send(Send(SYS,@GetWarEvent),@IsSameSide,#player1=self,#player2=victim)
+               AND NOT Send(Send(SYS,@GetWarEvent),@CanAttackAllies)
+            {
+               if report
+               {
+                  Send(self,@MsgSendUser,#message_rsc=cannot_attack_ally,
+                        #parm1=Send(victim,@GetName),
+                        #parm2=Send(victim,@GetHeShe));
+               }
+
+               return FALSE;
+            }
+         }
+
          return TRUE;
       }
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -6683,15 +6683,15 @@ messages:
    NewHoldObject(what = $)
    {
       if pbLogged_on
-      {	  
+      {
          AddPacket(1,BP_INVENTORY_ADD);
          Send(self,@ToCliObject,#what=what,#show_type=SHOW_INVENTORY);
          SendPacket(poSession);
-         
+
          Post(self,@DrawCapacity);
          Post(self,@DrawBulk);
       }
-      
+
       propagate;
    }
 
@@ -6702,7 +6702,7 @@ messages:
          AddPacket(1,BP_INVENTORY_REMOVE,4,what);
          SendPacket(poSession);
          Post(self,@DrawCapacity);
-         Post(self,@DrawBulk);    
+         Post(self,@DrawBulk);
       }
 
       propagate;
@@ -7311,13 +7311,13 @@ messages:
       {
          AddPacket(1,BP_USE,4,what);
          SendPacket(poSession);
+
+         if IsClass(what,&Weapon)
+         {
+            Post(self,@DrawOffense);
+         }
       }
-      
-      if IsClass(what,&Weapon)
-      {
-         Post(self,@DrawOffense);
-      }
-      
+
       return;
    }
 
@@ -7327,13 +7327,13 @@ messages:
       {
          AddPacket(1,BP_UNUSE,4,what);
          SendPacket(poSession);
+
+         if IsClass(what,&Weapon)
+         {
+            Post(self,@DrawOffense);
+         }
       }
 
-      if IsClass(what,&Weapon)
-      {
-         Post(self,@DrawOffense);
-      }
-      
       return;
    }
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2616,7 +2616,7 @@ messages:
             {
                if Send(Send(SYS,@GetWarEvent),@IsSameSide,#player1=self,#player2=what)
                {
-                  return MM_PLAYER | MM_PLAYER_IS_GUILDMATE;
+                  return MM_PLAYER | MM_PLAYER_IS_FRIEND;
                }
 
                return MM_PLAYER | MM_PLAYER_IS_ENEMY;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2612,6 +2612,16 @@ messages:
             OR oIllusion = $
             OR NOT IsClass(oIllusion,&Monster)
          {
+            if Send(Send(SYS,@GetWarEvent),@IsActive)
+            {
+               if Send(Send(SYS,@GetWarEvent),@IsSameSide,#player1=self,#player2=what)
+               {
+                  return MM_PLAYER | MM_PLAYER_IS_GUILDMATE;
+               }
+
+               return MM_PLAYER | MM_PLAYER_IS_ENEMY;
+            }
+
             % Standard player blue dot.
             if Send(what,@CheckPlayerFlag,#flag=PFLAG2_TEMPSAFE,#flagset=2)
             {

--- a/kod/object/item/passitem/KarmaPotion.kod
+++ b/kod/object/item/passitem/KarmaPotion.kod
@@ -19,23 +19,28 @@ resources:
    KarmaPotion_icon_rsc = potion01.bgf
    
    KarmaPotion_name_rsc = "Karma Potion"
-   KarmaPotion_desc_rsc = "Drinking this potion during a frenzy will change your karma."
+   KarmaPotion_desc_rsc = \
+      "Drinking this potion during a frenzy will change your karma."
 
    KarmaPotion_pos_name_rsc = "Positive Karma Potion"
-   KarmaPotion_pos_desc_rsc = "Drinking this potion during a Frenzy will change your karma to +100."
+   KarmaPotion_pos_desc_rsc = \
+      "Drinking this potion during a Frenzy will change your karma to +100."
    
    KarmaPotion_neg_name_rsc = "Negative Karma Potion"
-   KarmaPotion_neg_desc_rsc = "Drinking this potion during a Frenzy will change your karma to -100."
+   KarmaPotion_neg_desc_rsc = \
+      "Drinking this potion during a Frenzy will change your karma to -100."
    
-   KarmaPotion_drink = "You quaff the contents of the Karma Potion in a single gulp."
-   KarmaPotion_no_drink = "You can't use this potion when it is not a frenzy."
+   KarmaPotion_drink = \
+      "You quaff the contents of the Karma Potion in a single gulp."
+   KarmaPotion_no_drink = \
+      "You can't use this potion when it is not a frenzy."
 
 classvars:
 
    vrIcon = KarmaPotion_icon_rsc
 
    viBulk = 20
-   viWeight = 5000          % weighs more than a mortal can normally hold - ensures can only be given out via admin globally
+   viWeight = 20
    viValue_average = 60
 
    viItem_type = ITEMTYPE_POTION | ITEMTYPE_SUNDRY
@@ -52,69 +57,94 @@ properties:
    piItem_flags = XLAT_TO_SKY
    piKarma = 0
 
-
 messages:
 
-   Constructor(Karma=$)
-   "Creates the Karma Potion with a negative or positive karma value. INT above zero makes positive potion INT below zero makes a negative potion."
+   Constructor(karma=$,model=$)
+   "Creates the Karma Potion with a negative or positive karma value. "
+   "INT above zero makes positive potion INT below zero makes a "
+   "negative potion."
    {
-     if karma > 0
-     {
-       vrName = KarmaPotion_pos_name_rsc;
-       vrDesc = KarmaPotion_pos_desc_rsc;
-       piItem_Flags = PT_MET_GREEN;
-       piKarma = 10000;
-     }
-		
-     if karma < 0
-     {
-       vrName = KarmaPotion_neg_name_rsc;
-       vrDesc = KarmaPotion_neg_desc_rsc;
-       piItem_Flags = PT_MET_RED;
-       piKarma = -10000;
-     }
-		
-     propagate;
+      % If we buy the potion (i.e. during a frenzy) we use the model
+      % parameter to determine which type of potion it is.
+      if model <> $
+      {
+         karma = Send(model,@GetKarma);
+      }
+
+      % If we somehow end up with $ karma, pick it at random.
+      if karma = $
+      {
+         if Random(0,1) = 1
+         {
+            karma = 10000;
+         }
+         else
+         {
+            karma = -10000;
+         }
+      }
+
+      if karma > 0
+      {
+         vrName = KarmaPotion_pos_name_rsc;
+         vrDesc = KarmaPotion_pos_desc_rsc;
+         piItem_Flags = PT_MET_GREEN;
+         piKarma = 10000;
+      }
+
+      if karma < 0
+      {
+         vrName = KarmaPotion_neg_name_rsc;
+         vrDesc = KarmaPotion_neg_desc_rsc;
+         piItem_Flags = PT_MET_RED;
+         piKarma = -10000;
+      }
+
+      propagate;
    }
-   
+
    ApplyPotionEffects(apply_on = $)
    {
-     if Send(SYS, @GetChaosNight)				
-     {	
-       Send(apply_on,@SetKarma,#value=piKarma);
-     }    
-     else
-     {
-       Send(apply_on,@MsgSendUser,#message_rsc=KarmaPotion_no_drink);
-       Send(self,@Delete);								% deletes it self if someone tries to use it outside frenzy.	
+      if Send(SYS,@GetChaosNight)
+         OR IsClass(apply_on,&DM)
+      {
+         Send(apply_on,@SetKarma,#value=piKarma);
+      }
+      else
+      {
+         Send(apply_on,@MsgSendUser,#message_rsc=KarmaPotion_no_drink);
+         % Delete and log a message if outside frenzy.
+         Debug("ALERT!  ",Send(apply_on,@GetTrueName)," tried to drink a ",
+               "karma potion!");
+         Send(self,@Delete);
      }
 
      return;
    }
-   
+
    ReqNewApply(what = $,apply_on = $)
    {
-     if what = apply_on
-     {
-       return TRUE;
-     }
-      
-     return FALSE;
+      if what = apply_on
+      {
+         return TRUE;
+      }
+
+      return FALSE;
    }
-   
+
    NewApplied(what = $,apply_on = $)
    {
-     if isClass(apply_on,&Player) 
-     {
-       Send(apply_on,@waveSenduser,#wave_rsc=BetaPotion_gulp_sound);
-     }
+      if isClass(apply_on,&Player) 
+      {
+         Send(apply_on,@waveSenduser,#wave_rsc=BetaPotion_gulp_sound);
+      }
 
-     Send(apply_on,@MsgSendUser,#message_rsc=KarmaPotion_drink);
-     Send(self,@ApplyPotionEffects,#apply_on=apply_on);
+      Send(apply_on,@MsgSendUser,#message_rsc=KarmaPotion_drink);
+      Send(self,@ApplyPotionEffects,#apply_on=apply_on);
 
-     Send(self,@Delete);
+      Send(self,@Delete);
 
-     return;
+      return;
    }
 
    IsBeverage()
@@ -131,12 +161,11 @@ messages:
    {
      return FALSE;
    }
-   
+
    GetKarma()
    {
      return piKarma;
    }
-   
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/warjoin.kod
+++ b/kod/object/item/passitem/warjoin.kod
@@ -22,9 +22,9 @@ resources:
       "This will allow you to join the war on the side of:\n"
    WarJoinPendant_desc_after_rsc = \
       "This pendant shows your allegiance to:\n"
-	
+
 classvars:
-   
+
    vrName = WarJoinPendant_name_rsc
    vrIcon = WarJoinPendant_icon_rsc
 
@@ -52,15 +52,18 @@ messages:
       {
          piSide = side;
 
-         piItem_flags = send(SYS,@EncodeTwoColorXLAT,#color1=send(send(SYS,@GetWarEvent),@GetSideColor,#side=piSide),#color2=XLAT_TO_SKIN1);
+         piItem_flags = Send(SYS,@EncodeTwoColorXLAT,
+                           #color1=Send(Send(SYS,@GetWarEvent),
+                           @GetSideColor,#side=piSide),#color2=XLAT_TO_SKIN1);
       }
-      
+
       propagate;
    }
 
    ReqUse()
    {
-      return send(send(SYS,@GetWarEvent),@AddPlayerToSide,#who=poOwner,#side=piSide);
+      return Send(Send(SYS,@GetWarEvent),@AddPlayerToSide,
+                  #who=poOwner,#side=piSide);
    }
 
    ReqUnuse()
@@ -71,22 +74,22 @@ messages:
    NewUsed()
    {
       local iSequence, oRobe, oJoinItem;
-      
+
       pbUsed = TRUE;
       vrDesc = WarJoinPendant_desc_after_rsc;
 
       % Fix possible disciple robe problems
-      oRobe = send(poOwner,@FindUsing,#class=&Robe);
+      oRobe = Send(poOwner,@FindUsing,#class=&Robe);
 
       % Are they using a robe?
       if oRobe <> $
       {
          % Fix art/color problems.
-         send(oRobe,@ResetColors);
-         send(oRobe,@DoPlayerArt);
+         Send(oRobe,@ResetColors);
+         Send(oRobe,@DoPlayerArt);
       }
-         
-      % Delete all other WarJoin pendants
+
+      % Delete all other WarJoin pendants.
       iSequence = 1;
       oJoinItem = Send(poOwner,@FindHolding,#class=&WarJoinPendant);
 
@@ -95,21 +98,22 @@ messages:
          % Delete the item if it's not this one!
          if oJoinItem <> self
          {
-            post(oJoinItem,@Delete);
+            Post(oJoinItem,@Delete);
          }
 
-         % Find the next in line
+         % Find the next in line.
          iSequence = iSequence + 1;
-         oJoinItem = send(poOwner,@FindHolding,#class=&WarJoinPendant,#sequence=iSequence);
+         oJoinItem = Send(poOwner,@FindHolding,#class=&WarJoinPendant,
+                           #sequence=iSequence);
       }
-            
+
       return;
    }
 
    AppendDesc()
    {
-      AppendTempString(send(send(SYS,@GetWarEvent),@GetSideName,#side=piSide));
-      
+      AppendTempString(Send(Send(SYS,@GetWarEvent),@GetSideName,#side=piSide));
+
       return;
    }
 
@@ -123,7 +127,7 @@ messages:
       return FALSE;
    }
 
-   CanBeStoredInVault()   
+   CanBeStoredInVault()
    {
       return FALSE;
    }
@@ -152,7 +156,7 @@ messages:
       }
       else
       {
-         % no dropping into oblivion
+         % No dropping into oblivion.
          return FALSE;
       }
 
@@ -161,4 +165,3 @@ messages:
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-

--- a/kod/util/chaosnight.kod
+++ b/kod/util/chaosnight.kod
@@ -7,13 +7,13 @@
 % Meridian is a registered trademark.
 
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 ChaosNight is UtilityFunctions
 
 % Handles a chaos night, or "frenzy".  This is a mode where combat is encouraged
-% and people can kill each other without permanent repurcussions.  Generally the
-% game is saved first, and restored afterward.  This can't be done from Blakod so
-% a frenzy requires manual intervention.
+% and people can kill each other without permanent repercussions.  Generally the
+% game is saved first, and restored afterwards.  This can't be done from Blakod
+% so a frenzy requires manual intervention.
 
 constants:
 
@@ -53,22 +53,34 @@ properties:
    plChaosNightLoot = $
    ptChaosNightLootTimer = $
    piChaosNightLootTimerIntervalMs = 3 * 60 * 1000
+
+   % Is loot given to all players?
+   pbGiveGlobalLoot = FALSE
+
+   % Do we hand out reagents with loot?
    pbGiveReagents = FALSE
+
+   % Do we have Innkeepers sell frenzy loot?
+   pbSellFrenzyLoot = TRUE
+   
+   % If we hand out shillings during frenzy, how much do we give at one time?
+   piFrenzyMoneyAmount = 200000
 
 messages:
 
    Constructor()
    {
       % Chaos night MUST be started after a system save, and afterwards,
-      %  the attending guardian MUST revert back to that old save game!
+      % the attending guardian MUST revert back to that old save game!
       % You have been warned!
+
       local i;
 
-      for i in Send(SYS, @GetRooms)
+      for i in Send(SYS,@GetRooms)
       {
          % Sets all rooms to no reagent use.
          Send(i,@TurnReagentsOff);
-		 
+
          % Make all rooms except for inns kill zones (anyone can die).
          % Also, change the background graphic.
          if NOT Send(i,@CheckRoomFlag,#flag=ROOM_HOMETOWN)
@@ -78,7 +90,13 @@ messages:
       }
 
       % Set up a timer to give everyone some reagents, etc.
-      Send(self, @ChaosNightPeriodicLoot);
+      Send(self,@ChaosNightPeriodicLoot);
+
+      % Give Innkeepers a list of frenzy loot to sell to players.
+      if pbSellFrenzyLoot
+      {
+         Post(self,@SetFrenzyNPCSellers);
+      }
 
       % Tell the users online what's going on.
       for i in Send(SYS, @GetUsersLoggedOn)
@@ -91,6 +109,7 @@ messages:
             Send(i,@MsgSendUser,#message_rsc=chaos_night_admin_rsc);
          }
       }
+
       return;
    }
 
@@ -98,28 +117,28 @@ messages:
    {
       local i;
 
-      if ptChaosNightLootTimer <> $ 
+      if ptChaosNightLootTimer <> $
       {
          DeleteTimer(ptChaosNightLootTimer);
          ptChaosNightLootTimer = $;
       }
 
       % Tell the rooms to change their flags back to normal, and to
-      %  redraw the correct background.
+      % redraw the correct background.
       for i in Send(SYS, @GetRooms)
       {
          % Sets all rooms to use reagents.
          Send(i,@TurnReagentsOn);
-		 
-         if not Send(i,@CheckRoomFlag,#flag=ROOM_HOMETOWN)
+
+         if NOT Send(i,@CheckRoomFlag,#flag=ROOM_HOMETOWN)
          {
             Send(i,@EndChaosNight);
          }
       }
 
       % Only Send this message to DMs and up, since this message should
-      %  never be seen.
-      for i in Send(SYS, @GetUsersLoggedOn)
+      % never be seen.
+      for i in Send(SYS,@GetUsersLoggedOn)
       {
          if IsClass(i,&DM)
          {
@@ -134,6 +153,21 @@ messages:
    {
       Send(who,@MsgSendUser,#message_rsc=chaos_night_rsc);
       Send(who,@WaveSendUser,#wave_rsc=chaos_wav);
+
+      return;
+   }
+
+   SetFrenzyNPCSellers()
+   "Sets Innkeepers to sell frenzy loot."
+   {
+      Send(&JasperInnKeeper,@SetForSaleFrenzy);
+      Send(&MarionInnkeeper,@SetForSaleFrenzy);
+      Send(&CorNothInnkeeper,@SetForSaleFrenzy);
+      Send(&BarloqueInnkeeper,@SetForSaleFrenzy);
+      Send(&TosInnKeeper,@SetForSaleFrenzy);
+      Send(&HazarInnKeeper,@SetForSaleFrenzy);
+      Send(&KocatanInnkeeper,@SetForSaleFrenzy);
+
       return;
    }
 
@@ -142,9 +176,9 @@ messages:
    {
       local oPlayer, lGiveList, oItem, oGift;
 
-      if Send(Send(SYS, @GetLore), @BetaPotionsEnabled)
+      if Send(Send(SYS,@GetLore),@BetaPotionsEnabled)
       {
-        return Send(SYS, @GetFailureRsc);
+        return Send(SYS,@GetFailureRsc);
       }
 
       % Reset the loot list if it's niled out.
@@ -176,45 +210,73 @@ messages:
                             ];
       }
 
-      lGivelist = Send(SYS, @GetUsersLoggedOn);
+      lGivelist = Send(SYS,@GetUsersLoggedOn);
 
       for oPlayer in lGiveList
       {
-        for oItem in plChaosNightLoot
-        {
-          if IsClass(oItem,&NumberItem)
-          {
-            oGift = Create(GetClass(oItem),#number=Send(oItem,@GetNumber));
-          }           
-            
-          if IsClass(oItem,&KarmaPotion)
-          {
-            oGift = Create(GetClass(oItem),#karma=Send(oItem,@GetKarma));
-           }            
-            
-          else
-          {
-            if NOT IsClass(oItem,&NumberItem)
+         for oItem in plChaosNightLoot
+         {
+            if IsClass(oItem,&NumberItem)
             {
-              oGift = Create(GetClass(oItem));
+               oGift = Create(GetClass(oItem),#number=Send(oItem,@GetNumber));
             }
-          }
 
-          Send(oPlayer,@NewHold,#what=oGift);
+            if IsClass(oItem,&KarmaPotion)
+            {
+               oGift = Create(GetClass(oItem),#karma=Send(oItem,@GetKarma));
+            }
+            else
+            {
+               if NOT IsClass(oItem,&NumberItem)
+               {
+                  oGift = Create(GetClass(oItem));
+               }
+            }
 
-          if Send(oPlayer,@IsLoggedOn)
-          {
-            Send(oPlayer,@MsgSendUser,#Message_rsc=chaos_gift,
-                 #parm1=Send(oGift,@GetIndef),#parm2=Send(oGift,@GetName));
-          }
-        }
-		
-        % Reagent handouts turned off by default as reagent cost is now
-        % disabled during frenzies via room flag pbNoReagents.
-        if pbGiveReagents
-        {        
-           Send(oPlayer,@AddReagentsForSpells,#iNumCasts=iNumCasts);
-        }
+            Send(oPlayer,@NewHold,#what=oGift);
+
+            if Send(oPlayer,@IsLoggedOn)
+            {
+               Send(oPlayer,@MsgSendUser,#Message_rsc=chaos_gift,
+                     #parm1=Send(oGift,@GetIndef),#parm2=Send(oGift,@GetName));
+            }
+         }
+
+         % Reagent handouts turned off by default as reagent cost is now
+         % disabled during frenzies via room flag pbNoReagents.
+         if pbGiveReagents
+         {
+            Send(oPlayer,@AddReagentsForSpells,#iNumCasts=iNumCasts);
+         }
+      }
+
+      return Send(SYS, @GetSuccessRsc);
+   }
+
+   ChaosNightMoney()
+   "Hands out shillings to all players so they can buy from NPCs."
+   {
+      local lGivelist, oPlayer, oMoney;
+
+      if Send(Send(SYS,@GetLore),@BetaPotionsEnabled)
+      {
+        return Send(SYS,@GetFailureRsc);
+      }
+
+      lGivelist = Send(SYS,@GetUsersLoggedOn);
+
+      for oPlayer in lGiveList
+      {
+         oMoney = Create(&Money,#number=piFrenzyMoneyAmount);
+
+         Send(oPlayer,@NewHold,#what=oMoney);
+
+            if Send(oPlayer,@IsLoggedOn)
+            {
+               Send(oPlayer,@MsgSendUser,#Message_rsc=chaos_gift,
+                     #parm1=Send(oMoney,@GetIndef),
+                     #parm2=Send(oMoney,@GetName));
+            }
       }
 
       return Send(SYS, @GetSuccessRsc);
@@ -223,10 +285,27 @@ messages:
    ChaosNightPeriodicLoot()
    "Timer function that periodically gives people loot during a chaos night"
    {
-      Send(self, @ChaosNightLoot);
-      ptChaosNightLootTimer = CreateTimer(self, @ChaosNightPeriodicLoot, 
-         piChaosNightLootTimerIntervalMs);
+      % Loot is now handled by updated sell lists on Innkeeper NPCs.
+      % In case we still want to use the global loot handout, we keep
+      % this timer active but control whether loot is distributed with
+      % a setting.
+
+      if pbGiveGlobalLoot
+      {
+         Send(self,@ChaosNightLoot);
+      }
+
+      % If NPCs are selling the loot, gotta give the players some cash.
+      if pbSellFrenzyLoot
+      {
+         Send(self,@ChaosNightMoney);
+      }
+
+      ptChaosNightLootTimer = CreateTimer(self,@ChaosNightPeriodicLoot,
+                                    piChaosNightLootTimerIntervalMs);
+
       return;
    }
 
 end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/util/chaosnight.kod
+++ b/kod/util/chaosnight.kod
@@ -39,7 +39,12 @@ resources:
        "properly!  The 'Reign of Blood Frenzy' ~Imust~n be ended by restoring "
        "LASTSAVE.TXT at the server.  Otherwise, character status may be "
        "corrupted due to the Frenzy."
-
+   chaos_night_npcs_rsc = \
+      "~B~U~k[###]~n ~B~rThe Innkeepers in each city have been preparing for "
+      "this day, and have stockpiled massive quantities of items useful for "
+      "defending their homes!  To outfit yourself for the coming battles, "
+      "go to your nearest Innkeeper and check what they have for sale.  For "
+      "a price, they may part with some much needed supplies."
    chaos_gift = \
        "~B~U~k[###]~n ~B~vQor grants you %s%s to smite your enemies!"
 
@@ -98,11 +103,8 @@ messages:
          Post(self,@SetFrenzyNPCSellers);
       }
 
-      % Reduce the weight and bulk of all items.
-      Post(SYS,@ReduceAllItemWeightAndBulk,#iNumber=1);
-
       % Tell the users online what's going on.
-      for i in Send(SYS, @GetUsersLoggedOn)
+      for i in Send(SYS,@GetUsersLoggedOn)
       {
          Send(i,@MsgSendUser,#message_rsc=chaos_night_rsc);
          Send(i,@WaveSendUser,#wave_rsc=chaos_wav);
@@ -110,6 +112,11 @@ messages:
          if IsClass(i,&Admin)
          {
             Send(i,@MsgSendUser,#message_rsc=chaos_night_admin_rsc);
+         }
+
+         if pbSellFrenzyLoot
+         {
+            Send(i,@MsgSendUser,#message_rsc=chaos_night_npcs_rsc);
          }
       }
 
@@ -160,6 +167,11 @@ messages:
       Send(who,@MsgSendUser,#message_rsc=chaos_night_rsc);
       Send(who,@WaveSendUser,#wave_rsc=chaos_wav);
 
+      if pbSellFrenzyLoot
+      {
+         Send(who,@MsgSendUser,#message_rsc=chaos_night_npcs_rsc);
+      }
+
       return;
    }
 
@@ -173,6 +185,9 @@ messages:
       Send(&TosInnKeeper,@SetForSaleFrenzy);
       Send(&HazarInnKeeper,@SetForSaleFrenzy);
       Send(&KocatanInnkeeper,@SetForSaleFrenzy);
+
+      % Reduce the weight and bulk of all items.
+      Send(SYS,@ReduceAllItemWeightAndBulk,#iNumber=1);
 
       return;
    }

--- a/kod/util/chaosnight.kod
+++ b/kod/util/chaosnight.kod
@@ -98,6 +98,9 @@ messages:
          Post(self,@SetFrenzyNPCSellers);
       }
 
+      % Reduce the weight and bulk of all items.
+      Post(SYS,@ReduceAllItemWeightAndBulk,#iNumber=1);
+
       % Tell the users online what's going on.
       for i in Send(SYS, @GetUsersLoggedOn)
       {
@@ -146,6 +149,9 @@ messages:
          }
       }
 
+      % Set NPCs back to selling the correct items.
+      Send(self,@UnsetFrenzyNPCSellers);
+
       return;
    }
 
@@ -167,6 +173,20 @@ messages:
       Send(&TosInnKeeper,@SetForSaleFrenzy);
       Send(&HazarInnKeeper,@SetForSaleFrenzy);
       Send(&KocatanInnkeeper,@SetForSaleFrenzy);
+
+      return;
+   }
+
+   UnsetFrenzyNPCSellers()
+   "If the Innkeepers need to be set back to selling the correct items."
+   {
+      Send(&JasperInnKeeper,@SetForSale);
+      Send(&MarionInnkeeper,@SetForSale);
+      Send(&CorNothInnkeeper,@SetForSale);
+      Send(&BarloqueInnkeeper,@SetForSale);
+      Send(&TosInnKeeper,@SetForSale);
+      Send(&HazarInnKeeper,@SetForSale);
+      Send(&KocatanInnkeeper,@SetForSale);
 
       return;
    }

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -5421,6 +5421,32 @@ messages:
       return plItemTemplates;
    }
 
+   ReduceAllItemWeightAndBulk(iNumber=1)
+   "Reduces (or increases) the weight and bulk of all items "
+   "to the number given. Default 1. Item has to be in the "
+   "item templates list. Does not affect shillings."
+   {
+      local i;
+
+      % Check for frenzy active first, to avoid running
+      % this accidentally.
+      if poChaosNight = $
+      {
+         return;
+      }
+
+      for i in plItemTemplates
+      {
+         if NOT IsClass(i,&Money)
+         {
+            SetClassVar(i,"viBulk",iNumber);
+            SetClassVar(i,"viWeight",iNumber);
+         }
+      }
+
+      return;
+   }
+
    RecreateMoneyTemplates()
    {
       plMoneyTemplates = $;

--- a/kod/util/warevent.kod
+++ b/kod/util/warevent.kod
@@ -42,7 +42,7 @@ resources:
       "~B~rWar has been declared!\n"
       "~kYou may choose to join a side by using a war pendant found in your inventory.  "
       "The pendant you use will determine which side you are part of for this battle.  "
-      "Each side can be identfied by the color of their shirt or robe; neutral characters "
+      "Each side can be identified by the color of their shirt or robe; neutral characters "
       "are dressed in grey.  Any kill scored by your side against an opposing non-neutral "
       "character will be recorded.  The results of this battle will be announced at the "
       "end of the war.  Good luck!"
@@ -57,7 +57,9 @@ resources:
    WarEvent_kill_rsc = " kill "
    WarEvent_kills_rsc = " kills."
 
-   WarEvent_cant_join = "This team is too large currently. Join another team or wait for the teams to even out."
+   WarEvent_cant_join = \
+      "This team is too large currently. Join another team or wait "
+      "for the teams to even out."
 
    WarEvent_mail_sender = "War Event Report"
 
@@ -76,25 +78,25 @@ properties:
    % A count of the kills scored by each side.
    plKills = $
 
-   % Who do we mail final statstics to?
+   % Who do we mail final statistics to?
    poReporter = $
 
    % Are people restricted from joining a particular side?
-   %  If not we want to enforce size limits on the groups.
+   % If not we want to enforce size limits on the groups.
    pbRestricted = WAR_UNRESTRICTED
 
    % Is war active?
    pbActive = FALSE
 
    % This is the information about each side.
-   %  A list of side identifier, text description, shirt color.
+   % A list of side identifier, text description, shirt color.
    plSideInfo = $
 
 messages:
 
    Constructor()
    {
-      send(self,@Reset);
+      Send(self,@Reset);
 
       return;
    }
@@ -109,7 +111,7 @@ messages:
       pbRestricted = WAR_UNRESTRICTED;
 
       % Delete out WarJoin Items
-      send(&WarJoinPendant,@Delete);
+      Send(&WarJoinPendant,@Delete);
 
       plSideInfo = [ [FACTION_DUKE, WarEvent_Duke_name, XLAT_TO_PURPLE],
                      [FACTION_PRINCESS, WarEvent_Princess_name, XLAT_TO_ORANGE],
@@ -135,9 +137,10 @@ messages:
    {
       local lGiveList, oPlayer, iSide;
       
-      % Only during frenzies, or during special occasions (testing), or when we have enough sides for a war.
-      if NOT (override OR send(SYS,@GetChaosNight))
-         OR length(plSides) < 2
+      % Only during frenzies, or during special occasions (testing),
+      % or when we have enough sides for a war.
+      if NOT (override OR Send(SYS,@GetChaosNight))
+         OR Length(plSides) < 2
       {
          return FALSE;
       }
@@ -146,46 +149,47 @@ messages:
       pbActive = TRUE;
 
       % Get rid of those shirts!  Set everyone to neutral color.
-      send(&Player,@RemoveShirt);
-      send(&Player,@SetDefaultClothes,#shirt_color=viNeutralColor);
-      
-      % Give out joining objects
-      lGiveList = send(SYS,@GetUsers);
+      Send(&Player,@RemoveShirt);
+      Send(&Player,@SetDefaultClothes,#shirt_color=viNeutralColor);
+
+      % Give out joining objects.
+      lGiveList = Send(SYS,@GetUsers);
 
       for oPlayer in lGiveList
       {
          % Give out global message.
-         send(oPlayer,@MsgSendUser,#message_rsc=WarEvent_start_message);
-         
+         Send(oPlayer,@MsgSendUser,#message_rsc=WarEvent_start_message);
+
          if NOT pbRestricted
          {
             % Give out one pendant for everyone.
             for iSide in plSides
             {
-               send(oPlayer,@NewHold,#what=Create(&WarJoinPendant,#side=iSide));
+               Send(oPlayer,@NewHold,#what=Create(&WarJoinPendant,#side=iSide));
             }
          }
          else
          {
-            % Restrict objects to qualified players.  Must be part of the group to join.
+            % Restrict objects to qualified players.
+            % Must be part of the group to join.
             if pbRestricted = WAR_FACTION_RESTRICTED
             {
-               iSide = send(oPlayer,@GetFaction);
+               iSide = Send(oPlayer,@GetFaction);
 
                if iSide <> FACTION_NEUTRAL
                {
-                  send(oPlayer,@NewHold,#what=Create(&WarJoinPendant,#side=iSide));
+                  Send(oPlayer,@NewHold,#what=Create(&WarJoinPendant,#side=iSide));
                }
             }
             else
             {
                if pbRestricted = WAR_TOWN_RESTRICTED
                {
-                  iSide = send(oPlayer,@GetHomeRoom);
+                  iSide = Send(oPlayer,@GetHomeRoom);
 
                   if iSide <> RID_RAZA
                   {
-                     send(oPlayer,@NewHold,#what=Create(&WarJoinPendant,#side=iSide));
+                     Send(oPlayer,@NewHold,#what=Create(&WarJoinPendant,#side=iSide));
                   }
                }
             }
@@ -206,33 +210,34 @@ messages:
       }
 
       % Broadcast the end and the final scores.
-      send(SYS,@SystemBroadcast,#type=SAY_MESSAGE,#string=WarEvent_end_message);
+      Send(SYS,@SystemBroadcast,#type=SAY_MESSAGE,#string=WarEvent_end_message);
 
       ClearTempString();
       AppendTempString("~B~k");
       AppendTempString(WarEvent_final_scores_rsc);
       AppendTempString("~n");
-      send(self,@ConstructScores);
+      Send(self,@ConstructScores);
 
-      send(SYS,@SystemBroadcast,#type=SAY_MESSAGE,#string=send(SYS,@GetPercentQRsc),
-           #parm1=GetTempString());
+      Send(SYS,@SystemBroadcast,#type=SAY_MESSAGE,#string=Send(SYS,@GetPercentQRsc),
+            #parm1=GetTempString());
 
-      % Send out info mail to the reporter
+      % Send out info mail to the reporter.
       if poReporter <> $
       {
          sMessage = CreateString();
          SetString(sMessage,GetTempString());
 
-         % Remove color codes
+         % Remove color codes.
          StringSubstitute(sMessage,"~B~k","");
          StringSubstitute(sMessage,"~n","");
-         
-         send(poReporter,@ReceiveNestedMail,#from=WarEvent_mail_sender,#dest_list=[poReporter],
-              #nest_list=[sMessage]);
+         StringSubstitute(sMessage,"~v","");
+
+         Send(poReporter,@ReceiveNestedMail,#from=WarEvent_mail_sender,
+               #dest_list=[poReporter],#nest_list=[sMessage]);
       }
 
       % Reset everything.
-      send(self,@Reset);
+      Send(self,@Reset);
 
       return;
    }
@@ -240,12 +245,12 @@ messages:
    SetupFactionWar()
    "Sets up a restricted war based on faction."
    {
-      send(self,@Reset);
+      Send(self,@Reset);
       pbRestricted = WAR_FACTION_RESTRICTED;
 
-      send(self,@AddSide,#side=FACTION_REBEL);
-      send(self,@AddSide,#side=FACTION_DUKE);
-      send(self,@AddSide,#side=FACTION_PRINCESS);
+      Send(self,@AddSide,#side=FACTION_REBEL);
+      Send(self,@AddSide,#side=FACTION_DUKE);
+      Send(self,@AddSide,#side=FACTION_PRINCESS);
 
       return;
    }
@@ -253,14 +258,14 @@ messages:
    SetupTownWar()
    "Sets up a restricted war based on hometowns."
    {
-      send(self,@Reset);
+      Send(self,@Reset);
       pbRestricted = WAR_TOWN_RESTRICTED;
 
-      send(self,@AddSide,#side=RID_JASPER);
-      send(self,@AddSide,#side=RID_CORNOTH);
-      send(self,@AddSide,#side=RID_MARION);
-      send(self,@AddSide,#side=RID_BARLOQUE);
-      send(self,@AddSide,#side=RID_TOS);
+      Send(self,@AddSide,#side=RID_JASPER);
+      Send(self,@AddSide,#side=RID_CORNOTH);
+      Send(self,@AddSide,#side=RID_MARION);
+      Send(self,@AddSide,#side=RID_BARLOQUE);
+      Send(self,@AddSide,#side=RID_TOS);
 
       return;
    }
@@ -270,15 +275,15 @@ messages:
    {
       local iNumber, iSide;
 
-      iNumber = bound(number,2,4);
+      iNumber = Bound(number,2,4);
 
-      send(self,@Reset);
+      Send(self,@Reset);
       pbRestricted = WAR_UNRESTRICTED;
 
       iSide = 0;
       while iSide < iNumber
       {
-         send(self,@AddSide,#side=(WAR_TEAM_ALPHA+iSide));
+         Send(self,@AddSide,#side=(WAR_TEAM_ALPHA+iSide));
          iSide = iSide + 1;
       }
 
@@ -296,16 +301,17 @@ messages:
          plSoldiers = cons($,plSoldiers);
          plKills = cons(0,plKills);
       }
-      
+
       return;
    }
 
    AddPlayerToSide(who=$,side=$)
-   "Does proper checks, then adds player to specified side if able.  Returns success."
+   "Does proper checks, then adds player to specified side if able. "
+   "Returns success."
    {
       local iSidePosition, lSoldiers, iNumSoldiers;
 
-      % Bail for missing info or if not active
+      % Bail for missing info or if not active.
       if who = $ OR side = $
          OR NOT pbActive
       {
@@ -321,7 +327,7 @@ messages:
       }
 
       % See if the player is already a member of a side.
-      if send(self,@GetPlayerSide,#who=who) <> $
+      if Send(self,@GetPlayerSide,#who=who) <> $
       {
          % Player was found.
          return FALSE;
@@ -333,8 +339,8 @@ messages:
          if pbRestricted = WAR_FACTION_RESTRICTED
          {
             % Side is a faction
-            if send(who,@GetFaction) <> side
-               OR send(who,@GetFaction) = FACTION_NEUTRAL
+            if Send(who,@GetFaction) <> side
+               OR Send(who,@GetFaction) = FACTION_NEUTRAL
             {
                return FALSE;
             }
@@ -344,8 +350,8 @@ messages:
             % Side is a homeroom
             if pbRestricted = WAR_TOWN_RESTRICTED
             {
-               if send(who,@GetHomeRoom) <> side
-                  OR send(who,@GetHomeRoom) = RID_RAZA
+               if Send(who,@GetHomeRoom) <> side
+                  OR Send(who,@GetHomeRoom) = RID_RAZA
                {
                   return FALSE;
                }
@@ -354,19 +360,20 @@ messages:
       }
       else
       {
-         % We're unrestricted, so check for balance of numbers
-         % Don't mess around if we have less than 6 soldiers on a side
-         iNumSoldiers = length(Nth(plSoldiers,iSidePosition));
+         % We're unrestricted, so check for balance of numbers.
+         % Don't mess around if we have less than 6 soldiers on a side.
+         iNumSoldiers = Length(Nth(plSoldiers,iSidePosition));
          if iNumSoldiers >= 6
          {
             for lSoldiers in plSoldiers
             {
-               % Allow them to join if other groups have at least 80% of the desired side's population.
-               %  This prevents one side from growing ungainly large.
-               if (length(lSoldiers) * 100) / iNumSoldiers < 80
+               % Allow them to join if other groups have at least 80%
+               % of the desired side's population. This prevents one
+               % side from growing ungainly large.
+               if (Length(lSoldiers) * 100) / iNumSoldiers < 80
                {
-                  send(who,@MsgSendUser,#message_rsc=WarEvent_cant_join);
-                  
+                  Send(who,@MsgSendUser,#message_rsc=WarEvent_cant_join);
+
                   return FALSE;
                }
             }
@@ -376,19 +383,21 @@ messages:
       % Add to the appropriate list.
       SetNth(plSoldiers,iSidePosition,cons(who,Nth(plSoldiers,iSidePosition)));
 
-      % Give a message and set the color
-      send(who,@MsgSendUser,#Message_rsc=WarEvent_join_rsc,#parm1=send(self,@GetSideName,#side=side));
-      send(who,@SetDefaultClothes,#shirt_color=send(self,@GetSideColor,#side=side));
+      % Give a message and set the color.
+      Send(who,@MsgSendUser,#Message_rsc=WarEvent_join_rsc,
+            #parm1=Send(self,@GetSideName,#side=side));
+      Send(who,@SetDefaultClothes,#shirt_color=Send(self,@GetSideColor,#side=side));
 
       return TRUE;
    }
 
    RecordWarKill(who=$,victim=$)
-   "Checks to see if who and victim are in the war, then increments the kill count if appropriate."
+   "Checks to see if who and victim are in the war, then "
+   "increments the kill count if appropriate."
    {
       local lSoldiers, iSidePosition, iVictimSide;
-      
-      % Bail for missing info, if victim isn't a player, or if not active
+
+      % Bail for missing info, if victim isn't a player, or if not active.
       if who = $ OR victim = $
          OR NOT IsClass(victim,&Player)
          OR NOT pbActive
@@ -397,7 +406,7 @@ messages:
       }
 
       % Find who's side.
-      iSidePosition = send(self,@GetPlayerSide,#who=who,#position=TRUE);
+      iSidePosition = Send(self,@GetPlayerSide,#who=who,#position=TRUE);
 
       % Bail if not found on a side.
       if iSidePosition = $
@@ -406,7 +415,7 @@ messages:
       }
 
       % Find victim's side.
-      iVictimSide = send(self,@GetPlayerSide,#who=victim,#position=TRUE);
+      iVictimSide = Send(self,@GetPlayerSide,#who=victim,#position=TRUE);
 
       % Bail if not found on a side or on who's side.
       if iVictimSide = $
@@ -425,12 +434,13 @@ messages:
    }
 
    GetPlayerSide(who=$,position=FALSE)
-   "Returns the player's side.  If position=TRUE, then return the side's position in plSides."
+   "Returns the player's side.  If position=TRUE, then return "
+   "the side's position in plSides."
    {
       local lSoldiers, iSide;
 
       iSide = 0;
-      
+
       for lSoldiers in plSoldiers
       {
          iSide = iSide + 1;
@@ -442,11 +452,11 @@ messages:
             {
                return iSide;
             }
-            
+
             return Nth(plSides,iSide);
          }
       }
-      
+
       return $;
    }
 
@@ -457,12 +467,12 @@ messages:
 
       for lSideInfo in plSideInfo
       {
-         if first(lSideInfo) = side
+         if First(lSideInfo) = side
          {
             return Nth(lSideInfo,2);
          }
       }
-      
+
       return $;
    }
 
@@ -471,7 +481,7 @@ messages:
    {
       local lSideInfo;
 
-      % This is the neutral color
+      % This is the neutral color.
       if side = $
       {
          return viNeutralColor;
@@ -479,12 +489,12 @@ messages:
 
       for lSideInfo in plSideInfo
       {
-         if first(lSideInfo) = side
+         if First(lSideInfo) = side
          {
             return Nth(lSideInfo,3);
          }
       }
-      
+
       return $;
    }
 
@@ -500,14 +510,13 @@ messages:
       AppendTempString("~B~k");
       AppendTempString(WarEvent_current_scores_rsc);
       AppendTempString("~n");
-      send(self,@ConstructScores);
+      Send(self,@ConstructScores);
 
-      send(SYS,@SystemBroadcast,#type=SAY_MESSAGE,#string=send(SYS,@GetPercentQRsc),
-           #parm1=GetTempString());
+      Send(SYS,@SystemBroadcast,#type=SAY_MESSAGE,#string=Send(SYS,@GetPercentQRsc),
+            #parm1=GetTempString());
 
       return;
    }
-
 
    ConstructScores()
    {
@@ -515,10 +524,10 @@ messages:
 
       n = 1;
 
-      while n <= length(plSides)
+      while n <= Length(plSides)
       {
          AppendTempString("\n");
-         AppendTempString(send(self,@GetSideName,#side=Nth(plSides,n)));
+         AppendTempString(Send(self,@GetSideName,#side=Nth(plSides,n)));
          AppendTempString(WarEvent_have_rsc);
 
          iKills = Nth(plKills,n);
@@ -532,14 +541,11 @@ messages:
             AppendTempString(WarEvent_kills_rsc);
          }
 
-
          n = n + 1;
       }
 
       return;
-   }   
+   }
 
 end
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-

--- a/kod/util/warevent.kod
+++ b/kod/util/warevent.kod
@@ -85,6 +85,9 @@ properties:
    % If not we want to enforce size limits on the groups.
    pbRestricted = WAR_UNRESTRICTED
 
+   % Do we allow allies to attack each other?
+   pbCanAttackAllies = FALSE
+
    % Is war active?
    pbActive = FALSE
 
@@ -460,6 +463,53 @@ messages:
       return $;
    }
 
+   IsSameSide(player1 = $, player2 = $)
+   "Returns TRUE if player1 is on the same side as player 2, "
+   "FALSE otherwise."
+   {
+      local lSoldiers, iSide, iSide1, iSide2;
+
+      if player1 = $
+         OR player2 = $
+      {
+         return FALSE;
+      }
+
+      iSide = 0;
+      iSide1 = $;
+      iSide2 = $;
+
+      for lSoldiers in plSoldiers
+      {
+         iSide = iSide + 1;
+
+         if lSoldiers <> $
+         {
+            if FindListElem(lSoldiers,player1) <> 0
+            {
+               iSide1 = iSide;
+            }
+            if FindListElem(lSoldiers,player2) <> 0
+            {
+               iSide2 = iSide;
+            }
+         }
+      }
+
+      if iSide1 = $
+         OR iSide2 = $
+      {
+         return FALSE;
+      }
+
+      if iSide1 = iSide2
+      {
+         return TRUE;
+      }
+
+      return FALSE;
+   }
+
    GetSideName(side=$)
    "Returns the resource for the name of the side."
    {
@@ -502,6 +552,12 @@ messages:
    "Returns if war event is active or not."
    {
       return pbActive;
+   }
+
+   CanAttackAllies()
+   "Returns TRUE if allies can attack each other, FALSE if not."
+   {
+      return pbCanAttackAllies;
    }
 
    GetScores()

--- a/kod/util/warevent.kod
+++ b/kod/util/warevent.kod
@@ -77,6 +77,12 @@ properties:
 
    % A count of the kills scored by each side.
    plKills = $
+   
+   % A count of the kills scored by each player.
+   plKillsByName = $
+
+   % A count of the deaths taken by each player.
+   plDeathsByName = $
 
    % Who do we mail final statistics to?
    poReporter = $
@@ -111,6 +117,8 @@ messages:
       plSides = $;
       plSoldiers = $;
       plKills = $;
+      plKillsByName = $;
+      plDeathsByName = $;
       pbRestricted = WAR_UNRESTRICTED;
 
       % Delete out WarJoin Items
@@ -398,7 +406,7 @@ messages:
    "Checks to see if who and victim are in the war, then "
    "increments the kill count if appropriate."
    {
-      local lSoldiers, iSidePosition, iVictimSide;
+      local lSoldiers, iSidePosition, iVictimSide, i, bFound;
 
       % Bail for missing info, if victim isn't a player, or if not active.
       if who = $ OR victim = $
@@ -432,6 +440,56 @@ messages:
 
       % Send a message
       Send(who,@MsgSendUser,#message_rsc=WarEvent_got_kill_rsc);
+
+      bFound = FALSE;
+      % Record a kill for the killer.
+      if plKillsByName = $
+      {
+         % First kill!
+         plKillsByName = [ [ who, 1 ] ];
+      }
+      else
+      {
+         for i in plKillsByName
+         {
+            if First(i) = who
+            {
+               SetNth(i,2,Nth(i,2) + 1);
+               bFound = TRUE;
+
+               break;
+            }
+         }
+         if bFound = FALSE
+         {
+            plKillsByName = Cons([who,1],plKillsByName);
+         }
+      }
+
+      bFound = FALSE;
+      % Record a death for the victim.
+      if plDeathsByName = $
+      {
+         % First death!
+         plDeathsByName = [ [ victim, 1 ] ];
+      }
+      else
+      {
+         for i in plDeathsByName
+         {
+            if First(i) = victim
+            {
+               SetNth(i,2,Nth(i,2) + 1);
+               bFound = TRUE;
+
+               break;
+            }
+         }
+         if bFound = FALSE
+         {
+            plDeathsByName = Cons([victim,1],plDeathsByName);
+         }
+      }
 
       return TRUE;
    }
@@ -576,7 +634,7 @@ messages:
 
    ConstructScores()
    {
-      local n, iKills;
+      local n, iKills, i;
 
       n = 1;
 
@@ -598,6 +656,38 @@ messages:
          }
 
          n = n + 1;
+      }
+
+      if plKillsByName <> $
+      {
+         AppendTempString("\n\n~B~kList of kills:~n\n");
+         for i in plKillsByName
+         {
+            AppendTempString("[");
+            AppendTempString(Send(self,@GetSideName,
+                  #side=Send(self,@GetPlayerSide,#who=First(i))));
+            AppendTempString("] ");
+            AppendTempString(Send(First(i),@GetTrueName));
+            AppendTempString(": ");
+            AppendTempString(Nth(i,2));
+            AppendTempString(" kills.\n");
+         }
+      }
+
+      if plDeathsByName <> $
+      {
+         AppendTempString("\n~B~kList of deaths:~n\n");
+         for i in plDeathsByName
+         {
+            AppendTempString("[");
+            AppendTempString(Send(self,@GetSideName,
+                  #side=Send(self,@GetPlayerSide,#who=First(i))));
+            AppendTempString("] ");
+            AppendTempString(Send(First(i),@GetTrueName));
+            AppendTempString(": ");
+            AppendTempString(Nth(i,2));
+            AppendTempString(" deaths.\n");
+         }
       }
 
       return;

--- a/kod/util/warevent.kod
+++ b/kod/util/warevent.kod
@@ -300,9 +300,9 @@ messages:
       if plSides = $
          OR FindListElem(plSides,side) = 0
       {
-         plSides = cons(side,plSides);
-         plSoldiers = cons($,plSoldiers);
-         plKills = cons(0,plKills);
+         plSides = Cons(side,plSides);
+         plSoldiers = Cons($,plSoldiers);
+         plKills = Cons(0,plKills);
       }
 
       return;
@@ -341,7 +341,7 @@ messages:
       {
          if pbRestricted = WAR_FACTION_RESTRICTED
          {
-            % Side is a faction
+            % Side is a faction.
             if Send(who,@GetFaction) <> side
                OR Send(who,@GetFaction) = FACTION_NEUTRAL
             {
@@ -350,7 +350,7 @@ messages:
          }
          else
          {
-            % Side is a homeroom
+            % Side is a homeroom.
             if pbRestricted = WAR_TOWN_RESTRICTED
             {
                if Send(who,@GetHomeRoom) <> side
@@ -384,7 +384,7 @@ messages:
       }
 
       % Add to the appropriate list.
-      SetNth(plSoldiers,iSidePosition,cons(who,Nth(plSoldiers,iSidePosition)));
+      SetNth(plSoldiers,iSidePosition,Cons(who,Nth(plSoldiers,iSidePosition)));
 
       % Give a message and set the color.
       Send(who,@MsgSendUser,#Message_rsc=WarEvent_join_rsc,


### PR DESCRIPTION
During a frenzy war event, all players will now be drawn with red halos or if allied, green halos. Added an IsSameSide message to WarEvent to facilitate this.

Added a boolean property to WarEvent to allow or disallow attacking of teammates (default no attack).

Formatted warevent.kod.

Added frenzy loot to innkeeper NPCs - loot no longer distributed through globalgive. These can be reversed via booleans in the frenzy object. The default settings will hand out 200000 shillings to players every 3 minutes, allowing them to buy their own loot in the remaining safe zones.

But, how will they carry all those items? Frenzies will now use the new SetClassVar C function (requires #933) to reduce the bulk and weight of all items to 1. Combined, these two changes will enable inventory organisation during the frenzy, and stop the item spam during the fighting. In addition the server will no longer start lagging out after an hour due to the amount of items and list nodes being generated (provided players don't go nuts buying and dropping stuff the entire time - money and weight are still factors for this reason).