### PR TITLE
Timer error fixes, Goad's Arena teleport bug fix.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/grdworm.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/grdworm.kod
@@ -413,6 +413,19 @@ messages:
       return TRUE;
    }
 
+   Killed(what = $)
+   {
+      % Delete this now, in case this timer is active.
+      if ptPostPop <> $
+      {
+         DeleteTimer(ptPostPop);
+      }
+
+      ptPostPop = $;
+
+      propagate;
+   }
+
    Delete()
    {
       local i;
@@ -426,8 +439,8 @@ messages:
       if ptPostPop <> $
       {
          DeleteTimer(ptPostPop);
-         ptPostPop = $;
       }
+      ptPostPop = $;
 
       propagate;
    }

--- a/kod/object/active/holder/nomoveon/battler/monster/revenant.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/revenant.kod
@@ -299,6 +299,14 @@ messages:
    {
       if poHauntee = victim
       {
+         % Posting Delete so delete Place timer here.
+         if ptPlace <> $
+         {
+            DeleteTimer(ptPlace);
+         }
+
+         ptPlace = $;
+
          Post(self,@Delete);  % MUST post this
       }
 
@@ -315,6 +323,14 @@ messages:
    {
       if what = poHauntee
       {
+         % Posting Delete so delete Place timer here.
+         if ptPlace <> $
+         {
+            DeleteTimer(ptPlace);
+         }
+
+         ptPlace = $;
+
          Post(self,@Delete);
       }
 

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/Goad.kod
@@ -562,6 +562,8 @@ messages:
    {
       local i;
 
+      Send(poOwner,@ClearFromOccupiedList,#who=who);
+
       if (died = FALSE)
          AND (Send(self,@FightInSession)
             OR ptCommence <> $)

--- a/kod/object/active/holder/room/barlqrm/barapoth.kod
+++ b/kod/object/active/holder/room/barlqrm/barapoth.kod
@@ -14,7 +14,6 @@ constants:
 
    include blakston.khd
 
-
 resources:
 
    room_barapoth = barapoth.roo
@@ -45,7 +44,6 @@ properties:
 
 messages:
 
-
    CreateStandardExits()
    {
       plExits = $;
@@ -63,16 +61,8 @@ messages:
       Send(self,@NewHold,#what=Create(&BarloqueApothecary),
            #new_row=3,#new_col=6,#new_angle=ANGLE_SOUTH);
 
-      Send(self,@NewHold,#what=Create(&Brazier),
-           #new_row=9,#new_col=3);
-      Send(self,@NewHold,#what=Create(&Brazier),
-           #new_row=9,#new_col=9);
-%      Send(self,@NewHold,#what=Create(&Brazier),
-%           #new_row=3,#new_col=3,#fine_col=0,#fine_row=0);
-%      (no light circle for this brazier)
       propagate;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/room/necarena.kod
+++ b/kod/object/active/holder/room/necarena.kod
@@ -346,8 +346,8 @@ messages:
          Send(SYS,@UtilGoNearSquare,#what=what,#where=self,
               #new_row=row,#new_col=col);
 
-         % Mark position as occupied.
-         SetNth(plOccupied,rand,1);
+         % Mark position as occupied, with the player object number.
+         SetNth(plOccupied,rand,what);
 
          if ptCheckLavaTimer = $
          {
@@ -489,6 +489,21 @@ messages:
    BeginFight(lCombatants=$)
    {
       plOccupied = [0,0,0,0,0,0];
+
+      return;
+   }
+
+   ClearFromOccupiedList(who=$)
+   "Clears a combatant from the occupied list."
+   {
+      local i;
+
+      if who <> $
+         AND plOccupied <> $
+         AND FindListElem(plOccupied,who)
+      {
+         SetNth(plOccupied,FindListElem(plOccupied,who),0);
+      }
 
       return;
    }

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -1612,27 +1612,31 @@ messages:
             }
          }
       }
-		
+
       % Count that this spell was cast successfully
-      Send(Send(SYS, @GetStatistics), @SpellCast, #oSpell = self, #who = who);
+      Send(Send(SYS,@GetStatistics),@SpellCast,#oSpell=self,#who=who);
+
       return;
    }
 
    PlaySpellSound(room_obj = $,what = $)
-   {      
+   {
       local wave_rsc;
 
-      wave_rsc = Send(self,@GetSpellSound);
+      if room_obj <> $
+      {
+         wave_rsc = Send(self,@GetSpellSound);
 
-      if wave_rsc <> $        
-      {
-         Send(room_obj,@SomethingWaveRoom,#what=what,#wave_rsc=wave_rsc);
+         if wave_rsc <> $
+         {
+            Send(room_obj,@SomethingWaveRoom,#what=what,#wave_rsc=wave_rsc);
+         }
+         else
+         {
+            debug("Spell has no spell sound defined, is not a jala song!");
+         }
       }
-      else
-      {
-         debug("Spell has no spell sound defined, is not a jala song!");
-      }
-      
+
       return;
    }
 

--- a/kod/object/passive/spell/heal.kod
+++ b/kod/object/passive/spell/heal.kod
@@ -18,18 +18,23 @@ resources:
    heal_name_rsc = "minor heal"
    heal_icon_rsc = iheal.bgf
    heal_desc_rsc = \
-      "The compassionate power of Shal'ille heals the wounds of the caster or another "
-      "person.  Is particularly potent on those protected by guardian angels.  "
-      "Shal'ille gives a small reward toward the karma of the mage who heals another "
-      "good soul.  "
-      "Requires herbs to cast."
+      "The compassionate power of Shal'ille heals the wounds of the caster "
+      "or another person.  Is particularly potent on those protected by "
+      "guardian angels.  Shal'ille gives a small reward toward the karma "
+      "of the mage who heals another good soul.  "
+      "Requires one herb to cast."
 
-   heal_cast_rsc = "%s%s's spell heals some minor injuries, restoring ~g~B%i~B~n hitpoints."
-   heal_cast_self = "Shal'ille's holy magic heals some minor injuries, restoring ~g~B%i~B~n hitpoints."
+   heal_cast_rsc = \
+      "%s%s's spell heals some minor injuries, restoring ~g~B%i~B~n hitpoints."
+   heal_cast_self = \
+      "Shal'ille's holy magic heals some minor injuries, restoring "
+      "~g~B%i~B~n hitpoints."
    heal_cast_on_other = "You heal %s%s for ~g~B%i~B~n hitpoints."
    heal_unnecessary_rsc = "%s%s is perfectly healthy."
 
-   heal_spell_intro = "Shal'ille Lv. 1: Bestows the healing touch of Shal'ille, restoring points of health."
+   heal_spell_intro = \
+      "Shal'ille Lv. 1: Bestows the healing touch of Shal'ille, restoring "
+      "points of health."
 
 classvars:
 
@@ -71,7 +76,7 @@ messages:
    CanPayCosts(who = $, lTargets = $)
    {
       local target, i;
-      
+
       % Can cast spell if the 1 target item is a user
       if Length(lTargets) <> 1
       {
@@ -79,19 +84,20 @@ messages:
       }
 
       target = First(lTargets);
-      if not IsClass(target,&User)
+      if NOT IsClass(target,&User)
       {
-         Send(who,@MsgSendUser,#message_rsc=spell_bad_target, 
-              #parm1=vrName,#parm2=Send(target,@GetDef),#parm3=Send(target,@GetName));
-           
+         Send(who,@MsgSendUser,#message_rsc=spell_bad_target,
+               #parm1=vrName,#parm2=Send(target,@GetDef),
+               #parm3=Send(target,@GetName));
+
          return FALSE;
       }
-      
+
       if Send(target,@GetHealth) >= Send(target,@GetMaxHealth)
       {
          Send(who,@MsgSendUser,#message_rsc=heal_unnecessary_rsc,
-              #parm1=Send(target,@GetDef),#parm2=Send(target,@GetName));
-              
+               #parm1=Send(target,@GetDef),#parm2=Send(target,@GetName));
+
          return FALSE;
       }
 
@@ -103,43 +109,43 @@ messages:
       local iHeal, oTarget;
 
       oTarget = First(lTargets);
-      
-      iHeal = random(100,500) + ((iSpellPower + 1)*5) + (Send(oTarget,@GetKarma)*5);
-      iHeal = bound(iHeal,0,1000);
+
+      iHeal = Random(100,500) + ((iSpellPower + 1)*5) + (Send(oTarget,@GetKarma)*5);
+      iHeal = Bound(iHeal,0,1000);
+
+      iHeal = Send(oTarget,@GainHealthNormal,#amount=iHeal,#precision=TRUE);
 
       % A little boost for casting on newbies, even if you're the newbie!
-      if NOT send(oTarget,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
+      if NOT Send(oTarget,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
       {
          iHeal = iHeal + random(200,500);
       }
-      
+
       if who <> oTarget
       {
          Send(who,@MsgSendUser,#message_rsc=heal_cast_on_other,
-              #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName),#parm3=iHeal/100);
-              
+               #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName),
+               #parm3=iHeal/100);
+
          Send(oTarget,@MsgSendUser,#message_rsc=heal_cast_rsc,
-              #parm1=Send(who,@GetCapDef),#parm2=Send(who,@GetName),#parm3=iHeal/100);
+               #parm1=Send(who,@GetCapDef),#parm2=Send(who,@GetName),
+               #parm3=iHeal/100);
 
          % Give them a little boost if they help someone of higher Karma.
-         if send(who,@GetKarma) < send(oTarget,@GetKarma)
+         if Send(who,@GetKarma) < Send(oTarget,@GetKarma)
          {
-            send(who,@AddKarma,#amount = send(who,@CalculateKarmaChangeFromAct,
-                #karma_doer=send(who,@GetKarma),#karma_act=send(oTarget,@GetKarma),
-                #Swing_factor = 1));
+            Send(who,@AddKarma,#amount = Send(who,@CalculateKarmaChangeFromAct,
+                  #karma_doer=Send(who,@GetKarma),#karma_act=Send(oTarget,@GetKarma),
+                  #Swing_factor = 1));
          }
       }
-
       else
       {
          Send(who,@MsgSendUser,#message_rsc=heal_cast_self,#parm1=iHeal/100);
       }
-           
-      Send(oTarget,@GainHealthNormal,#amount=iHeal,#precision=TRUE);
 
       propagate;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/hospice.kod
+++ b/kod/object/passive/spell/hospice.kod
@@ -22,10 +22,12 @@ resources:
       "Rejuvenates the target of the spell with Shal'ille's healing energy.  "
       "Shal'ille gives a small reward toward the karma of the mage who heals "
       "another good soul.  "
-      "Requires herbs to cast."
+      "Requires three herbs to cast."
 
-   hospice_cast_rsc = "%s%s's spell rejuvenates you, restoring ~g~B%i~B~n hitpoints."
-   hospice_cast_self = "Shal'ille's holy magic rejuvenates you, restoring ~g~B%i~B~n hitpoints."
+   hospice_cast_rsc = \
+      "%s%s's spell rejuvenates you, restoring ~g~B%i~B~n hitpoints."
+   hospice_cast_self = \
+      "Shal'ille's holy magic rejuvenates you, restoring ~g~B%i~B~n hitpoints."
    hospice_cast_on_other = "You heal %s%s for ~g~B%i~B~n hitpoints."
    hospice_unnecessary_rsc = "%s%s is perfectly healthy."
 
@@ -68,7 +70,7 @@ messages:
    CanPayCosts(who = $, lTargets = $, bItemCast = FALSE)
    {
       local target, i;
-      
+
       % Can cast spell if the 1 target item is a user
       if Length(lTargets) <> 1
       {
@@ -76,14 +78,15 @@ messages:
       }
 
       target = First(lTargets);
-      if not IsClass(target, &User)
+      if NOT IsClass(target,&User)
       {
-         if not bItemCast
+         if NOT bItemCast
          {
-            Send(who, @MsgSendUser, #message_rsc=spell_bad_target, 
-                 #parm1=vrName,#parm2=Send(target,@GetDef),#parm3=Send(target,@GetName));
+            Send(who,@MsgSendUser,#message_rsc=spell_bad_target, 
+                  #parm1=vrName,#parm2=Send(target,@GetDef),
+                  #parm3=Send(target,@GetName));
          }
-         
+
          return FALSE;
       }
 
@@ -91,10 +94,11 @@ messages:
       {
          if NOT bItemCast
          {
-            Send(who, @MsgSendUser, #message_rsc=hospice_unnecessary_rsc,
-              #parm1=Send(target,@GetCapDef), #parm2=Send(target,@GetName));
+            Send(who,@MsgSendUser,#message_rsc=hospice_unnecessary_rsc,
+                  #parm1=Send(target,@GetCapDef),
+                  #parm2=Send(target,@GetName));
          }
-         
+
          return FALSE;
       }
 
@@ -106,37 +110,36 @@ messages:
       local iHeal, oTarget;
 
       oTarget = First(lTargets);
-          
-      iHeal = random(-300,300) + iSpellPower*20 + Send(oTarget,@GetKarma)*10;
-      iheal = bound(iHeal,0,2500);
 
+      iHeal = Random(-300,300) + iSpellPower*20 + Send(oTarget,@GetKarma)*10;
+      iHeal = Bound(iHeal,0,2500);
+
+      iHeal = Send(oTarget,@GainHealthNormal,#amount=iHeal,#precision=TRUE);
       if who <> oTarget 
       {
          Send(who,@MsgSendUser,#message_rsc=hospice_cast_on_other,
-              #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName),#parm3=iHeal/100);
-              
+               #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName),
+               #parm3=iHeal/100);
+
          Send(oTarget,@MsgSendUser,#message_rsc=hospice_cast_rsc,
-              #parm1=Send(who,@GetCapDef),#parm2=Send(who,@GetName),#parm3=iHeal/100);
+               #parm1=Send(who,@GetCapDef),#parm2=Send(who,@GetName),
+               #parm3=iHeal/100);
 
          % Give them a little boost if they help someone of higher Karma.
-         if send(who,@GetKarma) < send(oTarget,@GetKarma)
+         if Send(who,@GetKarma) < Send(oTarget,@GetKarma)
          {
-            send(who,@AddKarma,#amount = send(who,@CalculateKarmaChangeFromAct,
-                 #karma_doer=send(who,@GetKarma),#karma_act=send(oTarget,@GetKarma),
-                 #Swing_factor=2));
+            Send(who,@AddKarma,#amount=Send(who,@CalculateKarmaChangeFromAct,
+                  #karma_doer=Send(who,@GetKarma),#karma_act=Send(oTarget,@GetKarma),
+                  #Swing_factor=2));
          }
-      }       
-
+      }
       else
       {
          Send(who,@MsgSendUser,#message_rsc=hospice_cast_self,#parm1=iHeal/100);
       }
 
-      Send(oTarget,@GainHealthNormal,#amount=iHeal,#precision=TRUE);
-
       propagate;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/majheal.kod
+++ b/kod/object/passive/spell/majheal.kod
@@ -24,11 +24,14 @@ resources:
       "on evil souls will reduce your own karmic standing.  "
       "Requires herbs to cast."
 
-   majorheal_cast_rsc = "%s%s's spell floods you with pure healing energy, restoring ~g~B%i~B~n hitpoints."
-   majorheal_cast_self = "Shal'ille's holy magic floods you with pure healing energy, restoring ~g~B%i~B~n hitpoints."
+   majorheal_cast_rsc = \
+      "%s%s's spell floods you with pure healing energy, "
+      "restoring ~g~B%i~B~n hitpoints."
+   majorheal_cast_self = \
+      "Shal'ille's holy magic floods you with pure healing energy, "
+      "restoring ~g~B%i~B~n hitpoints."
    majorheal_cast_on_other = "You heal %s%s for ~g~B%i~B~n hitpoints."
    majorheal_unnecessary_rsc = "%s%s is perfectly healthy."
-
 
 classvars:
 
@@ -43,7 +46,7 @@ classvars:
    viMeditate_ratio = 50
 
    viFlash = FLASH_GOOD
-   
+
 properties:
 
 messages:
@@ -66,7 +69,7 @@ messages:
    CanPayCosts(who = $, lTargets = $)
    {
       local target, i;
-      
+
       % Can cast spell if the 1 target item is a user
       if Length(lTargets) <> 1
       {
@@ -76,17 +79,18 @@ messages:
       target = First(lTargets);
       if NOT IsClass(target, &User)
       {
-         Send(who,@MsgSendUser,#message_rsc=spell_bad_target, 
-              #parm1=vrName,#parm2=Send(target,@GetDef),#parm3=Send(target,@GetName));
-              
+         Send(who,@MsgSendUser,#message_rsc=spell_bad_target,
+               #parm1=vrName,#parm2=Send(target,@GetDef),
+               #parm3=Send(target,@GetName));
+
          return FALSE;
       }
-      
+
       if Send(target,@GetHealth) >= Send(target,@GetMaxHealth)
       {
          Send(who,@MsgSendUser,#message_rsc=majorheal_unnecessary_rsc,
-              #parm1=Send(target,@GetCapDef),#parm2=Send(target,@GetName));
-              
+               #parm1=Send(target,@GetCapDef),#parm2=Send(target,@GetName));
+
          return FALSE;
       }
 
@@ -98,34 +102,34 @@ messages:
       local iHeal, oTarget;
 
       oTarget = First(lTargets);
-      
-      iHeal  = random(700,1300) + iSpellPower*20 + Send(oTarget,@GetKarma)*20;
-      iheal = bound(iHeal,0,5000);
 
-      if who <> oTarget 
+      iHeal  = Random(700,1300) + iSpellPower*20 + Send(oTarget,@GetKarma)*20;
+      iHeal = Bound(iHeal,0,5000);
+
+      iHeal = Send(oTarget,@GainHealthNormal,#amount=iHeal,#precision=TRUE);
+      if who <> oTarget
       {
          Send(who,@MsgSendUser,#message_rsc=majorheal_cast_on_other,
-              #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName),#parm3=iHeal/100);
-              
+               #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName),
+               #parm3=iHeal/100);
+
          Send(oTarget,@MsgSendUser,#message_rsc=majorheal_cast_rsc,
-              #parm1=Send(who,@GetCapDef),#parm2=Send(who,@GetName),#parm3=iHeal/100);
+               #parm1=Send(who,@GetCapDef),#parm2=Send(who,@GetName),
+               #parm3=iHeal/100);
          
          % Nudge the karma of the caster towards that of the healed.
-         send(who,@AddKarma,#amount=send(who,@CalculateKarmaChangeFromAct,
-             #karma_doer=send(who,@GetKarma),#karma_act=send(oTarget,@GetKarma),
-             #Swing_factor=2));
-      }       
-
+         Send(who,@AddKarma,#amount=Send(who,@CalculateKarmaChangeFromAct,
+               #karma_doer=Send(who,@GetKarma),#karma_act=Send(oTarget,@GetKarma),
+               #Swing_factor=2));
+      }
       else
       {
-         Send(who,@MsgSendUser,#message_rsc=majorheal_cast_self,#parm1=iHeal/100);
+         Send(who,@MsgSendUser,#message_rsc=majorheal_cast_self,
+               #parm1=iHeal/100);
       }
-      
-      Send(oTarget,@GainHealthNormal,#amount=iHeal,#precision=TRUE);
 
       propagate;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Fix up timer errors with revenants and groundworms - both of these are generating rare errors for still existing timers for deleted monsters.

Fixed a bug with Goad's Arena which was occasionally preventing players from being teleported to the arena correctly.