### PR TITLE
Scaletp

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8690,7 +8690,29 @@ messages:
          {
             piTraining_points = piTraining_points + 1
                + (Send(what,@GetBoostedLevel)
-               / Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalTP));
+               * Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalTP));
+            
+            if monster_level > 75
+            {
+               if monster_level <= 121
+               {
+                  piTraining_points = piTraining_points + 1;
+               }
+               else
+               {
+                  if monster_level <= 150
+                  {
+                     piTraining_points = piTraining_points + 2;
+                  }
+                  else
+                  {
+                     if monster_level >= 151
+                     {
+                        piTraining_points = piTraining_points + 3;
+                     }
+                  }
+               }
+            }
          }
 
          % Let the player know how many training points they have, if they


### PR DESCRIPTION
This does what people have been wanting for a while.

Scaled training points

This gives training points per mob killed determined by the monsters viLevel or HP (tougher limit)

the lowest you can gain is 1 with a highest of 4:

Mob HP = Training Points
0-75 = 1
76-120 = 2
121-150 = 3
151+ = 4

The code has been tested multiple times 

I a sure anyone who tries it will be satisfied to see that its fully operational 

#Diggie
