### PR TITLE
Allow skeletons to use doors in CV main room.

### DIFF
--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3303,7 +3303,10 @@ messages:
                           #iAngle=Send(what,@GetAngle),
                           #iAngle_Change=Nth(i,6));
 
-            Send(what,@WaveSendUser,#wave_rsc=Send(self,@GetDoorSound));
+            if IsClass(what,&User)
+            {
+               Send(what,@WaveSendUser,#wave_rsc=Send(self,@GetDoorSound));
+            }
 
             Send(SYS,@UtilGoNearSquare,#what=what,
                  #where=Send(SYS,@FindRoomByNum,#num=Nth(i,3)),

--- a/kod/object/active/holder/room/monsroom/objroom/castle1.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/castle1.kod
@@ -102,7 +102,27 @@ messages:
       propagate;
    }
 
+   SomethingMoved(what = $, new_row = $, new_col = $, fine_row = FINENESS/2,
+                  fine_col = FINENESS/2, cause = CAUSE_UNKNOWN, speed = 0,
+                  non_monsters_only = FALSE)
+   {
+      if IsClass(what,&Skeleton)
+      {
+         if new_row = 9
+            OR new_row = 8
+         {
+            if new_col = 4
+               OR new_col = 10
+               OR new_col = 26
+               OR new_col = 32
+            {
+               Post(self,@SomethingTryGo,#what=what,#row=new_row,#col=new_col);
+            }
+         }
+      }
+
+      propagate;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-


### PR DESCRIPTION
So they can get revenge on players botting Final Rites and Earthquake. If the skeleton tries to move onto the door location, they use the door.