### PR TITLE
TP fix, monsters casting ET fix.

### DIFF
--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -48,7 +48,7 @@ typedef unsigned char Bool;
 enum {False = 0, True = 1};
 
 #define MAJOR_REV 50   /* Major version of client program */
-#define MINOR_REV 22  /* Minor version of client program; must be in [0, 99] */
+#define MINOR_REV 23  /* Minor version of client program; must be in [0, 99] */
 
 #define MAXAMOUNT 9     /* Max # of digits in a server integer */
 #define MAXSTRINGLEN 512 /* Max length of a string loaded from string table */

--- a/clientd3d/move.c
+++ b/clientd3d/move.c
@@ -64,6 +64,9 @@
 
 #define MIN_SIDE_MOVE (MOVEUNITS / 4)
 
+#define USER_WALKING_SPEED 25 // Speed we send to the server for walking.
+#define USER_RUNNING_SPEED 50 // Speed we send to the server for running.
+
 // Number of milliseconds between retrying to change rooms
 #define MOVE_OFF_ROOM_INTERVAL 1000
 // Time when we last tried to move off room
@@ -355,22 +358,22 @@ void UserMovePlayer(int action)
       // See if trying to move off room.
       if (!IsInRoom(row, col, current_room))
       {
-	 // Delay between consecutive attempts to move off room
-	 if (now - move_off_room_time >= MOVE_OFF_ROOM_INTERVAL)
-	 {
-	    RequestMove(y, x, 0, player.room_id);
-	    move_off_room_time = now;
-	 }
-	 // Don't actually move player off room
-	 x = last_x;
-	 y = last_y;
-	 z = last_z;
-	 break;
+         // Delay between consecutive attempts to move off room
+         if (now - move_off_room_time >= MOVE_OFF_ROOM_INTERVAL) // current time 
+         {
+            RequestMove(y, x, USER_RUNNING_SPEED, player.room_id);
+            move_off_room_time = now;
+         }
+         // Don't actually move player off room
+         x = last_x;
+         y = last_y;
+         z = last_z;
+         break;
       }
       else
       {
-	 // Reset moving-off-room timer, since this move doesn't go off the room
-	 move_off_room_time = 0;
+         // Reset moving-off-room timer, since this move doesn't go off the room
+         move_off_room_time = 0;
       }
 
       // Check next part of step with new floor height or current player height, whichever
@@ -819,7 +822,7 @@ void MoveUpdateServer(void)
 /************************************************************************/
 /*
  * MoveUpdatePosition:  Update the server's knowledge of our position.
- *   This procudure does not care about elapsed interval, but  
+ *   This procedure does not care about elapsed interval, but
  *   sends the update only when the position has changed at least a bit.
  */ 
 void MoveUpdatePosition(void)
@@ -833,28 +836,28 @@ void MoveUpdatePosition(void)
    // don't send update if we didn't move
    if ((server_x - x) * (server_x - x) + (server_y - y) * (server_y - y) > MOVE_THRESHOLD)
    {
-	   // debug output
-	   debug(("MoveUpdatePosition: x (%d -> %d), y (%d -> %d)\n", server_x, x, server_y, y));
+      // debug output
+      debug(("MoveUpdatePosition: x (%d -> %d), y (%d -> %d)\n", server_x, x, server_y, y));
    
-	   // the following speed values must match
-	   // the actual speed a player is moving
-	   // defined by MOVEUNITS and MOVE_DELAY
-	   // as well as those defined in user.kod
+      // the following speed values must match
+      // the actual speed a player is moving
+      // defined by MOVEUNITS and MOVE_DELAY
+      // as well as those defined in user.kod
 
-	   // walk-speed (USER_WALKING_SPEED from user.kod)
-	   speed = 25;
+      // walk-speed (USER_WALKING_SPEED from user.kod)
+      speed = USER_WALKING_SPEED;
    
-	   // run-speed (USER_RUNNING_SPEED from user.kod)
-	   if (IsMoveFastAction(last_move_action))
-		 speed = 50;
+      // run-speed (USER_RUNNING_SPEED from user.kod)
+      if (IsMoveFastAction(last_move_action))
+         speed = USER_RUNNING_SPEED;
 
-	   // send update
-	   RequestMove(y, x, speed, player.room_id);
+      // send update
+      RequestMove(y, x, speed, player.room_id);
    
-	   // save last sent position and tick
-	   server_x = x;
-	   server_y = y;
-	   server_time = timeGetTime();
+      // save last sent position and tick
+      server_x = x;
+      server_y = y;
+      server_time = timeGetTime();
    }
 }
 /************************************************************************/
@@ -876,8 +879,8 @@ void MoveSetValidity(Bool valid)
 
       if (player_obj == NULL)
       {
-	 debug(("MoveSetValidity got NULL player object\n"));
-	 return;
+         debug(("MoveSetValidity got NULL player object\n"));
+         return;
       }
 
       player.x = player_obj->motion.x;
@@ -886,7 +889,6 @@ void MoveSetValidity(Bool valid)
       server_y = player.y;
    }
 }
-
 /************************************************************************/
 void UserTurnPlayer(int action)
 {

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8581,7 +8581,7 @@ messages:
          monster_level = Send(what,@GetLevel);
       }
 
