### PR TITLE
Minor error fixes.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -716,6 +716,8 @@ messages:
          ptUnturn = $;
       }
 
+      poLastAttacker = $;
+
       propagate;
    }
 

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -60,7 +60,7 @@ constants:
 
    % Speedhack/cheating detection:
    % What's the maximum number of times we should log a violation?
-   MAX_LOGGED_THRESHOLD = 25
+   MAX_LOGGED_THRESHOLD = 50
 
 resources:
 
@@ -3315,9 +3315,14 @@ messages:
       if speed < USER_WALKING_SPEED
          OR speed > USER_RUNNING_SPEED
       {
-         Debug("ALERT! ",Send(self,@GetTrueName),self,
-               " had transmitted speed changed from ",speed, "to ",
-               USER_RUNNING_SPEED);
+         % Make a log entry
+         if piCheaterLogs < MAX_LOGGED_THRESHOLD
+         {
+            piCheaterLogs = piCheaterLogs + 1;
+            Debug("ALERT! ",Send(self,@GetTrueName),self,
+                  " had transmitted speed changed from ",speed, "to ",
+                  USER_RUNNING_SPEED);
+         }
          speed = USER_RUNNING_SPEED;
       }
 

--- a/kod/object/active/holder/room/monsroom/survivalroom.kod
+++ b/kod/object/active/holder/room/monsroom/survivalroom.kod
@@ -970,10 +970,15 @@ messages:
                      AND (NOT Send(oMonster,@IsOwnedByPlayer))
                      AND oMonster <> victim
                      AND Random(1,2) = 1
+                     AND plParticipants <> $ % Sometimes $ by this stage?
                   {
                      oTarget = First(plParticipants);
-                     Send(oMonster,@TargetSwitch,#what=oTarget,#iHatred=100);
-                     Send(oMonster,@EnterStateChase,#target=oTarget,#actnow=True);
+                     if oTarget <> $
+                     {
+                        Send(oMonster,@TargetSwitch,#what=oTarget,#iHatred=100);
+                        Send(oMonster,@EnterStateChase,#target=oTarget,
+                              #actnow=True);
+                     }
                   }
                }
             }


### PR DESCRIPTION
-Set poLastAttacker to $ on monster deletion.
-Increase MAX_LOGGED_THRESHOLD for piCheaterLogs to 50 (up from 25).
Increment piCheaterLogs for transmitted speed changes.
-More checks for $ list/object in SurvivalRoom; sometimes the
plParticipants list is $ and this causes some errors.