### PR TITLE
Fix error in placing wall elements due to bad handling of player angle, misc. bug fixes.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
@@ -154,7 +154,11 @@ messages:
          }
       }
 
-      plAttackers = Cons(what,plAttackers);
+      if what <> $
+         AND IsClass(what,&Battler)
+      {
+         plAttackers = Cons(what,plAttackers);
+      }
 
       propagate;
    }

--- a/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
@@ -134,6 +134,13 @@ messages:
       propagate;
    }
 
+   Delete()
+   {
+      plAttackers = $;
+
+      propagate;
+   }
+
    AssessDamage(what = $,damage = $,atype = 0, aspell = 0,bonus = 0)
    "This is called when something causes damage to us"
    {

--- a/kod/object/active/holder/nomoveon/battler/monster/orcboss.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/orcboss.kod
@@ -127,12 +127,13 @@ messages:
 
    SecondAttackTimer()
    {
+      ptSecondAttack = $;
+
       if pbFirstAttack
       {
          return;
       }
 
-      ptSecondAttack = $;
       if poTarget <> $
          AND poOwner = Send(poTarget,@GetOwner)
       {

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -4379,7 +4379,7 @@ messages:
 
       % A room can completely block a piece of communication if it chooses.
       % An excellent example is Out Of Grace, which blocks all tells to 
-      %  non-DMs, as well as Guild Tells and Broadcasts
+      % non-DMs, as well as Guild Tells and Broadcasts
 
       % User took an action!  Wake any AIs in the room to the user's presence!
       % bitflag check instead of function for speed.
@@ -4395,13 +4395,15 @@ messages:
             lSurvivalOptions = $;
             if NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
                OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
+               OR Send(poOwner,@GetRoomNum) = RID_FIELD1
             {
                Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
+
                return;
             }
 
-            Send(Send(SYS,@GetSurvivalRoomMaintenance),@CreateRoom,
-                      #who=self);
+            Send(Send(SYS,@GetSurvivalRoomMaintenance),@CreateRoom,#who=self);
+
             return;
          }
 
@@ -4411,21 +4413,24 @@ messages:
             if poGuild = $
             {
                Send(self,@MsgSendUser,#message_rsc=survival_err_no_guild);
+
                return;
             }
-            
+
             if NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
                OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
+               OR Send(poOwner,@GetRoomNum) = RID_FIELD1
             {
                Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
+
                return;
             }
-            
+
             if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindRoomByGuild,
                      #oGuild=poGuild) = $
             {
                Send(Send(SYS,@GetSurvivalRoomMaintenance),@CreateRoom,
-                         #who=self,#guild_survival=TRUE);
+                     #who=self,#guild_survival=TRUE);
             }
             else
             {
@@ -4439,10 +4444,12 @@ messages:
          {
             lSurvivalOptions = $;
             if (NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
-               OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD)
-               AND NOT IsClass(self,&DM)
+               OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
+               OR Send(poOwner,@GetRoomNum) = RID_FIELD1)
+               AND NOT IsClass(self,&Admin)
             {
                Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
+
                return;
             }
 
@@ -4466,23 +4473,23 @@ messages:
             if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindPublicRoom) = $
             {
                Send(Send(SYS,@GetSurvivalRoomMaintenance),@CreateRoom,
-                         #who=self,#iPublic=TRUE,#sString=string,
-                         #lSurvivalOptions=lSurvivalOptions,
-                         #poForceBaseRoom=poForceBaseRoom);
+                     #who=self,#iPublic=TRUE,#sString=string,
+                     #lSurvivalOptions=lSurvivalOptions,
+                     #poForceBaseRoom=poForceBaseRoom);
             }
             
             if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindPublicRoom) = $
             {
                Send(Send(SYS,@GetSurvivalRoomMaintenance),@CreateRoom,
-                         #who=self,#iPublic=TRUE,
-                         #lSurvivalOptions=lSurvivalOptions,
-                         #poForceBaseRoom=poForceBaseRoom);
+                     #who=self,#iPublic=TRUE,
+                     #lSurvivalOptions=lSurvivalOptions,
+                     #poForceBaseRoom=poForceBaseRoom);
             }
             else
             {
                Send(self,@MsgSendUser,#message_rsc=survival_err_already_public);
             }
-            
+
             return;
          }
 
@@ -4491,35 +4498,38 @@ messages:
             if poGuild = $
             {
                Send(self,@MsgSendUser,#message_rsc=survival_err_no_guild);
+
                return;
             }
 
             if NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
                OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
+               OR Send(poOwner,@GetRoomNum) = RID_FIELD1
             {
                Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
+
                return;
             }
-            
+
             if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindRoomByGuild,
                      #oGuild=poGuild) = $
             {
                Send(self,@MsgSendUser,#message_rsc=survival_no_guild_rooms);
+
                return;
             }
 
             if Send(Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                    @FindRoomByGuild,#oGuild=poGuild),
-                    @GetAllowJoins)
+                     @FindRoomByGuild,#oGuild=poGuild),@GetAllowJoins)
             {
                Send(Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                    @FindRoomByGuild,#oGuild=poGuild),
-                    @Teleport,#what=self);
+                     @FindRoomByGuild,#oGuild=poGuild),@Teleport,#what=self);
             }
             else
             {
                Send(self,@MsgSendUser,#message_rsc=guild_survival_too_late);
             }
+
             return;
          }
 
@@ -4527,37 +4537,40 @@ messages:
          {
             if NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
                OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
+               OR Send(poOwner,@GetRoomNum) = RID_FIELD1
             {
                Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
+
                return;
             }
             
             if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindPublicRoom) = $
             {
                Send(self,@MsgSendUser,#message_rsc=survival_no_public_rooms);
+
                return;
             }
 
             if Send(Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                    @FindPublicRoom),
-                    @GetAllowJoins)
+                     @FindPublicRoom),@GetAllowJoins)
             {
                Send(Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                    @FindPublicRoom),
-                    @Teleport,#what=self);
+                     @FindPublicRoom),@Teleport,#what=self);
             }
             else
             {
                Send(self,@MsgSendUser,#message_rsc=public_survival_too_late);
             }
+
             return;
          }
-         
+
          if StringContain(String,"autocombine on")
             AND NOT Send(self,@IsAutoCombining)
          {
             Send(self,@SetAutoCombine,#value=TRUE);
             Send(self,@MsgSendUser,#message_rsc=autocombine_on_msg);
+
             return;
          }
 
@@ -4566,6 +4579,7 @@ messages:
          {
             Send(self,@SetAutoCombine,#value=FALSE);
             Send(self,@MsgSendUser,#message_rsc=autocombine_off_msg);
+
             return;
          }
 
@@ -4574,6 +4588,7 @@ messages:
          {
             Send(self,@SetAutoloot,#value=TRUE);
             Send(self,@MsgSendUser,#message_rsc=autoloot_on_msg);
+
             return;
          }
 
@@ -4582,6 +4597,7 @@ messages:
          {
             Send(self,@SetAutoloot,#value=FALSE);
             Send(self,@MsgSendUser,#message_rsc=autoloot_off_msg);
+
             return;
          }
 
@@ -4590,6 +4606,7 @@ messages:
          {
             Send(self,@SetReagentBagAuto,#value=TRUE);
             Send(self,@MsgSendUser,#message_rsc=reagentbag_auto_on);
+
             return;
          }
 
@@ -4598,6 +4615,7 @@ messages:
          {
             Send(self,@SetReagentBagAuto,#value=FALSE);
             Send(self,@MsgSendUser,#message_rsc=reagentbag_auto_off);
+
             return;
          }
       }
@@ -4613,18 +4631,20 @@ messages:
          if StringContain(string,guild_motd_command)
             AND poGuild <> $
             AND (Send(poGuild,@GetRank,#who=self) = RANK_MASTER
-                OR Send(poGuild,@GetRank,#who=self) = RANK_LIEUTENANT)
+               OR Send(poGuild,@GetRank,#who=self) = RANK_LIEUTENANT)
          {
             Send(poGuild,@SetGuildMOTD,#who=self,#string=string);
+
             return;
          }
          if StringContain(string,guild_clear_motd_command)
             AND poGuild <> $
             AND Send(poGuild,@GetGuildMaster) = self
             AND (Send(poGuild,@GetRank,#who=self) = RANK_MASTER
-                OR Send(poGuild,@GetRank,#who=self) = RANK_LIEUTENANT)
+               OR Send(poGuild,@GetRank,#who=self) = RANK_LIEUTENANT)
          {
             Send(poGuild,@SetGuildMOTD,#who=self,#string=$);
+
             return;
          }
 

--- a/kod/object/passive/guild.kod
+++ b/kod/object/passive/guild.kod
@@ -666,7 +666,7 @@ messages:
                      #message_rsc=guild_threeperson_failed);
             }
 
-            Send(self,@Delete,#timerdelete=TRUE);
+            Send(self,@Delete,#timerdelete=FALSE);
 
             return;
          }

--- a/kod/object/passive/spell/walspell/brmblwll.kod
+++ b/kod/object/passive/spell/walspell/brmblwll.kod
@@ -89,7 +89,7 @@ messages:
       iBrambleHits = bound(iSpellPower/2,10,50);
 
       % Facing East
-      if iAngle > ANGLE_ENE OR iAngle < ANGLE_ESE
+      if iAngle >= ANGLE_ENE OR iAngle < ANGLE_ESE
       {
          iRow = Send(who,@GetRow) - 2;
          iCol = Send(who,@GetCol) + 1;

--- a/kod/object/passive/spell/walspell/summfog.kod
+++ b/kod/object/passive/spell/walspell/summfog.kod
@@ -92,7 +92,7 @@ messages:
       iDuration = Bound(iDuration,15,95);
 
       % Facing East
-      if iAngle > ANGLE_ENE OR iAngle < ANGLE_ESE
+      if iAngle >= ANGLE_ENE OR iAngle < ANGLE_ESE
       {
          iCol = Send(who,@GetCol) + 2;
          iRow = Send(who,@GetRow);

--- a/kod/object/passive/spell/walspell/summpfog.kod
+++ b/kod/object/passive/spell/walspell/summpfog.kod
@@ -90,7 +90,7 @@ messages:
       iDuration = Bound(iDuration,20,130);
 
       % Facing East
-      if iAngle > ANGLE_ENE OR iAngle < ANGLE_ESE
+      if iAngle >= ANGLE_ENE OR iAngle < ANGLE_ESE
       {
          iCol = Send(who,@GetCol) + 2;
          iRow = Send(who,@GetRow);

--- a/kod/object/passive/spell/walspell/summweb.kod
+++ b/kod/object/passive/spell/walspell/summweb.kod
@@ -89,7 +89,7 @@ messages:
 
 
       % Facing East
-      if iAngle > ANGLE_ENE OR iAngle < ANGLE_ESE
+      if iAngle >= ANGLE_ENE OR iAngle < ANGLE_ESE
       {
          iCol = Send(who,@GetCol) + 2;
          iRow = Send(who,@GetRow);


### PR DESCRIPTION
This code gets the player's row/col to determine where to place the elements, but the if statements neglect to account for the player facing exactly ANGLE_ENE. Some of the wall spells had the correct logic here, these ones didn't. If a player happened to be standing at ANGLE_ENE and cast the spell, the elements weren't placed and a lot of errors logged instead.

Fixes also included here are prevention of survival arena start/join from Fields, a fix to pogg king (clear the plAttackers list on deletion) to stop GetObjectByID errors in survival arena, and fixes for deleting non-existent timers in OPB and guild deletion.