### PR TITLE
Add target self key for classic key binding.

### DIFF
--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -48,7 +48,7 @@ typedef unsigned char Bool;
 enum {False = 0, True = 1};
 
 #define MAJOR_REV 50   /* Major version of client program */
-#define MINOR_REV 24  /* Minor version of client program; must be in [0, 99] */
+#define MINOR_REV 25  /* Minor version of client program; must be in [0, 99] */
 
 #define MAXAMOUNT 9     /* Max # of digits in a server integer */
 #define MAXSTRINGLEN 512 /* Max length of a string loaded from string table */

--- a/clientd3d/key.h
+++ b/clientd3d/key.h
@@ -20,6 +20,7 @@
 #define VK_COMMA		0xBC
 #define VK_SLASH		0xBF
 #define VK_LBRACKET		0xDB
+#define VK_BACKSLASH 0xDC
 #define VK_RBRACKET		0xDD
 #define VK_BACKQUOTE	0xC0
 

--- a/module/merintr/merintr.c
+++ b/module/merintr/merintr.c
@@ -209,10 +209,11 @@ keymap interface_key_table[] = {
 
 { VK_TAB,         KEY_NONE,             A_TABFWD,   (void *) IDC_MAIN },
 { VK_TAB,         KEY_SHIFT,            A_TABBACK,  (void *) IDC_MAIN },
-{ VK_ESCAPE,	  KEY_ANY,				A_TARGETCLEAR },			//	Does an A_GOTOMAIN as well.
+{ VK_ESCAPE,      KEY_ANY,              A_TARGETCLEAR }, // Does an A_GOTOMAIN as well.
 
-{ VK_LBRACKET,	  KEY_NONE,				A_TARGETPREVIOUS },			//	No idea why it's this value instead of '['. xxx
-{ VK_RBRACKET,	  KEY_NONE,				A_TARGETNEXT },				//	']'
+{ VK_LBRACKET,   KEY_NONE,              A_TARGETPREVIOUS }, // No idea why it's this value instead of '['. xxx
+{ VK_RBRACKET,   KEY_NONE,              A_TARGETNEXT },     // ']'
+{ VK_BACKSLASH,  KEY_NONE,              A_TARGETSELF },
 
 { 'A',            KEY_NONE,             A_TEXTINSERT, "a" },
 { 'B',            KEY_NONE,             A_TEXTINSERT, "b" },
@@ -434,6 +435,7 @@ static ascii_key	gAsciiKeyMap[] =
 	{"/",		VK_SLASH},
 	{"[",		VK_LBRACKET},
 	{"]",		VK_RBRACKET},
+	{"\\",		VK_BACKSLASH},
 	{"home",	VK_HOME},
 	{"end",		VK_END},
 	{"insert",	VK_INSERT},


### PR DESCRIPTION
Player requested - there was no target self key available for classic key binding, so I've enabled the \ key to do this. Also defined VK_BACKSLASH in key.h and added it to the ascii key map in merintr.c.