-      if (piFlags & PFLAG_DID_DAMAGE)
+      if ((piFlags & PFLAG_DID_DAMAGE)
          AND poKill_target = what)
          OR group_member_kill
       {

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8714,8 +8714,8 @@ messages:
          {
             piTraining_points = piTraining_points + 1
                + (Send(what,@GetBoostedLevel)
-               * Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalTP));
-            
+               / Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalTP));
+
             if monster_level > 75
             {
                if monster_level <= 121
@@ -8730,10 +8730,8 @@ messages:
                   }
                   else
                   {
-                     if monster_level >= 151
-                     {
-                        piTraining_points = piTraining_points + 3;
-                     }
+                     piTraining_points = piTraining_points + 3;
+
                   }
                }
             }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1204,7 +1204,7 @@ messages:
 
       if flagset = 1 AND (flag & PFLAG_PKILL_ENABLE) AND value
       {
-         if Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+         if (piFlags & PFLAG_PKILL_ENABLE)
          {
             return;
          }
@@ -1672,7 +1672,7 @@ messages:
          Send(self,@SetPlayerFlag,#flag=PFLAG_MOVED_SINCE_ENTRY,#value=FALSE);
 
          % Don't create the revenant if we're in a safe location.
-         if Send(self,@CheckPlayerFlag,#flag=PFLAG_HAUNTED)
+         if (piFlags & PFLAG_HAUNTED)
          {
             Create(&Revenant,#target=self,#location=poOwner,
                    #level=bound((((piBase_Max_health*150)/100)+
@@ -1755,7 +1755,7 @@ messages:
    {
       local i,oEnchanter, rank, HitPoint_Percent;
 
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (piFlags & PFLAG_MORPHED)
          AND poIllusion_set <> $
       {
          % Since piHealth is internally inflated by a factor of 100, this 
@@ -2066,7 +2066,7 @@ messages:
 
    UserLogonHook()
    {
-      local i, oGame, oParl, oRoom, iBonus, iDefaultBonus, iTimespan;
+      local i, oGame, oParl, iBonus, iDefaultBonus, iTimespan;
 
       for i in plPassive
       {
@@ -2133,7 +2133,7 @@ messages:
       %   then give us a commands list.
       if IsClass(poOwner,&Guest1)
          OR (IsClass(poOwner,&Newb1)
-            AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_TUTORIAL))
+            AND NOT (piFlags & PFLAG_TUTORIAL))
       {
          Post(self,@MsgSendUser,#message_rsc=player_newbie_commands);
       }
@@ -2144,10 +2144,9 @@ messages:
       Send(self,@ComputeMaxMana);
 
       % Tell others that we're here
-      oRoom = Send(self, @GetOwner);
-      if oRoom <> $ AND NOT IsClass(self, &DM)
+      if poOwner <> $ AND NOT IsClass(self, &DM)
       {
-         Send(oRoom, @SomethingWaveRoom, #what=self,
+         Send(poOwner,@SomethingWaveRoom,#what=self,
                #wave_rsc=player_logged_on_wav_rsc);
       }
 
@@ -2193,7 +2192,7 @@ messages:
 
    UserLogoffHook()
    {
-      local i, oRoom;
+      local i;
 
       for i in plPassive
       {
@@ -2245,10 +2244,9 @@ messages:
       Send(self,@CancelRescue);
 
       % Tell others that we're leaving
-      oRoom = Send(self, @GetOwner);
-      if oRoom <> $ AND NOT IsClass(self, &DM) 
+      if poOwner <> $ AND NOT IsClass(self,&DM)
       {
-         Send(oRoom, @SomethingWaveRoom, #what=self, 
+         Send(poOwner,@SomethingWaveRoom,#what=self,
                #wave_rsc=player_logged_off_wav_rsc);
       }
 
@@ -2556,7 +2554,7 @@ messages:
 
       % Send first mail the first time player plays.
       % Set their honor strong if this is a truly new character (max 1 reroll)
-      if NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_TUTORIAL) 
+      if NOT (piFlags & PFLAG_TUTORIAL)
       {
          Send(self,@ReceiveNestedMail,#from=player_angel,
                #dest_list=[self],#nest_list=[4,player_first_mail]);
@@ -3722,7 +3720,7 @@ messages:
          return FALSE;
       }
 
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (piFlags & PFLAG_MORPHED)
       {
          Send(self,@MsgSendUser,#message_rsc=player_cant_use);
 
@@ -4107,7 +4105,7 @@ messages:
 
       % Check for temporary safety flag.
       if IsClass(victim,&Player)
-         AND (Send(self,@CheckPlayerFlag,#flag=PFLAG2_TEMPSAFE,#flagset=2)
+         AND ((piFlags2 & PFLAG2_TEMPSAFE)
             OR Send(victim,@CheckPlayerFlag,#flag=PFLAG2_TEMPSAFE,#flagset=2))
       {
          if report
@@ -4149,7 +4147,7 @@ messages:
             OR IsClass(victim,&EvilTwin)
             OR Send(victim,@GetMaster) <> $
          {
-            if NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+            if NOT (piFlags & PFLAG_PKILL_ENABLE)
             {
                if report
                {
@@ -4231,7 +4229,7 @@ messages:
 
          if NOT Send(oRoom,@CheckRoomFlag,#flag=ROOM_KILL_ZONE)
          {
-            if NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+            if NOT (piFlags & PFLAG_PKILL_ENABLE)
             {
                % A newbie (someone below GetPKillEnableHP) tried to attack
                % another player! note that this does not affect murderers
@@ -4422,8 +4420,8 @@ messages:
          }
          else
          {
-            if NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
-               AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
+            if NOT (piFlags & PFLAG_MURDERER)
+               AND NOT (piFlags & PFLAG_OUTLAW)
                AND actual = TRUE
             {
                % attacking someone who is without fault is cause to
@@ -4867,7 +4865,8 @@ messages:
 
       % Morphed?
       oMonster = Send(self,@GetIllusionForm);
-      if (oMonster <> $) and Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (oMonster <> $)
+         AND (piFlags & PFLAG_MORPHED)
       {
          iOffense = Send(oMonster,@GetOffense,#what=what,#stroke_obj=stroke_obj);
       }
@@ -4954,7 +4953,8 @@ messages:
 
       % Morphed?
       oMonster = Send(self,@GetIllusionForm);
-      if (oMonster <> $) and Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (oMonster <> $)
+         AND (piFlags & PFLAG_MORPHED)
       {
          iDefense = Send(oMonster,@GetDefense,#what=what,
                         #stroke_obj=stroke_obj);
@@ -5014,7 +5014,8 @@ messages:
 
       % Morphed?
       oMonster = Send(self,@GetIllusionForm);
-      if oMonster <> $ AND Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (oMonster <> $)
+         AND (piFlags & PFLAG_MORPHED)
       {
          return Send(oMonster,@GetParryAbility,#stroke_obj=stroke_obj);
       }
@@ -5037,7 +5038,8 @@ messages:
 
       % Morphed?
       oMonster = Send(self,@GetIllusionForm);
-      if oMonster <> $ AND Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (oMonster <> $)
+         AND (piFlags & PFLAG_MORPHED)
       {
          % Should only be one morph enchantment on the player.
          return Send(oMonster,@GetBlockAbility,#stroke_obj=stroke_obj);
@@ -5066,8 +5068,9 @@ messages:
 
       % Morphed?
       oMonster = Send(self,@GetIllusionForm);
-      if oMonster <> $ AND Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
-         AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_NO_MOVE)
+      if (oMonster <> $)
+         AND (piFlags & PFLAG_MORPHED)
+         AND NOT (piFlags & PFLAG_NO_MOVE)
       {
          return Send(oMonster,@GetDodgeAbility,#stroke_obj=stroke_obj);
       }
@@ -5088,7 +5091,8 @@ messages:
 
       % Morphed?
       oMonster = Send(self,@GetIllusionForm);
-      if oMonster <> $ AND Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (oMonster <> $)
+         AND (piFlags & PFLAG_MORPHED)
       {
          iDamage = Send(oMonster,@GetDamage,#what=what,#stroke_obj=stroke_obj);
       }
@@ -5172,7 +5176,8 @@ messages:
 
       % Morphed?
       oMonster = Send(self,@GetIllusionForm);
-      if oMonster <> $ AND Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (oMonster <> $)
+         AND (piFlags & PFLAG_MORPHED)
       {
          return Send(oMonster,@GetDamageType,#what=what);
       }
@@ -5201,7 +5206,8 @@ messages:
 
       % Morphed?
       oMonster = Send(self,@GetIllusionForm);
-      if oMonster <> $ AND Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (oMonster <> $)
+         AND (piFlags & PFLAG_MORPHED)
       {
          return Send(oMonster,@GetSpellType,#what=what);
       }
@@ -5362,7 +5368,7 @@ messages:
 
       if damage > 0
       {
-         if Send(self,@CheckPlayerFlag,#flag=PFLAG2_PARALYZED,#flagset=2)
+         if (piFlags2 & PFLAG2_PARALYZED)
          {
             Send(self,@RemoveEnchantment,
                   #what=Send(SYS,@FindSpellByNum,#num=SID_PARALYZE));
@@ -5376,8 +5382,8 @@ messages:
          % If we have more health than twice our max, no percent limit on damage.
          % If we are outlaw or murderer, no percent limit on damage.
          if piHealth < (piBase_Max_Health * 200)
-            AND ((NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
-               AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER))
+            AND ((NOT (piFlags & PFLAG_OUTLAW)
+               AND NOT (piFlags & PFLAG_MURDERER))
                OR Send(Send(SYS,@GetSettings),@DamageCapProtectionMurderersEnabled))
          {
             % Cap damage to 1/3 of max health (+2 so we "round up")
@@ -5740,7 +5746,7 @@ messages:
                   % Apply penalties for someone NOT holding a token
                   if Send(what,@FindUsing,#class=&Token) = $
                   {
-                     if Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
+                     if (piFlags & PFLAG_MURDERER)
                      {
                         Send(self,@MsgSendUser,#message_rsc=player_killed_player);
                      }
@@ -5915,7 +5921,7 @@ messages:
 
       % PFLAG2_NOHAUNT is only settable by a guide or guardian. The last
       % two checks prevent outlaw/murderer players from creating revenants.
-      if Send(Self,@CheckPlayerFlag,#flagset=2,#flag=PFLAG2_NOHAUNT)
+      if (piFlags2 & PFLAG2_NOHAUNT)
          OR Send(target,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
          OR Send(target,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
       {
@@ -6759,7 +6765,7 @@ messages:
       % Give them the "further info" gmail if they've advanced to 25.
       if piBase_Max_health = 25
          AND amount > 0
-         AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_TUTORIAL)
+         AND NOT (piFlags & PFLAG_TUTORIAL)
       {
          Send(self,@ReceiveNestedMail,#from=player_angel,
                #dest_list=[self],#nest_list=[4,player_tutorial_mail]);
@@ -7344,7 +7350,7 @@ messages:
 
    CalculateKarmaChangeFromKill(karma_killer=0,karma_victim=0,bIsMob=FALSE)
    {
-      local iChange, iSwing, oRoom, oSpellDeathLink;
+      local iChange, iSwing, oSpellDeathLink;
 
       % No karma change in survival room. Mobs in this room *should*
       % return 0 karma, but there are cases where it doesn't happen.
@@ -7364,8 +7370,8 @@ messages:
 
       % No karma changes in the newbie area. Otherwise e.g. killing a negative
       % karma monster may make your spell inoperable.
-      oRoom = Send(self, @GetOwner);
-      if oRoom <> $ AND Send(oRoom, @GetRegion) = RID_NEWB_BASE
+      if poOwner <> $
+         AND Send(poOwner,@GetRegion) = RID_NEWB_BASE
       {
          return 0;
       }
@@ -7553,7 +7559,7 @@ messages:
                       refigureschools = TRUE)
    {
       local i, bFound, elemNum, iAbility, bUsed, spellName, iChange,
-            newAbility, oSpell, oRoom, shrunken;
+            newAbility, oSpell, shrunken;
 
       oSpell = Send(SYS,@FindSpellByNum,#num=spell_num);
       if oSpell = $
@@ -7601,16 +7607,19 @@ messages:
       Send(self,@DrawStatSpell,#index=elemNum);
       if report AND iChange > 0
       {
-         oRoom = Send(self, @GetOwner);
-         Post(self,@MsgSendUser,#message_rsc=player_improved,#parm1=spellName);
-         Send(oRoom, @SomethingWaveRoom, #what=self, 
-              #wave_rsc=player_improved_wav_rsc);
-
-         % report to shrunken head
-         shrunken = Send(self,@FindHolding,#class=&ShrunkenHead);
-         if shrunken <> $
+         if poOwner <> $
          {
-            Send(shrunken,@Improvement,#spellName=spellName);
+            Post(self,@MsgSendUser,#message_rsc=player_improved,
+                  #parm1=spellName);
+            Send(poOwner,@SomethingWaveRoom,#what=self,
+                  #wave_rsc=player_improved_wav_rsc);
+
+            % Report to shrunken head.
+            shrunken = Send(self,@FindHolding,#class=&ShrunkenHead);
+            if shrunken <> $
+            {
+               Send(shrunken,@Improvement,#spellName=spellName);
+            }
          }
       }
 
@@ -8089,7 +8098,7 @@ messages:
    ChangeSkillAbility(Skill_num=0,amount=0,report=FALSE,refigureschools=TRUE,bDM=FALSE)
    {
       local i, bFound, elemnum, iability, bUsed, iChange, skillname, 
-            newability, oSkill, oRoom;
+            newability, oSkill;
 
       oSkill = Send(SYS,@FindSkillByNum,#num=skill_num);
       if oSkill = $
@@ -8144,16 +8153,19 @@ messages:
       Send(self,@DrawStatSkill,#index=elemnum);
       if report AND (iChange > 0)
       {
-         oRoom = Send(self, @GetOwner);
-         Post(self,@MsgSendUser,#message_rsc=player_improved,#parm1=skillName);
-         Send(oRoom, @SomethingWaveRoom, #what=self, 
-              #wave_rsc=player_improved_wav_rsc);
+         if poOwner <> $
+         {
+            Post(self,@MsgSendUser,#message_rsc=player_improved,
+                  #parm1=skillName);
+            Send(poOwner,@SomethingWaveRoom,#what=self,
+                  #wave_rsc=player_improved_wav_rsc);
+         }
       }
 
       Send(self,@PlayerIsIntriguing);
 
       if refigureschools
-      {    
+      {
          Send(self,@AddToSchools,#school=Send(oSkill,@GetSchool),
                #change=iChange);
       }
@@ -8569,14 +8581,14 @@ messages:
          monster_level = Send(what,@GetLevel);
       }
 
-      if (Send(self,@CheckPlayerFlag,#flag=PFLAG_DID_DAMAGE)
+      if (piFlags & PFLAG_DID_DAMAGE)
          AND poKill_target = what)
          OR group_member_kill
       {
          % Allow players to improve defensive spells!
          if killing_blow 
-            AND (Send(self,@CheckPlayerFlag,#flag=PFLAG_TOOK_DAMAGE)
-               OR Send(self,@CheckPlayerFlag,#flag=PFLAG_DODGED))
+            AND ((piFlags & PFLAG_TOOK_DAMAGE)
+               OR (piFlags & PFLAG_DODGED))
          {
             for i in plPassiveImprovement
             {
@@ -8590,8 +8602,8 @@ messages:
          if monster_level > piBase_Max_health
          {
             if killing_blow
-               AND (Send(self,@CheckPlayerFlag,#flag=PFLAG_TOOK_DAMAGE)
-                  OR Send(self,@CheckPlayerFlag,#flag=PFLAG_DODGED))
+               AND ((piFlags & PFLAG_TOOK_DAMAGE)
+                  OR (piFlags & PFLAG_DODGED))
             {
                % Player took damage and landed killing blow
                gain = 2;
@@ -8643,8 +8655,8 @@ messages:
             %  no roll chance.
             if (monster_level + 5) > piBase_Max_health
                AND IsClass(what,&monster) AND killing_blow 
-               AND (Send(self,@CheckPlayerFlag,#flag=PFLAG_TOOK_DAMAGE)
-                  OR Send(self,@CheckPlayerFlag,#flag=PFLAG_DODGED))
+               AND ((piFlags & PFLAG_TOOK_DAMAGE)
+                  OR (piFlags & PFLAG_DODGED))
             {
                gain = 1;
             }
@@ -8677,8 +8689,8 @@ messages:
                AND NOT group_member_kill
                AND killing_blow
                AND (monster_level + 5) > piBase_Max_health
-               AND (Send(self,@CheckPlayerFlag,#flag=PFLAG_TOOK_DAMAGE)
-                  OR Send(self,@CheckPlayerFlag,#flag=PFLAG_DODGED))
+               AND ((piFlags & PFLAG_TOOK_DAMAGE)
+                  OR (piFlags & PFLAG_DODGED))
             {
                gain = gain + 1;
             }
@@ -8817,7 +8829,7 @@ messages:
          }
       }
 
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_DODGED)
+      if (piFlags & PFLAG_DODGED)
          AND NOT group_member_kill
       {
          oWeapon = Send(self,@LookupPlayerWeapon);
@@ -9264,8 +9276,8 @@ messages:
       }
 
       if piDeathCost > 0
-         AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_TUTORIAL)
-         AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
+         AND NOT (piFlags & PFLAG_TUTORIAL)
+         AND NOT (piFlags & PFLAG_MURDERER)
       {
          % Give an encouraging gmail and some mana to broadcast.
          Send(self,@ReceiveNestedMail,#from=player_angel,
@@ -9322,7 +9334,7 @@ messages:
          Send(self,@SetPlayerFlag,#flag=PFLAG_OUTLAW,#value=FALSE);
          Post(self,@EvaluatePKStatus);
 
-         if Send(self,@CheckPlayerFlag,#flag=PFLAG_HAUNTED)
+         if (piFlags & PFLAG_HAUNTED)
          {
             if pbLogged_on
             {
@@ -9336,8 +9348,8 @@ messages:
       % Only do this stuff if the cost of death is not zero.
       if piDeathCost > 0
       {
-         if NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_TUTORIAL)
-            AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
+         if NOT (piFlags & PFLAG_TUTORIAL)
+            AND NOT (piFlags & PFLAG_MURDERER)
          {
             piDeathCost = piDeathCost / 3;
          }
@@ -9392,7 +9404,7 @@ messages:
       % Lose some skill or spell proficiency.
 
       % Murderers get hit harder.
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
+      if (piFlags & PFLAG_MURDERER)
       {
          iAmount = -2;
       }
@@ -12222,17 +12234,17 @@ messages:
    {
       local i, ass_game;
 
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_LOCK)
+      if (piFlags & PFLAG_PKILL_LOCK)
       {
          return FALSE;
       }
 
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+      if (piFlags & PFLAG_PKILL_ENABLE)
       {
          if poGuild = $
             AND piBase_Max_health < Send(Send(SYS,@GetSettings),@GetPKillEnableHP)
-            AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
-            AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
+            AND NOT (piFlags & PFLAG_MURDERER)
+            AND NOT (piFlags & PFLAG_OUTLAW)
          {
             ass_game = Send(SYS,@GetAssassinGame);
             if Send(ass_game,@IsCombatant,#who=self)
@@ -12251,8 +12263,8 @@ messages:
       {
          if poGuild <> $
             OR piBase_Max_health >= Send(Send(SYS,@GetSettings),@GetPKillEnableHP)
-            OR Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
-            OR Send(self,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
+            OR (piFlags & PFLAG_MURDERER)
+            OR (piFlags & PFLAG_OUTLAW)
          {
             if Send(SYS,@IsPKAllowed)
             {
@@ -12557,7 +12569,7 @@ messages:
          return FALSE;
       }
 
-      wasint = Send(self,@CheckPlayerFlag,#flag=PFLAG_INTRIGUING);
+      wasint = (piFlags & PFLAG_INTRIGUING);
 
       if wasint AND Send(oParl,@IsShutdown)
       {
@@ -12587,7 +12599,7 @@ messages:
          return FALSE;
       }
 
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+      if (piFlags & PFLAG_PKILL_ENABLE)
          AND (Send(self,@PlayerIsHPIntrigue)
               OR Send(self,@PlayerIsAdept))
       {
@@ -12974,7 +12986,7 @@ messages:
 
    CheckLog()
    {
-      return (Send(self,@CheckPlayerFlag,#flag=PFLAG_LOG));
+      return (piFlags & PFLAG_LOG);
    }
 
    DecayPKillCount()
@@ -13022,8 +13034,8 @@ messages:
       }
 
       if IsClass(oRoom,&GuildHall)
-         AND (NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
-            OR Send(self,@CheckPlayerFlag,#flag=PFLAG2_TEMPSAFE,#flagset=2))
+         AND (NOT (piFlags & PFLAG_PKILL_ENABLE)
+            OR (piFlags & PFLAG2_TEMPSAFE))
       {
          Send(self,@MsgSendUser,#message_rsc=player_no_enter);
 
@@ -13395,7 +13407,7 @@ messages:
 
    IsInvisible()
    {
-      return Send(self,@CheckPlayerFlag,#flag=PFLAG_INVISIBLE);
+      return (piFlags & PFLAG_INVISIBLE);
    }
 
    IsShadowForm()
@@ -13405,7 +13417,7 @@ messages:
 
    IsMorphed()
    {
-      return Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED);
+      return (piFlags & PFLAG_MORPHED);
    }
 
    %%% Get Color Routines
@@ -14012,10 +14024,10 @@ messages:
       }
 
       piBound_Room = Send(poOwner,@GetRoomNum);
-      piBound_row = Send(self,@GetRow);
-      piBound_col = Send(self,@GetCol);
-      piBound_fine_row = Send(self,@GetFineRow);
-      piBound_fine_col = Send(self,@GetFineCol);
+      piBound_row = piRow;
+      piBound_col = piCol;
+      piBound_fine_row = piFine_row;
+      piBound_fine_col = piFine_col;
       piBound_angle = Send(self,@GetAngle);
 
       return;
@@ -14520,8 +14532,8 @@ messages:
 
    GetBasePhaseTime()
    {
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
-         OR Send(self,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
+      if (piFlags & PFLAG_MURDERER)
+         OR (piFlags & PFLAG_OUTLAW)
       {
          return Send(Send(SYS,@GetSettings),
                @GetOutlawMurdererLogoffPenaltyGhostTime);
@@ -14600,25 +14612,20 @@ messages:
    
    DoPvpNotify()
    {
-      local oRoom;
-
       % Don't gong if we are already in pvp
       if piTimeAttackedPlayer < GetTime() - PVP_NOTIFY_DECAY
       {
-         oRoom = Send(self, @GetOwner);
-         
-         if oRoom <> $
+         if poOwner <> $
          {
-            Send(oRoom, @SomethingWaveRoom, #what=self,
-               #wave_rsc=pvp_notify_wav);
-               
+            Send(poOwner,@SomethingWaveRoom,#what=self,
+                  #wave_rsc=pvp_notify_wav);
             piTimeAttackedByPlayer = GetTime();
          }
       }
 
       return;
    }
-   
+
    % Use this for when either phase or spectator do the same thing
    IsInCannotInteractMode()
    {

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -512,14 +512,14 @@ messages:
    {
       % Send a blank string if we're anonymous, if we're a blank or if we're
       %  a hidden admin.
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_ANONYMOUS)
+      if (piFlags & PFLAG_ANONYMOUS)
          OR vrIcon = admin_icon_blank
          OR (IsClass(self,&DM) AND Send(self,@IsHidden))
       {         
          return Send(self,@GetBlankName);
       }
 
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (piFlags & PFLAG_MORPHED)
          AND poIllusion_set <> $
       {
          return Send(poIllusion_set,@IllusionGetName,#who=self);
@@ -530,7 +530,7 @@ messages:
 
    GetDef()
    {
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (piFlags & PFLAG_MORPHED)
          AND poIllusion_set <> $
       {
          return Send(poIllusion_set,@IllusionGetDef,#who=self);
@@ -541,7 +541,7 @@ messages:
    
    GetCapDef()
    {
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (piFlags & PFLAG_MORPHED)
          AND poIllusion_set <> $
       {
          return Send(poIllusion_set,@IllusionGetCapDef,#who=self);
@@ -552,7 +552,7 @@ messages:
 
    GetIndef()
    {
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (piFlags & PFLAG_MORPHED)
          AND poIllusion_set <> $
       {
          return Send(poIllusion_set,@IllusionGetIndef,#who=self);
@@ -563,7 +563,7 @@ messages:
 
    GetHisHer()
    {
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (piFlags & PFLAG_MORPHED)
          AND poIllusion_set <> $
       {
          return Send(poIllusion_set,@IllusionGetHisHer,#who=self);
@@ -574,7 +574,7 @@ messages:
 
    GetCapIndef()
    {
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (piFlags & PFLAG_MORPHED)
          AND poIllusion_set <> $
       {
          return Send(poIllusion_set,@IllusionGetCapIndef,#who=self);
@@ -587,13 +587,13 @@ messages:
    {
       local rName;
       
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (piFlags & PFLAG_MORPHED)
          AND poIllusion_set <> $
-      {            
+      {
          return Send(poIllusion_set,@IllusionGetName,#who=self);
       }
 
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_ANONYMOUS)
+      if (piFlags & PFLAG_ANONYMOUS)
       {
          if cap
          {
@@ -1684,9 +1684,9 @@ messages:
          {
             Send(self,@SetPlayerFlag,#flag=PFLAG_TEMP_SAFETY,#value=TRUE);
 
-            if Send(self,@GetBaseMaxHealth) > 99
-               OR Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
-               OR Send(self,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
+            if piBase_max_health > 99
+               OR (piFlags & PFLAG_MURDERER)
+               OR (piFlags & PFLAG_OUTLAW)
                OR Send(self,@FindUsing,#class=&SoldierShield) <> $
             {
                Send(self,@MsgSendUser,#message_rsc=user_temp_safe_invalid);
@@ -1700,9 +1700,9 @@ messages:
          {
             Send(self,@SetPlayerFlag,#flag=PFLAG_TEMP_SAFETY,#value=FALSE);
 
-            if Send(self,@GetBaseMaxHealth) > 99
-               OR Send(self,@CheckPlayerFlag,#flag=PFLAG_MURDERER)
-               OR Send(self,@CheckPlayerFlag,#flag=PFLAG_OUTLAW)
+            if piBase_max_health > 99
+               OR (piFlags & PFLAG_MURDERER)
+               OR (piFlags & PFLAG_OUTLAW)
                OR Send(self,@FindUsing,#class=&SoldierShield) <> $
             {
                Send(self,@MsgSendUser,#message_rsc=user_temp_safe_invalid);
@@ -2493,7 +2493,7 @@ messages:
       iFlags = Send(what,@GetObjectFlags);
       % If we can see the invisible object, remove its invis drawing flag
       % and set it to flash instead (in object flags).
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG2_DETECT_INVIS,#flagset=2)
+      if (piFlags2 & PFLAG2_DETECT_INVIS)
          AND (iDrawingFlags & DRAWFX_MASK) = DRAWFX_INVISIBLE
       {
          iDrawingFlags = (iDrawingFlags & (~DRAWFX_MASK));
@@ -2506,7 +2506,7 @@ messages:
          iEnemyKarma = Send(what,@GetKarma,#detect=TRUE);
          iSelfKarma = Send(self,@GetKarma);
 
-         if Send(self,@CheckPlayerFlag,#flag=PFLAG2_DETECT_EVIL,#flagset=2)
+         if (piFlags2 & PFLAG2_DETECT_EVIL)
             AND iSelfKarma > 0
             AND iEnemyKarma < -10
             AND (IsClass(what,&Player)
@@ -2516,7 +2516,7 @@ messages:
             iFlags = (iFlags | OF_FLASHING);
          }
 
-         if Send(self,@CheckPlayerFlag,#flag=PFLAG2_DETECT_GOOD,#flagset=2)
+         if (piFlags2 & PFLAG2_DETECT_GOOD)
             AND iSelfKarma < 0
             AND iEnemyKarma > 10
             AND (IsClass(what,&Player)
@@ -3474,7 +3474,7 @@ messages:
       }
 
       % Do not allow angle changes while we are immobile.
-      if Send(self,@CheckPlayerflag,#flag=PFLAG_NO_MOVE)
+      if (piFlags & PFLAG_NO_MOVE)
          AND ((NOT Send(self,@IsResting))
               OR Send(self,@IsEnchanted,#byClass=&Hold))
       {
@@ -4385,7 +4385,7 @@ messages:
 
       if type = SAY_NORMAL
       {
-         If StringContain(String,"start solo survival")
+         if StringContain(String,"start solo survival")
          {
             lSurvivalOptions = $;
             if NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
@@ -4400,10 +4400,10 @@ messages:
             return;
          }
 
-         If StringContain(String,"start guild survival")
+         if StringContain(String,"start guild survival")
          {
             lSurvivalOptions = $;
-            if Send(self,@GetGuild) = $
+            if poGuild = $
             {
                Send(self,@MsgSendUser,#message_rsc=survival_err_no_guild);
                return;
@@ -4417,7 +4417,7 @@ messages:
             }
             
             if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindRoomByGuild,
-                     #oGuild=Send(self,@GetGuild)) = $
+                     #oGuild=poGuild) = $
             {
                Send(Send(SYS,@GetSurvivalRoomMaintenance),@CreateRoom,
                          #who=self,#guild_survival=TRUE);
@@ -4430,7 +4430,7 @@ messages:
             return;
          }
 
-         If StringContain(String,"start public survival")
+         if StringContain(String,"start public survival")
          {
             lSurvivalOptions = $;
             if (NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
@@ -4473,9 +4473,9 @@ messages:
             return;
          }
 
-         If StringEqual(String,"join guild survival")
+         if StringEqual(String,"join guild survival")
          {
-            if Send(self,@GetGuild) = $
+            if poGuild = $
             {
                Send(self,@MsgSendUser,#message_rsc=survival_err_no_guild);
                return;
@@ -4489,18 +4489,18 @@ messages:
             }
             
             if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindRoomByGuild,
-                     #oGuild=Send(self,@GetGuild)) = $
+                     #oGuild=poGuild) = $
             {
                Send(self,@MsgSendUser,#message_rsc=survival_no_guild_rooms);
                return;
             }
 
             if Send(Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                    @FindRoomByGuild,#oGuild=Send(self,@GetGuild)),
+                    @FindRoomByGuild,#oGuild=poGuild),
                     @GetAllowJoins)
             {
                Send(Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                    @FindRoomByGuild,#oGuild=Send(self,@GetGuild)),
+                    @FindRoomByGuild,#oGuild=poGuild),
                     @Teleport,#what=self);
             }
             else
@@ -4510,7 +4510,7 @@ messages:
             return;
          }
 
-         If StringEqual(String,"join public survival")
+         if StringEqual(String,"join public survival")
          {
             if NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
                OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
@@ -4540,7 +4540,7 @@ messages:
             return;
          }
          
-         If StringContain(String,"autocombine on")
+         if StringContain(String,"autocombine on")
             AND NOT Send(self,@IsAutoCombining)
          {
             Send(self,@SetAutoCombine,#value=TRUE);
@@ -4548,7 +4548,7 @@ messages:
             return;
          }
 
-         If StringContain(String,"autocombine off")
+         if StringContain(String,"autocombine off")
             AND Send(self,@IsAutoCombining)
          {
             Send(self,@SetAutoCombine,#value=FALSE);
@@ -4556,7 +4556,7 @@ messages:
             return;
          }
 
-         If StringContain(String,"autoloot on")
+         if StringContain(String,"autoloot on")
             AND NOT Send(self,@IsAutolooting)
          {
             Send(self,@SetAutoloot,#value=TRUE);
@@ -4564,7 +4564,7 @@ messages:
             return;
          }
 
-         If StringContain(String,"autoloot off")
+         if StringContain(String,"autoloot off")
             AND Send(self,@IsAutolooting)
          {
             Send(self,@SetAutoloot,#value=FALSE);
@@ -4572,7 +4572,7 @@ messages:
             return;
          }
 
-         If StringContain(String,"reagentbag on")
+         if StringContain(String,"reagentbag on")
             AND NOT Send(self,@GetReagentBagAuto)
          {
             Send(self,@SetReagentBagAuto,#value=TRUE);
@@ -4580,7 +4580,7 @@ messages:
             return;
          }
 
-         If StringContain(String,"reagentbag off")
+         if StringContain(String,"reagentbag off")
             AND Send(self,@GetReagentBagAuto)
          {
             Send(self,@SetReagentBagAuto,#value=FALSE);
@@ -4598,20 +4598,20 @@ messages:
       if type = SAY_GUILD
       {
          if StringContain(string,guild_motd_command)
-            AND Send(self,@GetGuild) <> $
-            AND (Send(Send(self,@GetGuild),@GetRank,#who=self) = RANK_MASTER
-                OR Send(Send(self,@GetGuild),@GetRank,#who=self) = RANK_LIEUTENANT)
+            AND poGuild <> $
+            AND (Send(poGuild,@GetRank,#who=self) = RANK_MASTER
+                OR Send(poGuild,@GetRank,#who=self) = RANK_LIEUTENANT)
          {
-            Send(Send(self,@GetGuild),@SetGuildMOTD,#who=self,#string=string);
+            Send(poGuild,@SetGuildMOTD,#who=self,#string=string);
             return;
          }
          if StringContain(string,guild_clear_motd_command)
-            AND Send(self,@GetGuild) <> $
-            AND Send(Send(self,@GetGuild),@GetGuildMaster) = self
-            AND (Send(Send(self,@GetGuild),@GetRank,#who=self) = RANK_MASTER
-                OR Send(Send(self,@GetGuild),@GetRank,#who=self) = RANK_LIEUTENANT)
+            AND poGuild <> $
+            AND Send(poGuild,@GetGuildMaster) = self
+            AND (Send(poGuild,@GetRank,#who=self) = RANK_MASTER
+                OR Send(poGuild,@GetRank,#who=self) = RANK_LIEUTENANT)
          {
-            Send(Send(self,@GetGuild),@SetGuildMOTD,#who=self,#string=$);
+            Send(poGuild,@SetGuildMOTD,#who=self,#string=$);
             return;
          }
 
@@ -4630,7 +4630,7 @@ messages:
          OR type = SAY_EMOTE
          OR type = SAY_DM
       {
-         if Send(self,@CheckPlayerFlag,#flag=PFLAG_TRANCE)
+         if (piFlags & PFLAG_TRANCE)
          {
             % See if the trance spell does anything special 
             %  with says.  Note that the 'say' will still go off.
@@ -5319,7 +5319,7 @@ messages:
          Send(self,@BreakTrance,#event=EVENT_ATTACK);
       }
 
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_NO_FIGHT)
+      if (piFlags & PFLAG_NO_FIGHT)
       {
          Send(self,@MsgSendUser,#message_rsc=user_no_fight);
 
@@ -5421,7 +5421,7 @@ messages:
          Send(self,@BreakTrance,#event=EVENT_CAST,#what=oSpell);
       }
 
-      if (Send(self,@CheckPlayerFlag,#flag=PFLAG_NO_MAGIC)
+      if (piFlags & PFLAG_NO_MAGIC)
          OR Send(self,@IsInCannotInteractMode))
          AND NOT IsClass(oSpell,&Phase)
       {
@@ -6315,7 +6315,7 @@ messages:
    {
       local bCanGo;
 
-      if Send(self,@CheckPlayerflag,#flag=PFLAG_NO_MOVE)
+      if (piFlags & PFLAG_NO_MOVE)
          OR Send(self,@IsEnchanted,#byClass=&Blind)
       {         
          Send(self,@MsgSendUser,#message_rsc=user_cant_go);
@@ -6756,7 +6756,7 @@ messages:
       %  one, then tell him he's safe again.  Ignore during chaos night.
 
       if NOT Send(SYS,@GetChaosNight)
-         AND NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+         AND NOT (piFlags & PFLAG_PKILL_ENABLE)
       {
          if Send(what,@CheckRoomFlag,#flag=ROOM_KILL_ZONE)
             AND (poOwner = $
@@ -6821,7 +6821,7 @@ messages:
       % This is intended to protect players from wall spells stacked on entrances. It will clear
       % out a small space when they enter the zone, so that they don't appear in the middle of a wall spell.
       if old <> $
-         AND Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+         AND (piFlags & PFLAG_PKILL_ENABLE)
          AND Send(poOwner,@AllowGuildAttack,#what=self)
          AND NOT IsClass(self,&DM)
       {
@@ -7306,7 +7306,7 @@ messages:
       }
 
       if what = self
-         AND Send(self,@CheckPlayerFlag,#flag=PFLAG2_DANCING,#Flagset=2)
+         AND (piFlags2 & PFLAG2_DANCING)
       {
          Send(self,@StopDancing);
       }
@@ -8621,7 +8621,7 @@ messages:
       }
 
       % Angeled characters cannot block other players.
-      if NOT Send(self,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+      if NOT (piFlags & PFLAG_PKILL_ENABLE)
       {
          iFlags = (iFlags & ~MOVEON_NO);
       }
@@ -8682,7 +8682,7 @@ messages:
       oIllusion = Send(self,@GetIllusionForm);
 
       % If we're morphed, get rid of any "player" flags
-      if Send(self,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
+      if (piFlags & PFLAG_MORPHED)
          AND oIllusion <> $
          AND IsClass(oIllusion,&Monster)
       {
@@ -9142,7 +9142,7 @@ messages:
       % We're not moving if it's been more than 2 seconds since we moved
       %   OR if we're flagged as unable to move.
       if (GetTime() - piLastMoveUpdateTime) > 2
-         OR Send(self,@CheckPlayerFlag,#flag=PFLAG_NO_MOVE)
+         OR (piFlags & PFLAG_NO_MOVE)
       {
          return FALSE;
       }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -443,7 +443,7 @@ properties:
 
    % The ms tick we received last position update from user
    piLastMoveUpdateTime = 0
-   
+
    % The ms tick we last drained vigor
    piLastVigorDrainTime = 0
 
@@ -3198,7 +3198,7 @@ messages:
       % 2. Do not allow any moves if player is marked as not allowed to move
       %
 
-      if Send(self,@CheckPlayerflag,#flag=PFLAG_NO_MOVE)
+      if (piFlags & PFLAG_NO_MOVE)
       {
          % Reset position
          Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
@@ -3224,31 +3224,31 @@ messages:
 
       %
       % 3.3 Bound time-deltas
-      %   These must not be too big for the calculations blow
+      %   These must not be too big for the calculations below
       %
-      iDelta = bound(iDelta,0,2000);
+      iDelta = Bound(iDelta,0,2000);
       iDeltaVigor = bound(iDeltaVigor,0,2000);
-	  
+
       %
       % 4.1 Calculate the squared movesize for running in this dt.
       %   USER_RUNNING_SPEED is defined as # of big squares per 10000ms
       %   The unit here is fine upscaled by another *16 (same is done below in 4.5)
       %
-      iMaxMoveRun = (USER_RUNNING_SPEED * FINENESS * 16 * iDelta) / 10000;
+      iMaxMoveRun = (Bound(speed,0,50) * FINENESS * 16 * iDelta) / 10000;
       iMaxMoveRun = (iMaxMoveRun * iMaxMoveRun);
-  
+
       %
       % 4.2 Fill up the movement bucket with tokens
       %   for the squared distance one could have travelled at maximum.
       %
-      piMovementBucket = piMovementBucket + iMaxMoveRun;        
+      piMovementBucket = piMovementBucket + iMaxMoveRun;
 
       %
       % 4.3 Bound the maximum bucketsize
       %
-      piMovementBucket = bound(piMovementBucket, 0, Send(Send(SYS, @GetSettings), @GetMovementBucketMax));
+      piMovementBucket = Bound(piMovementBucket, 0, Send(Send(SYS,@GetSettings),@GetMovementBucketMax));
       %Debug("Bucket before move:",piMovementBucket);
-			
+
       %
       % 4.4 Get move-deltas in FINENESS units
       %
@@ -3306,13 +3306,28 @@ messages:
       }
 
       %
-      % 5.2 This move is bigger than walking allows.
-      % Right now: Still use the transmitted speed
+      % 5.2 Double check the user's speed. USER_WALKING_SPEED should
+      % be 25, USER_RUNNING_SPEED should be 50. If the speed we've
+      % received is less than 25, make it 50 and log that we've
+      % changed it.
+      %
+
+      if speed < USER_WALKING_SPEED
+         OR speed > USER_RUNNING_SPEED
+      {
+         Debug("ALERT! ",Send(self,@GetTrueName),self,
+               " had transmitted speed changed from ",speed, "to ",
+               USER_RUNNING_SPEED);
+         speed = USER_RUNNING_SPEED;
+      }
+
+      %
+      % 5.3 This move is bigger than walking allows.
       %
       if (speed > USER_WALKING_SPEED)
       {
          % Disallow run with low vigor
-         if Send(self,@GetVigor) < VIGOR_RUN_THRESHOLD
+         if piVigor < VIGOR_RUN_THRESHOLD
          {
             % Reset position
             Send(SYS,@UtilGoNearSquare,#what=self,#where=poOwner,
@@ -3340,14 +3355,14 @@ messages:
          }
 
          % Stop dance
-         if Send(self,@CheckPlayerFlag,#flag=PFLAG2_DANCING,#flagset=2)
+         if (piFlags2 & PFLAG2_DANCING)
          {
             Send(self,@StopDancing);
          }
       }
 
       %
-      % 5.3 Manual move checks in some rooms
+      % 5.4 Manual move checks in some rooms
       %
       iRoomNum = Send(poOwner,@GetRoomNum);
       if iRoomNum = RID_CAVE2
@@ -3385,10 +3400,10 @@ messages:
          iExertion = iExertion * iExertion;
          iExertion = EXERTION_PER_MOVE * iExertion;
 
-         if Send(self,@CheckPlayerFlag,#flag=PFLAG2_HASTED,#flagset=2)
+         if (piFlags2 & PFLAG2_HASTED)
          {
             iHasteLevel = Send(self,@GetEnchantedState,
-                               #what=Send(SYS,@FindSpellByNum,#num=SID_HASTE));
+                              #what=Send(SYS,@FindSpellByNum,#num=SID_HASTE));
 
             if iHasteLevel <> $
             {
@@ -3400,7 +3415,6 @@ messages:
 
          % Save vigor drain tick
          piLastVigorDrainTime = iCurrentTime;
-
       }
 
       %
@@ -3414,11 +3428,12 @@ messages:
       %
       % 8. Save this move tick for next execution
       % and subtract the move tokens we have consumed.
+      %
       piLastMoveUpdateTime = iCurrentTime;
       piMovementBucket = piMovementBucket - iMoveLength;
       %Debug("Bucket after:",piMovementBucket);
 
-	  %
+      %
       % 9. Process the move
       %
       Send(poOwner,@SomethingMoved,#what=self,

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -4440,7 +4440,7 @@ messages:
                Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
                return;
             }
-            
+
             poForceBaseRoom = $;
             if IsClass(self,&DM)
             {
@@ -4454,8 +4454,16 @@ messages:
                }
                if StringContain(String,"--thisbase")
                {
-                 poForceBaseRoom = poOwner;
+                  poForceBaseRoom = poOwner;
                }
+            }
+
+            if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindPublicRoom) = $
+            {
+               Send(Send(SYS,@GetSurvivalRoomMaintenance),@CreateRoom,
+                         #who=self,#iPublic=TRUE,#sString=string,
+                         #lSurvivalOptions=lSurvivalOptions,
+                         #poForceBaseRoom=poForceBaseRoom);
             }
             
             if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindPublicRoom) = $
@@ -5421,7 +5429,7 @@ messages:
          Send(self,@BreakTrance,#event=EVENT_CAST,#what=oSpell);
       }
 
-      if (piFlags & PFLAG_NO_MAGIC)
+      if ((piFlags & PFLAG_NO_MAGIC)
          OR Send(self,@IsInCannotInteractMode))
          AND NOT IsClass(oSpell,&Phase)
       {

--- a/kod/object/active/holder/room/monsroom/survivalroom.kod
+++ b/kod/object/active/holder/room/monsroom/survivalroom.kod
@@ -958,6 +958,7 @@ messages:
 
          if plParticipants <> $
             AND Length(plParticipants) = 1
+            AND plLevelGoals <> $
          {
             % Finish it up if only one guy remains in a public room.
             if piPublic
@@ -968,6 +969,7 @@ messages:
                   if IsClass(oMonster,&Monster)
                      AND (NOT Send(oMonster,@IsOwnedByPlayer))
                      AND oMonster <> victim
+                     AND Random(1,2) = 1
                   {
                      oTarget = First(plParticipants);
                      Send(oMonster,@TargetSwitch,#what=oTarget,#iHatred=100);
@@ -978,11 +980,8 @@ messages:
             else
             {
                % Aggro one mob on the player.
-               if plLevelGoals <> $
-               {
-                  Send(self,@AggroOne,#who=(First(plParticipants)),
-                        #victim=victim);
-               }
+               Send(self,@AggroOne,#who=(First(plParticipants)),
+                     #victim=victim);
             }
          }
       }
@@ -1109,7 +1108,7 @@ messages:
                
                plParticipants = Cons(what,plParticipants);
                
-               Send(self,@AggroSome,#who=what);
+               Post(self,@AggroSome,#who=what);
 
                propagate;
             }

--- a/kod/object/passive/spell/SUMMTWIN.KOD
+++ b/kod/object/passive/spell/SUMMTWIN.KOD
@@ -69,10 +69,9 @@ messages:
       return 1;
    }
 
-
    CanPayCosts(who=$,lTargets=$)
    {
-      local  oTarget, oRoom;
+      local oTarget, oRoom;
 
       oTarget = First(lTargets);
 
@@ -93,8 +92,9 @@ messages:
          % all not valid targets
 
          Send(who,@MsgSendUser,#message_rsc=summonEvilTwin_bad_target,
-              #parm1=Send(oTarget,@GetDef),
-              #parm2=Send(oTarget,@GetName));
+               #parm1=Send(oTarget,@GetDef),
+               #parm2=Send(oTarget,@GetName));
+
          return FALSE;
       }
 
@@ -142,8 +142,14 @@ messages:
    {
       local i, j, oTwin, oRoom, iRow, iCol, iFine_Row, iFine_Col, oTarget;
 
+      % Monster casters can rarely end up with $ target.
+      if lTargets = $
+      {
+         return;
+      }
+
       oTarget = First(lTargets);
-      
+
       if IsClass(oTarget,&Player)
       {
          oTwin = Create(&EvilTwin,#iSpellpower=iSpellpower,#oMaster=who,

--- a/kod/util/survivalmaint.kod
+++ b/kod/util/survivalmaint.kod
@@ -75,7 +75,7 @@ messages:
       return;
    }
    
-   CreateRoom(who=$,guild_survival=FALSE,iPublic=FALSE,
+   CreateRoom(who=$,guild_survival=FALSE,iPublic=FALSE,sString=$,
               lSurvivalOptions=$,poForceBaseRoom=$)
    {
       local poRoom, poBaseRoom, plAllRooms, iRID, i, plPlayersLoggedOn, z,
@@ -114,9 +114,25 @@ messages:
             iPvP = TRUE;
          }
       }
-      
+
       plAllRooms = Send(SYS,@ListCopy,#source=Send(SYS,@GetRooms));
-      
+
+      % If we sent the string used to activate the arena (only for public)
+      % check it for a room name to use. If we sent a room name, use that
+      % for the survival room.
+      if sString <> $
+      {
+         for i in plAllRooms
+         {
+            if StringContain(sString,Send(i,@GetName))
+            {
+               poForceBaseRoom = i;
+
+               break;
+            }
+         }
+      }
+
       plExcludedRoomsObjs = $;
       for z in plExcludedRoomsList
       {
@@ -124,8 +140,20 @@ messages:
                                     plExcludedRoomsObjs);
       }
 
-      poBaseRoom = Nth(plAllRooms,Random(1,Length(plAllRooms)));
-      
+      % DMs can choose any room, but users can only pick from the allowed
+      % rooms.  Set poBaseRoom to the chosen room so it can be checked
+      % in the following code.
+      if NOT IsClass(who,&DM)
+         AND poForceBaseRoom <> $
+      {
+         poBaseRoom = poForceBaseRoom;
+         poForceBaseRoom = $;
+      }
+      else
+      {
+         poBaseRoom = Nth(plAllRooms,Random(1,Length(plAllRooms)));
+      }
+
       % Ensure it's a monster room, and shrink the list on every failure.
       if (NOT IsClass(poBaseRoom,&MonsterRoom))
          OR IsClass(poBaseRoom,&SurvivalRoom)
@@ -143,17 +171,19 @@ messages:
             poBaseRoom = Nth(plAllRooms,Random(1,Length(plAllRooms)));
          }
       }
-      
+
       if NOT IsClass(poBaseRoom,&MonsterRoom)
       {
          return $;
       }
-      
+
+      % If we still have a forced base room, it was given by a DM.
+      % Set the base room to the forced one.
       if poForceBaseRoom <> $
       {
          poBaseRoom = poForceBaseRoom;
       }
-      
+
       iRID = Send(self,@GetNextAvailableRID);
       
       if iRID = 0


### PR DESCRIPTION
Fix an error in the TP calculation for survival arenas - should divide rather than multiply by the survival TP increase level.

Added a target $ check to CastSpell in SummonEvilTwin, rarely a monster will try to cast this with $ target.