### PR TITLE
Allow KOD message names to be easily saved as strings by SetString. Add support for calling messages by string to SendMessage and PostMessage.

### DIFF
--- a/blakserv/term.c
+++ b/blakserv/term.c
@@ -105,25 +105,29 @@ const char * GetDataName(val_type val)
       r = GetResourceByID(val.v.data);
       if (r == NULL)
       {
-	 sprintf(s,"%i",val.v.data);
-	 return s;
+         sprintf(s,"%i",val.v.data);
+         return s;
       }
       if (r->resource_name == NULL)
       {
-	 sprintf(s,"%i",r->resource_id);
-	 return s;
+         sprintf(s,"%i",r->resource_id);
+         return s;
       }
       return r->resource_name;
+
    case TAG_CLASS :
       c = GetClassByID(val.v.data);
       if (c == NULL)
       {
-	 eprintf("GetTagData error, can't find class id %i\n",val.v.data);
-	 sprintf(s,"%i",val.v.data);
-	 return s;
+         eprintf("GetTagData error, can't find class id %i\n",val.v.data);
+         sprintf(s,"%i",val.v.data);
+         return s;
       }
       return c->class_name;
+
    case TAG_MESSAGE :
+      // Message tag saving *is* supported, however is not advised as message ID
+      // numbers can change and any resulting call could have undesired effects.
       eprintf("GetTagData error, message tag saving not supported %i\n",val.v.data);
 
       /* fall through */
@@ -194,12 +198,12 @@ int GetDataNum(int tag_val,const char *data_str)
       r = GetResourceByName(data_str);
       if (r != NULL)
       {
-	 retval = r->resource_id;
-	 break;
+         retval = r->resource_id;
+         break;
       }
 
       if (sscanf(data_str,"%i",&retval) != 1)
-	 retval = INVALID_DATA;
+         retval = INVALID_DATA;
 
       break;
 
@@ -207,18 +211,19 @@ int GetDataNum(int tag_val,const char *data_str)
       c = GetClassByName(data_str);
       if (c != NULL)
       {
-	 retval = c->class_id;
-	 break;
+         retval = c->class_id;
+         break;
       }
 
       if (sscanf(data_str,"%i",&retval) != 1)
-	 retval = INVALID_DATA;
+         retval = INVALID_DATA;
 
       break;
 
    case TAG_MESSAGE :
-      eprintf("GetDataNum error, message ID loading not supported\n");
-      retval = INVALID_DATA;
+      retval = GetIDByName(data_str);
+      if (retval == INVALID_ID)
+         retval = INVALID_DATA;
       break;
 
    case TAG_TEMP_STRING :
@@ -228,9 +233,8 @@ int GetDataNum(int tag_val,const char *data_str)
 
    default :
       if (sscanf(data_str,"%i",&retval) != 1)
-	 retval = INVALID_DATA;
+         retval = INVALID_DATA;
    }
 
    return retval;
 }
-


### PR DESCRIPTION
This is intended to be complementary to Keen's real-time/game event pull request. One of the issues faced with that system was the inability to call a message at a set time in the future without messy timer interactions (multiple timers for longer than 37 hours).

This pull request will allow C_SendMessage and C_PostMessage to be passed a string (TAG_STRING only) instead of a proper message, from which both C calls will use the message name given to obtain the proper message ID. This is handled inside the check for != TAG_MESSAGE thus existing calls should not run any slower.

C_SetString can now create its own string if passed $ to avoid the need for two calls to create a string. It can also now handle TAG_DEBUGSTR (anything enclosed in " ") and TAG_MESSAGE. If C_SetString is passed a message, it will set the string/created string to the name of that message, creating a data structure with TAG_STRING and the name value of the message sent. This string could then be saved to a list and retrieved later to call via the scheduling system Keen has created.

Saving a message itself (i.e. TAG_MESSAGE, message ID) in a list technically works, however blakserv would save and load this list node as-is, and if the KOD code is recompiled in a way which causes message numbers to change, the resulting message call might cause unwanted effects (e.g. perhaps that message ID now corresponds to Delete). I have a version of savegame.c and loadgame.c locally that can save messages by name for list nodes and reload them correctly however such a change has the potential to break save games (more so for anyone else using our codebase) and should probably be discussed before implementing it. If anyone is interested in looking at that change, you can find it here: https://github.com/skittles1/Meridian59_103/commit/3267c6f1e72dbe01d45647c742ac7ed89cd96fb5.

SetString/Send usage:
```
SomeMessage()
{
   local lList, sString;

   sString = SetString($,@SomeOtherMessage);
   lList = [sString];

   Send(self,First(lList));

   return;
}
```