### PR TITLE
Fix wrong user stat resistance being displayed, remove brazier from behind wall in CN inn. Misc. other bug fixes.

### DIFF
--- a/kod/object/active/holder/nomoveon.kod
+++ b/kod/object/active/holder/nomoveon.kod
@@ -329,16 +329,20 @@ messages:
 
    IsInSameRoom(what = $)
    {
-      if Send(self,@GetOwner) <> $
-         AND IsClass(Send(self,@GetOwner),&Room)
-         AND Send(what,@GetOwner) <> $
-         AND IsClass(Send(what,@GetOwner),&Room)
-         AND Send(self,@GetOwner) = Send(what,@GetOwner)
+      local oOwner;
+      
+      oOwner = Send(what,@GetOwner);
+
+      if poOwner <> $
+         AND IsClass(poOwner,&Room)
+         AND oOwner <> $
+         AND IsClass(oOwner,&Room)
+         AND poOwner = oOwner
       {
-         return 1;
+         return TRUE;
       }
 
-      return 0;
+      return FALSE;
    }
 
    SquaredDistanceTo(what = $)

--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -528,6 +528,8 @@ messages:
       if IsClass(self,&Player)
          AND Send(self,@IsInCannotInteractMode)
       {
+         Send(self,@NewMana);
+
          return 0;
       }
 
@@ -555,6 +557,8 @@ messages:
       if IsClass(self,&Player)
          AND Send(self,@IsInCannotInteractMode)
       {
+         Send(self,@NewMana);
+
          return 0;
       }
 

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -1048,9 +1048,12 @@ messages:
          piState = (piState & VSTATE_VALIDITY_MASK);
       }
 
-      Send(poBrain,@SomethingMoved,#mob=self,#state=piState,
-           #what=what,#new_row=new_row,#new_col=new_col,
-           #fine_row=fine_row,#fine_col=fine_col);
+      if poBrain <> $
+      {
+         Send(poBrain,@SomethingMoved,#mob=self,#state=piState,
+               #what=what,#new_row=new_row,#new_col=new_col,
+               #fine_row=fine_row,#fine_col=fine_col);
+      }
 
       propagate;
    }
@@ -1060,8 +1063,11 @@ messages:
    "appropriateIf were already fighting this person, this doesnt interrupt "
    "our plans."
    {
-      Send(poBrain,@SomethingAttacked,#mob=self,#state=piState,
-           #what=what,#victim=victim,#use_weapon=use_weapon);
+      if poBrain <> $
+      {
+         Send(poBrain,@SomethingAttacked,#mob=self,#state=piState,
+               #what=what,#victim=victim,#use_weapon=use_weapon);
+      }
 
       propagate;
    }

--- a/kod/object/active/holder/nomoveon/battler/monster/troop.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/troop.kod
@@ -742,6 +742,20 @@ messages:
       return $;
    }
 
+   GetDamageType()
+   {
+      local oWeapon;
+
+      oWeapon = Send(self,@GetWeapon);
+
+      if oWeapon <> $
+      {
+         return Send(oWeapon,@GetAttackType);
+      }
+
+      propagate;
+   }
+
    MonsterAttack(what = $)
    "Add in any attack animation calls."
    {

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -14429,7 +14429,7 @@ messages:
 
       % Add phase time to piTimeAttackedPlayer if it is currently
       % preventing the player from casting escape spells.
-      if Send(self,@GetLastPlayerAttackTime)
+      if piTimeAttackedPlayer
             + Send(Send(SYS,@GetSettings),@TeleportAttackDelaySec)
             > GetTime()
       {
@@ -14485,7 +14485,7 @@ messages:
 
       % If we added phase time to piTimeAttackedPlayer before,
       % remove what is remaining (restore to original time).
-      if Send(self,@GetLastPlayerAttackTime)
+      if piTimeAttackedPlayer
             + Send(Send(SYS,@GetSettings),@TeleportAttackDelaySec)
             > GetTime()
       {
@@ -14560,7 +14560,7 @@ messages:
       % Logoff ghosts call this when the player returns, so we remove
       % the phase time remaining from piTimeAttackedPlayer here if we
       % added it when the user logged off.
-      if Send(self,@GetLastPlayerAttackTime)
+      if piTimeAttackedPlayer
             + Send(Send(SYS,@GetSettings),@TeleportAttackDelaySec)
             > GetTime()
       {

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2712,7 +2712,15 @@ messages:
          }
       }
 
+      % Give masks a black dot.
+      if IsClass(what,&FaceMask)
+         AND IsClass(poOwner,&SurvivalRoom)
+      {
+         return MM_NPC;
+      }
+
       if poOwner <> $
+         AND IsClass(what,&Player)
       {
          if Send(poOwner,@AreGroupedHere,#who=self,#what=what)
          {

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -7823,13 +7823,13 @@ messages:
          {
             if Nth(i,1) = ATCK_WEAP_THRUST
             {
-               AddPacket(1,16, 4,user_resist_thrust, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
+               AddPacket(1,15, 4,user_resist_thrust, 1,STAT_VALUE, 1,STAT_INTEGER,4,Nth(i,2), 4,-30, 4,100, 4,0);
                bWeaponThrust = TRUE;
             }
          }
          if NOT bWeaponThrust
          {
-            AddPacket(1,16, 4,user_resist_thrust, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
+            AddPacket(1,15, 4,user_resist_thrust, 1,STAT_VALUE, 1,STAT_INTEGER,4,0, 4,-30, 4,100, 4,0);
          }
       }
       if num = 3

--- a/kod/object/active/holder/room/crnthrm/corinn.kod
+++ b/kod/object/active/holder/room/crnthrm/corinn.kod
@@ -63,21 +63,20 @@ messages:
       local oNews;
 
       Send(self,@NewHold,#what=Create(&CorNothInnKeeper),
-           #new_row=3,#new_col=11,#new_angle=ANGLE_WEST);
+            #new_row=3,#new_col=11,#new_angle=ANGLE_WEST);
 
       % Create news globe.
       oNews = Create(&NewsLink,#nid=NID_ANNOUNCEMENTS,
                      #name=cornews_god_name,#desc=cornews_god_desc);
-      Send(self,@NewHold,#what=oNews,#new_row=7,#new_col=9,#fine_row=40,#fine_col=40);
+      Send(self,@NewHold,#what=oNews,#new_row=7,#new_col=9,
+            #fine_row=40,#fine_col=40);
 
       % And some braziers.
       Send(self,@NewHold,#what=Create(&Brazier),#new_row=7,#new_col=3);
-      Send(self,@NewHold,#what=Create(&Brazier),#new_row=7,#new_col=10);
       Send(self,@NewHold,#what=Create(&Brazier),#new_row=4,#new_col=12);
 
       propagate;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/room/tosrm/tos.kod
+++ b/kod/object/active/holder/room/tosrm/tos.kod
@@ -128,97 +128,94 @@ messages:
 
    CreateStandardObjects()
    {
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=13,#new_col=22,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=19,#new_col=22,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=21,#new_col=22,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=23,#new_col=22,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=27,#new_col=22,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=30,#new_col=22,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=35,#new_col=22,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=43,#new_col=22,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=50,#new_col=27,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=43,#new_col=13,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=41,#new_col=13,#fine_row=17,#fine_col=30,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=61,#new_col=23,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=61,#new_col=26,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=59,#new_col=38,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=31,#new_col=4,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=31,#new_col=8,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=61,#new_col=10,#fine_row=0,#fine_col=0,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_TREE1),
            #new_row=17,#new_col=16,#fine_row=0,#fine_col=0,#new_angle=ANGLE_EAST);
 
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=48,#new_col=15,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=43,#new_col=15,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=41,#new_col=15,#fine_row=17,#fine_col=30,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=21,#new_col=16,#fine_row=0,#fine_col=0,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=13,#new_col=16,#fine_row=0,#fine_col=0,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=28,#new_col=22,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=50,#new_col=26,#fine_row=0,#fine_col=48,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=51,#new_col=27,#fine_row=0,#fine_col=0,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=51,#new_col=28,#fine_row=16,#fine_col=0,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=46,#new_col=15,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=49,#new_col=12,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=59,#new_col=29,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=32,#new_col=16,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=59,#new_col=29,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=49,#new_col=12,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=46,#new_col=15,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=32,#new_col=16,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=28,#new_col=22,#fine_row=32,#fine_col=32,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
+      Send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_RAZA_SHRUB),
            #new_row=21,#new_col=16,#fine_row=0,#fine_col=0,#new_angle=ANGLE_EAST);
 
-      send(self,@NewHold,#what=Create(&OrnamentalObject,#type=OO_BARREL),
-           #new_row=3,#new_col=46,#fine_row=16,#fine_col=8,#new_angle=ANGLE_EAST);
-
-      send(self,@NewHold,#what=Create(&Lamp),#new_row=55,#new_col=10,
+      Send(self,@NewHold,#what=Create(&Lamp),#new_row=55,#new_col=10,
            #fine_row=24,#fine_col=40,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&Lamp),#new_row=55,#new_col=28,
+      Send(self,@NewHold,#what=Create(&Lamp),#new_row=55,#new_col=28,
            #fine_row=8,#fine_col=8,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&Lamp),#new_row=60,#new_col=22,
+      Send(self,@NewHold,#what=Create(&Lamp),#new_row=60,#new_col=22,
            #fine_row=48,#fine_col=8,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&Lamp),#new_row=60,#new_col=14,
+      Send(self,@NewHold,#what=Create(&Lamp),#new_row=60,#new_col=14,
            #fine_row=32,#fine_col=16,#new_angle=ANGLE_EAST);
-      send(self,@NewHold,#what=Create(&Lamp),#new_row=49,#new_col=22,
+      Send(self,@NewHold,#what=Create(&Lamp),#new_row=49,#new_col=22,
            #fine_row=48,#fine_col=48,#new_angle=ANGLE_EAST);
 
-      send(self,@NewHold,#what=Create(&Fountain),#new_row=56,#new_col=18,
+      Send(self,@NewHold,#what=Create(&Fountain),#new_row=56,#new_col=18,
            #fine_row=36,#fine_col=36,#new_angle=ANGLE_EAST);
 
       propagate;
@@ -229,7 +226,7 @@ messages:
    {
       local iHour,iLight_effect;
 
-      iHour = send(SYS,@GetHour);
+      iHour = Send(SYS,@GetHour);
 
       if iHour >= 11 and iHour <= 17
       {
@@ -240,10 +237,10 @@ messages:
          iLight_effect = FLICKER_ON;
       }
 
-      send(self,@SetSectorLight,#sector=1,#light_effect=iLight_effect);
-      send(self,@SetSectorLight,#sector=2,#light_effect=iLight_effect);
-      send(self,@SetSectorLight,#sector=3,#light_effect=iLight_effect);
-      send(self,@SetSectorLight,#sector=4,#light_effect=iLight_effect);
+      Send(self,@SetSectorLight,#sector=1,#light_effect=iLight_effect);
+      Send(self,@SetSectorLight,#sector=2,#light_effect=iLight_effect);
+      Send(self,@SetSectorLight,#sector=3,#light_effect=iLight_effect);
+      Send(self,@SetSectorLight,#sector=4,#light_effect=iLight_effect);
 
       propagate;
    }

--- a/kod/object/item/passitem/easteregg.kod
+++ b/kod/object/item/passitem/easteregg.kod
@@ -489,6 +489,11 @@ messages:
       return;
    }
 
+   IsBeverage()
+   {
+      return FALSE;
+   }
+
    DestroyDisposable()
    {
       % Don't destroy easter eggs.

--- a/kod/object/item/passitem/numbitem/food/chaosfood.kod
+++ b/kod/object/item/passitem/numbitem/food/chaosfood.kod
@@ -8,7 +8,6 @@
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
 ChaosFood is Food
 
 constants:
@@ -21,10 +20,11 @@ resources:
    chaosfd_name_plural_rsc = "Frenzy Food"
    chaosfd_icon_rsc = mushroom.bgf
    chaosfd_desc_rsc = \
-        "At first glance, these mushrooms appear common, but look at the psychedelic colors!  "
-        "This is actually Frenzy Food! No Stomach No Problem!"
-	  
-   chaosfd_no_eat = "You can't eat this potion when it is not a frenzy."
+        "At first glance, these mushrooms appear common, but look at "
+        "the psychedelic colors!  This is actually Frenzy Food!  No "
+        "Stomach No Problem!"
+
+   chaosfd_no_eat = "You don't quite feel insane enough to eat this right now."
 
 classvars:
 
@@ -33,14 +33,16 @@ classvars:
    vrIcon = chaosfd_icon_rsc
    vrDesc = chaosfd_desc_rsc
 
-   viBulk = 10
-   viWeight = 5000         % Increased weight to ensure no mortal is able to pick these up outside of a frenzy.
+   viBulk = 2
+   viWeight = 4
    viValue_average = 1
 
 properties:
-		
+
    piItem_flags = PT_FRST_WHT3
-   viFilling = 0          % Ignores the characters stomach to allow for constant frenzy killing without being full...
+
+   % Zero filling so can always be eaten, does not fill up character's stomach.
+   viFilling = 0
    viNutrition = 200
    piNumber = 1
 
@@ -50,27 +52,27 @@ messages:
    {
      propagate;
    }
-   
+
    NewApplied(what = $,apply_on = $)
    {
-     if Send(SYS, @GetChaosNight)					
-     {
-       Send(self,@SendTaste,#what=what,#apply_on=apply_on);
-       Send(what,@WaveSendUser,#wave_rsc=vrEat_wav);
-       Send(apply_on,@EatSomething,#nutrition=viNutrition,#filling=viFilling);
-       Send(self,@SubtractNumber,#number=1);
-     }
-     else
-     {
-       % We only want these used during a frenzy, so if eaten outside of a frenzy
-       % the food will delete itself.
-       Send(apply_on,@MsgSendUser,#message_rsc=chaosfd_no_eat);
-       Send(self,@Delete);
-     }
-		
+      if Send(SYS,@GetChaosNight)
+         OR IsClass(apply_on,&DM)
+      {
+         Send(self,@SendTaste,#what=what,#apply_on=apply_on);
+         Send(what,@WaveSendUser,#wave_rsc=vrEat_wav);
+         Send(apply_on,@EatSomething,#nutrition=viNutrition,#filling=viFilling);
+         Send(self,@SubtractNumber,#number=1);
+      }
+      else
+      {
+         % We only want these used during a frenzy, so if eaten outside
+         % of a frenzy the food will delete itself.
+         Send(apply_on,@MsgSendUser,#message_rsc=chaosfd_no_eat);
+         Send(self,@Delete);
+      }
+
      return;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/weapon/bkdagger.kod
+++ b/kod/object/item/passitem/weapon/bkdagger.kod
@@ -26,45 +26,71 @@ resources:
    BlackDagger_name_rsc = "black dagger"
    BlackDagger_icon_rsc = bkswd.bgf
    BlackDagger_desc_rsc = \
-   "This elegant blade looks like it would fit snugly between a pair of shoulder blades. \n\n%s%s%s"
+      "This elegant blade looks like it would fit snugly between "
+      "a pair of shoulder blades. \n\n%s%s%s"
    
-   BlackDagger_gamestart_glow = "~IYour dagger gains an unearthly glow about it."
+   BlackDagger_gamestart_glow = \
+      "~IYour dagger gains an unearthly glow about it."
 
    BlackDagger_impact = "~IThe black blade shatters upon impact!"
-   BlackDagger_cant_use = "~IYou try to wield the dark blade, but somehow, your heart is not quite in it."
-   BlackDagger_shiver = "~IThe black dagger suddenly shivers ominously in your hand."
+   BlackDagger_cant_use = \
+      "~IYou try to wield the dark blade, but somehow, your heart "
+      "is not quite in it."
+   BlackDagger_shiver = \
+      "~IThe black dagger suddenly shivers ominously in your hand."
 
    BlackDagger_notches = "There are %i notches carved in the handle."
-   BlackDagger_one_notch = "There is a single elegant notch carved in the handle."
+   BlackDagger_one_notch = \
+      "There is a single elegant notch carved in the handle."
    BlackDagger_no_notches = "The handle is smooth and flawless."
 
-   BlackDagger_4_gems = "All four gems in the pommel shine with unparalleled brilliance.  "
-   BlackDagger_3_gems = "Three of the gems in the pommel glow with a healthy luster.  "
-   BlackDagger_2_gems = "Two of the gems in the pommel seem to be brighter than the others.  "
-   BlackDagger_1_gems = "Only one of the four gems has any glow in it at all, and even that seems to be flickering.  "
+   BlackDagger_4_gems = \
+      "All four gems in the pommel shine with unparalleled brilliance.  "
+   BlackDagger_3_gems = \
+      "Three of the gems in the pommel glow with a healthy luster.  "
+   BlackDagger_2_gems = \
+      "Two of the gems in the pommel seem to be brighter than the others.  "
+   BlackDagger_1_gems = \
+      "Only one of the four gems has any glow in it at all, and even "
+      "that seems to be flickering.  "
 
-   BlackDagger_runes = "There seem to be some runes carved in the blade, but you can't make heads or tails of them.  "
-   BlackDagger_name = "There is, very clearly, a name carved into the blade.  It reads, '%q'.  "
+   BlackDagger_runes = \
+      "There seem to be some runes carved in the blade, but you can't "
+      "make heads or tails of them.  "
+   BlackDagger_name = \
+      "There is, very clearly, a name carved into the "
+      "blade.  It reads, '%q'.  "
    BlackDagger_window_overlay_rsc = povbkswd.bgf
    BlackDagger_player_overlay = bkswdov.bgf
 
    BlackDagger_miss = "You miss %s%s with your black dagger."
    BlackDagger_miss_target = "%s%s misses you with %s black dagger."
 
-   BlackDagger_hit = "You hit %s%s with your black dagger, but the blade seems to weaken as you do so."
-   BlackDagger_hit_target = "%s%s hits you with the black dagger, but leaves nary a wound."
+   BlackDagger_hit = \
+      "You hit %s%s with your black dagger, but the blade seems to "
+      "weaken as you do so."
+   BlackDagger_hit_target = \
+      "%s%s hits you with the black dagger, but leaves nary a wound."
 
-   BlackDagger_surehit = "You hit %s%s with your black dagger, and sink it in to the hilt!"
-   BlackDagger_surehit_target = "%s%s hits you with %s black dagger, and you feel your soul being invaded!"
-                             BlackDagger_dies = "You have been slain at the hands of %s%s!"
+   BlackDagger_surehit = \
+      "You hit %s%s with your black dagger, and sink it in to the hilt!"
+   BlackDagger_surehit_target = \
+      "%s%s hits you with %s black dagger, and you feel your "
+      "soul being invaded!"
+   BlackDagger_dies = "You have been slain at the hands of %s%s!"
    BlackDagger_dies_killer = "You have slain %s%s with your black dagger!"
 
-   BlackDagger_no_leave = "As you release hold of the black dagger, it seems to cling to your hand!"
-   BlackDagger_glows = "~IOne of the gemstones in the hilt of your blade flickers back to life."
+   BlackDagger_no_leave = \
+      "As you release hold of the black dagger, it seems "
+      "to cling to your hand!"
+   BlackDagger_glows = \
+      "~IOne of the gemstones in the hilt of your blade "
+      "flickers back to life."
 
    BlackDagger_mail_logoff = "Subject: You ignored your gems, coward.\n"
-      "You logged off while one or more of your gems was not aglow, and therefore you were "
-      "kicked out of the Assassin's Game.\n\n-- Roq, the Dark Blade"
+      "You logged off while one or more of your gems was not aglow, and "
+      "therefore you were kicked out of the Assassin's Game.\n\n-- Roq, "
+      "the Dark Blade"
 
    BlackDagger_mail_warning = "Subject: I watch you, absent one.\n"
       "You have not been spending enough time online to compete in the "
@@ -179,7 +205,7 @@ messages:
       oTarget = Send(Send(SYS,@GetAssassinGame),@GetPrimaryOpponent,#who=poOwner);
       if oTarget = $
       {
-         debug("Invalid target!  Black dagger in hands of non-combatant?");
+         Debug("Invalid target!  Black dagger in hands of non-combatant?");
          AddPacket(4,BlackDagger_runes);
 
          return;
@@ -219,23 +245,23 @@ messages:
 
       if target = $
       {
-         DEBUG("Reached AssassinHit with Target equal NIL!");
-         
+         Debug("Reached AssassinHit with Target equal NIL!");
+
          return;
       }
 
       oDagger = Send(Send(SYS,@GetAssassinGame),@GetDagger,#who=target);
 
       Send(poOwner,@MsgSendUser,#message_rsc=BlackDagger_surehit,
-           #parm1=Send(target,@GetDef),#parm2=Send(target,@GetName));
+            #parm1=Send(target,@GetDef),#parm2=Send(target,@GetName));
       Send(target,@MsgSendUser,#message_rsc=BlackDagger_surehit_target,
-           #parm1=Send(poOwner,@GetCapDef),#parm2=Send(poOwner,@GetName),
-           #parm3=Send(poOwner,@GetHisHer));
+            #parm1=Send(poOwner,@GetCapDef),#parm2=Send(poOwner,@GetName),
+            #parm3=Send(poOwner,@GetHisHer));
 
       Send(poOwner,@DoHitMessageSound,#what=target,
-           #damage=10,#stroke_obj=Send(SYS,@findskillbynum,#num=SKID_SLASH));
+            #damage=10,#stroke_obj=Send(SYS,@FindSkillByNum,#num=SKID_SLASH));
       Send(oDagger,@AssassinTakesHit,#attacker=poOwner);
-      
+
       % Does the animations and overlays.
       Send(self,@WeaponAttack);
 
@@ -246,18 +272,18 @@ messages:
    {
       if target = $
       {
-         DEBUG("Reached AssassinHit with Target equal NIL!");
+         Debug("Reached AssassinHit with Target equal NIL!");
          
          return;
       }
 
       Send(poOwner,@MsgSendUser,#message_rsc=BlackDagger_hit,
-           #parm1=Send(target,@GetDef),#parm2=Send(target,@GetName));
+            #parm1=Send(target,@GetDef),#parm2=Send(target,@GetName));
       Send(target,@MsgSendUser,#message_rsc=BlackDagger_hit_target,
-           #parm1=Send(poOwner,@GetCapDef),#parm2=Send(poOwner,@GetName));
+            #parm1=Send(poOwner,@GetCapDef),#parm2=Send(poOwner,@GetName));
 
       Send(poOwner,@DoHitMessageSound,#what=target,
-           #damage=1,#stroke_obj=Send(SYS,@FindSkillByNum,#num=SKID_SLASH));
+            #damage=1,#stroke_obj=Send(SYS,@FindSkillByNum,#num=SKID_SLASH));
 
       % Does the animations and overlays
       Send(self,@WeaponAttack);
@@ -275,7 +301,7 @@ messages:
             ptDagger_heal = CreateTimer(self,@DaggerHealTimer,DAGGER_HEAL_TIME);
          }
       }
-      
+
       return;
    }
 
@@ -283,21 +309,21 @@ messages:
    {
       if target = $
       {
-         DEBUG("Reached AssassinHit with Target equal NIL!");
+         Debug("Reached AssassinHit with Target equal NIL!");
          
          return;
       }
 
       Send(poOwner,@MsgSendUser,#message_rsc=BlackDagger_miss,
-          #parm1=Send(target,@GetDef),#parm2=Send(target,@GetName));
+            #parm1=Send(target,@GetDef),#parm2=Send(target,@GetName));
       Send(target,@MsgSendUser,#message_rsc=BlackDagger_miss_target,
-          #parm1=Send(poOwner,@GetCapDef),#parm2=Send(poOwner,@GetName),
-          #parm3=Send(poOwner,@GetHisHer));
+            #parm1=Send(poOwner,@GetCapDef),#parm2=Send(poOwner,@GetName),
+            #parm3=Send(poOwner,@GetHisHer));
 
       % Does the animations and overlays
       Send(self,@WeaponAttack);
       Send(Send(SYS,@findskillbynum,#num=SKID_SLASH),@SendMissMessageToAttacker,
-           #who=poOwner,#victim=target,#weapon_used=self,#bText=FALSE);
+            #who=poOwner,#victim=target,#weapon_used=self,#bText=FALSE);
 
       return;
    }
@@ -306,7 +332,7 @@ messages:
    {
       if attacker = $
       {
-         DEBUG("Reached AssassinTakesHit with Target equal NIL!");
+         Debug("Reached AssassinTakesHit with Target equal NIL!");
 
          return;
       }
@@ -323,7 +349,7 @@ messages:
             ptPlayer_heal = CreateTimer(self,@PlayerHealTimer,PLAYER_HEAL_TIME);
          }
       }
-      
+
       return;
    }
 
@@ -333,8 +359,8 @@ messages:
 
       if attacker = $
       {
-         DEBUG("Reached AssassinDies with Target equal NIL!");
-         
+         Debug("Reached AssassinDies with Target equal NIL!");
+
          return;
       }
 
@@ -342,19 +368,19 @@ messages:
       Send(oDagger,@AddNotch);
 
       Send(poOwner,@MsgSendUser,#message_rsc=BlackDagger_dies,
-           #parm1=Send(attacker,@GetDef),#parm2=Send(attacker,@GetName));
+            #parm1=Send(attacker,@GetDef),#parm2=Send(attacker,@GetName));
       Send(attacker,@MsgSendUser,#message_rsc=BlackDagger_dies_killer,
-           #parm1=Send(poOwner,@GetCapDef),#parm2=Send(poOwner,@GetName));
+            #parm1=Send(poOwner,@GetCapDef),#parm2=Send(poOwner,@GetName));
       Send(Send(poOwner,@getOwner),@NewHold,#what=Send(poOwner,@CreateCorpse,#Assassinated=TRUE),
-           #new_row=Send(poOwner,@GetRow),#new_col=Send(poOwner,@GetCol),
-           #fine_row=16,#fine_col=16, #new_angle=Send(poOwner,@GetAngle));
+            #new_row=Send(poOwner,@GetRow),#new_col=Send(poOwner,@GetCol),
+            #fine_row=16,#fine_col=16, #new_angle=Send(poOwner,@GetAngle));
 
       Send(poOwner,@TeleportTo,#rid=RID_UNDERWORLD,#bAdminPort=FALSE);
 
       % Make this a penalty-free "death".
       Send(poOwner,@SetDeathCost,#DeathCost=0);
       Send(Send(SYS,@GetAssassinGame),@QuitCombatant,#who=poOwner,#kill=TRUE);
-     
+
       return;
    }
 
@@ -362,7 +388,7 @@ messages:
    {
       if piPlayer_hits < 1 OR piPlayer_hits > (PLAYER_MAX - 1)
       {
-         DEBUG("PlayerHealTimer called while piPlayer_hits was an invalid value!");
+         Debug("PlayerHealTimer called while piPlayer_hits was an invalid value!");
 
          return;
       }
@@ -389,7 +415,7 @@ messages:
    {
       if piDagger_hits < 1 OR piDagger_hits > (DAGGER_MAX - 1)
       {
-         DEBUG("DaggerHealTimer called while piDagger_hits was an invalid value!");
+         Debug("DaggerHealTimer called while piDagger_hits was an invalid value!");
 
          return;
       }
@@ -414,14 +440,14 @@ messages:
    AddNotch()
    {
       piNotches = piNotches + 1;
-      
+
       return;
    }
 
    ReqUse(what=$)
    {
       local oGame;
-      
+
       oGame=Send(SYS,@GetAssassinGame);
 
       if Send(oGame,@InSession) AND Send(oGame,@isCombatant,#who=what)
@@ -430,7 +456,7 @@ messages:
       }
 
       Send(poOwner,@MsgSendUser,#message_rsc=BlackDagger_cant_use);
-      
+
       return FALSE;
    }
 
@@ -481,7 +507,7 @@ messages:
    "NPC or offered to anyone."
    {
       Send(poOwner,@MsgSendUser,#message_rsc=BlackDagger_no_leave);
-      
+
       return FALSE;
    }
 
@@ -524,20 +550,20 @@ messages:
       }
 
       iStart_time = Send(Send(SYS,@GetAssassinGame),@GetStartTime);
-      iLogon_time = Send(poOwner,@GetLastLoginTime);   
+      iLogon_time = Send(poOwner,@GetLastLoginTime);
 
       if iStart_time > iLogon_time
       {
          return (piTime_online + (GetTime() - iStart_Time));
       }
-      
+
       return (piTime_online + (GetTime() - iLogon_time));
    }
 
    AddShiver()
-   {      
+   {
       piShiver = piShiver + 1;
-      
+
       return;
    }
 
@@ -549,7 +575,7 @@ messages:
       }
 
       % Just in case they logged off recently.
-      if ptShiver <> $                
+      if ptShiver <> $
       {
          DeleteTimer(ptShiver);
          ptShiver = $;
@@ -558,7 +584,7 @@ messages:
       if piTime_Online = 0
       {
          ptShiver = CreateTimer(self,@ShiverTimer,10000);
-         
+
          propagate;
       }
 
@@ -579,15 +605,15 @@ messages:
 
       if piShiver < 0 AND piTime_online <> 0
       {
-         DEBUG("piShiver not less than zero and piTime_online not = 0!");
-         
+         Debug("piShiver not less than zero and piTime_online not = 0!");
+
          return;
       }
 
       if piTime_online = 0
       {
          Send(poOwner,@MsgSendUser,#message_rsc=BlackDagger_gamestart_glow);
-       
+
          return;
       }
 
@@ -596,7 +622,7 @@ messages:
          Send(poOwner,@MsgSendUser,#message_rsc=BlackDagger_shiver);
          piShiver = piShiver - 1;
       }
-      
+
       return;
    }
 
@@ -613,9 +639,9 @@ messages:
    Warn()
    {
       Send(poOwner,@ReceiveNestedMail,#nest_list=[4,BlackDagger_mail_warning],
-           #from=BlackDagger_roq,#dest_list=[poOwner]);
+            #from=BlackDagger_roq,#dest_list=[poOwner]);
       pbWarned = TRUE;
-      
+
       return;
    }
 
@@ -631,7 +657,7 @@ messages:
       return FALSE;
    }
 
-   CanBeStoredInVault()   
+   CanBeStoredInVault()
    {
       return FALSE;
    }
@@ -641,7 +667,7 @@ messages:
    {
       return FALSE;
    }
-	
+
    Delete()
    {
       if ptDagger_heal <> $
@@ -649,13 +675,13 @@ messages:
          DeleteTimer(ptDagger_heal);
          ptDagger_heal = $;
       }
-      
+
       if ptPlayer_heal <> $
       {
          DeleteTimer(ptPlayer_heal);
          ptPlayer_heal = $;
       }
-      
+
       if ptShiver <> $
       {
          DeleteTimer(ptShiver);
@@ -673,16 +699,16 @@ messages:
 
    CleanUp()
    {
-		if poOwner <> $
-		{
-			debug("Cleaning up daggers.  Found one contained by",Send(poOwner,@GetName));
-		}
-		
-		Send(self,@Delete);
-		
-		return;
-   }
+      if poOwner <> $
+      {
+         Debug("Cleaning up daggers.  Found one contained by",
+               Send(poOwner,@GetName));
+      }
 
+      Send(self,@Delete);
+
+      return;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/weapon/unique.kod
+++ b/kod/object/item/passitem/weapon/unique.kod
@@ -31,21 +31,21 @@ resources:
       "Your weapon sears into your flesh, clinging to your hand as it burns."
    UniqueWeapon_logoff = \
       "Your weapon writhes free to seek a more blood thirsty owner."
-   
+
 classvars:
    vrName = UniqueWeapon_name_rsc
    vrIcon = UniqueWeapon_icon_rsc
    vrDesc = UniqueWeapon_desc_rsc
 
    % The Assassin's dagger is a low quality thrusting weapon, making it
-   %  shortsword like.
+   % shortsword like.
    viWeaponType = WEAPON_TYPE_THRUST
    viWeaponQuality = WEAPON_QUALITY_LOW
 
    viMin_damage = 8
    viMax_damage = 12
 
-   viProficiency_Needed = SKID_PROFICIENCY_SWORD
+   viProficiency_Needed = SKID_PROFICIENCY_SHORTSWORD
 
    viValue_average = 0
    viBulk = 35
@@ -64,6 +64,7 @@ properties:
 
    piAttack_type = ATCK_WEAP_NONMAGIC + ATCK_WEAP_PIERCE
    pbNewlyCreated = 0
+   piHitBonus = 75
 
 messages:
 
@@ -72,27 +73,21 @@ messages:
       pbNewlyCreated = 1;
       Send(&UniqueWeapon,@CheckNewlyCreated);
       pbNewlyCreated = 0;
-        
+
       propagate;
    }
 
    GetBaseDamage(who=$,target=$)
    {
-      return random(viMin_damage,viMax_damage);
-   }
-
-   ModifyHitRoll()
-   {
-      % Return a good bonus
-      return 20;
+      return Random(viMin_damage,viMax_damage);
    }
 
    CheckNewlyCreated()
    {
       if pbNewlyCreated = 0
       {
-         Post(self,@delete);
-         debug("Someone tried to make Multiple Unique Items.");
+         Post(self,@Delete);
+         Debug("Someone tried to make Multiple Unique Items.");
       }
 
       return;
@@ -104,9 +99,9 @@ messages:
       return FALSE;
    }
 
-   CanBeStoredInVault()   
+   CanBeStoredInVault()
    {
-      Send(poOwner,@msgSenduser,#message_rsc=UniqueWeapon_cant_vault);
+      Send(poOwner,@MsgSendUser,#message_rsc=UniqueWeapon_cant_vault);
 
       return FALSE;
    }
@@ -146,7 +141,7 @@ messages:
 
       oRoom = Send(SYS,@FindRoomByNum,#num=rid_DUKE4);
       % called every 2 minutes, so this means an average of 30 minutes.
-      if random(1,15) = 1        
+      if Random(1,15) = 1
       {
          Send(oRoom,@NewHold,#what=self,#new_row=20,#new_col=15);
       }
@@ -159,16 +154,16 @@ messages:
    {
       local iRandom;
 
-      iRandom = random(1,5);
+      iRandom = Random(1,5);
 
       % 20% chance to drop if you're not a DM+
       if iRandom = 1 AND NOT IsClass(poOwner,&DM)
       {
          Send(poOwner,@MsgSendUser,#message_rsc=UniqueWeapon_logoff);
          Send(Send(poOwner,@GetOwner),@NewHold,#what=self,
-              #new_row=Send(poOwner,@GetRow),#new_col=Send(poOwner,@GetCol),
-              #fine_row=Send(poOwner,@GetFineRow),
-              #fine_col=Send(poOwner,@GetFineCol));
+               #new_row=Send(poOwner,@GetRow),#new_col=Send(poOwner,@GetCol),
+               #fine_row=Send(poOwner,@GetFineRow),
+               #fine_col=Send(poOwner,@GetFineCol));
       }
 
       propagate;
@@ -183,7 +178,6 @@ messages:
 
       return ((poOwner = $) OR Send(poOwner,@ReqLeaveHold,#what=self));
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/util/assgame.kod
+++ b/kod/util/assgame.kod
@@ -32,8 +32,8 @@ constants:
    % One day
    GAME_DAY = 86400000
 
-   % Players must spend an average of 3 hours per day online. 
-   MINIMUM_TIME_ONLINE = 10800
+   % Players must spend an average of 1 hour per day online.
+   MINIMUM_TIME_ONLINE = 3600
 
 resources:
 
@@ -317,7 +317,7 @@ messages:
    "Removes the player from the combat proceedings.  Also, removes their "
    "dagger.  Also, lets others know that player is gone."
    {
-      local i, bFound, oOpponent;
+      local i, bFound, oOpponent, oDagger;
 
       if who = $
       {
@@ -356,8 +356,13 @@ messages:
 
             plCombatants = DelListElem(plCombatants,i);
             bFound = TRUE;
-            Send(Send(self,@GetDagger,#who=who),@delete);
-               
+
+            oDagger = Send(self,@GetDagger,#who=who);
+            if oDagger <> $
+            {
+               Send(oDagger,@Delete);
+            }
+
             if wincheck
             {
                Send(self,@CheckForWinner);
@@ -389,14 +394,14 @@ messages:
          return FALSE;
       }
 
-      if not isClass(who,&user)
+      if NOT isClass(who,&user)
       {
          Debug("Can't advertise to non-player!");
 
          return FALSE;
       }
 
-      if not Send(self,@IsAdvertised,#who=who)
+      if NOT Send(self,@IsAdvertised,#who=who)
       {
          plAdvertise = Cons(who,plAdvertise);
       }
@@ -438,10 +443,10 @@ messages:
       local i;
 
       % Remove from ad list
-      Send(self,@StopAdvertising,#who=who);        
+      Send(self,@StopAdvertising,#who=who);
 
       % Remove from combatant list
-      if Send(self,@IsCombatant,#who=who)          
+      if Send(self,@IsCombatant,#who=who)
       {
          Send(self,@QuitCombatant,#who=who);
       }
@@ -475,7 +480,7 @@ messages:
                if Length(plMost_kills) = 0
                {
                   piNum_kills = 0;
-               }   
+               }
             }
          }
         
@@ -519,7 +524,7 @@ messages:
          return FALSE;
       }
 
-      if not Send(self,@InSession)
+      if NOT Send(self,@InSession)
       {
          Debug("Player ",Send(attacker,@GetName)," attacked when a match "
                "wasn't in session!");
@@ -534,8 +539,8 @@ messages:
       }
 
       % Check for "safe zones".  Currently only the Underworld.
-      if not Send(Send(target,@GetOwner),@ReqAssassinGameAttack,#what=attacker)
-      {        
+      if NOT Send(Send(target,@GetOwner),@ReqAssassinGameAttack,#what=attacker)
+      {
          return FALSE;
       }
 
@@ -590,7 +595,7 @@ messages:
          for i in plCombatants
          {
             Send(i,@ReceiveNestedMail,#nest_list=[4,assgame_mail_reset],
-              #from=assgame_roq,#dest_list=[i]);
+               #from=assgame_roq,#dest_list=[i]);
          }
       }
       
@@ -603,11 +608,17 @@ messages:
       pbAccept_mode = FALSE;
       plMost_kills = $;
       piNum_kills = 0;
-      
+
       % Okay, at this point, the combatant list should be nil, and no black 
       %  daggers should exist anywhere.
       plCombatants = $;
-      Send(&BlackDagger,@CleanUp); 
+      Send(&BlackDagger,@CleanUp);
+
+      if ptMaintenance <> $
+      {
+         DeleteTimer(ptMaintenance);
+      }
+      ptMaintenance = $;
 
       % This will almost always be true.
       if ptGame <> $
@@ -617,7 +628,7 @@ messages:
 
       iValue = Bound(Random(piGame_Wait_Min,piGame_Wait_Max),1,MAX_INT);
       ptGame = CreateTimer(self,@GameTimer,iValue);
-      
+
       return;
    }
 
@@ -1164,7 +1175,5 @@ messages:
       return TRUE;
    }
 
-
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-

--- a/kod/util/assgame.kod
+++ b/kod/util/assgame.kod
@@ -760,6 +760,9 @@ messages:
    EnterAcceptMode()
    {
       local i, iValue;
+
+      % Clear combatants list.
+      plCombatants = $;
       
       % No daggers should exist right now - none have been given out.
       Send(&BlackDagger,@CleanUp);
@@ -804,8 +807,8 @@ messages:
 
          return FALSE;
       }
-      
-      if not Send(self,@IsViableGame)
+
+      if NOT Send(self,@IsViableGame)
       {
          Send(self,@EnterAcceptMode);
 
@@ -818,7 +821,7 @@ messages:
          DeleteTimer(ptGame);
          ptGame = $;
       }
-      
+
       pbAccept_mode = FALSE;
       pbGame_in_Session = TRUE;
 


### PR DESCRIPTION
Thrust resist should be 15, not 16. Bludgeon is displayed twice if this happens.

Removed a brazier that was behind a wall in CN inn.

Added IsBeverage message to EasterEgg class, called when someone tries to eat the egg but is full.

Cleaned up the IsInSameRoom message in NoMoveOn; message is much faster without all the unnecessary Send calls.

Fixed faction soldier NPCs doing slash damage no matter what weapon they are holding. They now ask the weapon for what damage type to do.

Fixed mana not regenerating after phasing back in. The mana timer is stopped if a user is phased out but is not started when phased back in. The timer will now be active during phase, but no mana will be lost or gained (it now works same as the health timer).

Fixed Assassin's game maintenance timer not being deleted on game reset, and check for dagger existing before sending it Delete. Clear combatants list when game enters admission state (game restart or end). Decreased min time online before getting booted from 3 hours to 1 hour.

Cleaned up bkdagger.kod, no changes.

Fixed hitroll on the unique dagger, was returning 20 (i.e. player's total offense would be ~20). Now gives a hit bonus of 75 in addition to what a short sword would normally give. Proficiency changed from fencing to short sword fighting. This item isn't currently in game, but I have some ideas on how we could use it.

Cleaned up chaosfood.kod. Lowered the weight so they can be bought during frenzy, as they're deleted if someone has them outside a frenzy anyway. Allowed DMs to eat them at any time for testing purposes.

Added a black minimap dot for masks in survival arena (no dot elsewhere). Added an IsClass check for player before checking for grouping (IsClass faster than Send, called on every object the player sees).