### PR TITLE
Convert single honor string in Player (psHonor) to honor string list.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1021,6 +1021,7 @@ properties:
    ptAttackTimer = $
 
    psHonor = $
+   plHonor = $
 
    piMonsterChasers = 0
 
@@ -1792,11 +1793,7 @@ messages:
          AND NOT (piFlags & PFLAG_TUTORIAL)
       {
          Send(self,@SetPlayerFlag,#flag=PFLAG_TUTORIAL,#value=TRUE);
-         if psHonor <> $
-            AND StringEqual(psHonor,player_newbie_honor_string)
-         {
-            Send(self,@SetHonorString);
-         }
+         Send(self,@RemoveHonorString,#string=player_newbie_honor_string);
       }
 
       return age;
@@ -1830,6 +1827,139 @@ messages:
    GetHonorString()
    {
       return psHonor;
+   }
+
+   SetHonorStrings()
+   "Used to set plHonor for all players using whatever psHonor they have. "
+   "Remove this if psHonor is removed (after switching to plHonor)."
+   {
+      if psHonor <> $
+      {
+         if psHonor = GetTempString()
+            OR StringEqual(psHonor,"")
+         {
+            return;
+         }
+
+         Send(self,@AddHonorString,#string=psHonor);
+      }
+
+      return;
+   }
+
+   GetHonorStringList()
+   {
+      return plHonor;
+   }
+
+   HasHonorString(string = $)
+   "Checks the plHonor list for the given string."
+   {
+      local i;
+
+      if plHonor = $
+         or string = $
+      {
+         return FALSE;
+      }
+
+      % Convert temp string if we received it.
+      if string = GetTempString()
+      {
+         string = SetString($,string);
+      }
+
+      for i in plHonor
+      {
+         if StringContain(i,string)
+         {
+            return TRUE;
+         }
+      }
+
+      return FALSE;
+   }
+
+   AppendHonorStrings()
+   "Appends all the honor strings to the temp string. Adds newline "
+   "between strings."
+   {
+      local i;
+
+      if plHonor <> $
+      {
+         for i in plHonor
+         {
+            AppendTempString(i);
+            AppendTempString("\n");
+         }
+      }
+
+      return;
+   }
+
+   AddHonorString(string=$,iPosition = 1)
+   "Adds string to plHonor list. iPosition allows string position "
+   "to be chosen."
+   {
+      if string = $
+      {
+         return;
+      }
+
+      % Convert temp string if we received it.
+      if string = GetTempString()
+      {
+         string = SetString($,string);
+      }
+
+      if plHonor = $
+      {
+         plHonor = [string];
+      }
+      else
+      {
+         plHonor = InsertListElem(plHonor,iPosition,string);
+      }
+
+      return;
+   }
+
+   RemoveHonorString(string=$)
+   "Removes the given string from plHonor. Searches the entire list, "
+   "so it will remove any duplicates."
+   {
+      local i;
+
+      if plHonor = $
+         OR string = $
+      {
+         return;
+      }
+
+      % Convert temp string if we received it.
+      if string = GetTempString()
+      {
+         string = SetString($,string);
+      }
+
+      for i in plHonor
+      {
+         if StringContain(i,string)
+         {
+            plHonor = DelListElem(plHonor,i);
+         }
+      }
+
+      return;
+   }
+
+   ClearHonorStrings()
+   "Removes all the honor strings."
+   {
+      plHonor = $;
+
+      return;
    }
 
    ShowExtraInfo()
@@ -2030,17 +2160,8 @@ messages:
 %         AppendTempString(player_nl);
 %      }
 
-      if psHonor <> $
-      {
-         if psHonor <> GetTempString()
-         {
-            AppendTempString(psHonor);
-         }
-         else
-         {
-            psHonor = $;
-         }
-      }
+      % Append all the honor strings to the temp string.
+      Send(self,@AppendHonorStrings);
 
       if plDonationYears <> $
       {
@@ -2558,7 +2679,7 @@ messages:
       {
          Send(self,@ReceiveNestedMail,#from=player_angel,
                #dest_list=[self],#nest_list=[4,player_first_mail]);
-         Send(self,@SetHonorString,#string=player_newbie_honor_string);
+         Send(self,@AddHonorString,#string=player_newbie_honor_string);
          Post(self,@MsgSendUser,#message_rsc=player_newbie_commands);
       }
 
@@ -9072,8 +9193,7 @@ messages:
       % Don't drop anything or take any penalties.
       if Send(SYS,@GetChaosNight)
         OR (iRoom >= RID_NEWB_BASE AND iRoom <= RID_NEWB_MAX)
-        OR psHonor <> $
-           AND StringEqual(psHonor,player_newbie_honor_string)
+        OR Send(self,@HasHonorString,#string=player_newbie_honor_string)
       {
          bNo_drop_death = TRUE;
          piDeathCost = FALSE;
@@ -12275,10 +12395,7 @@ messages:
             % Once you've become killable, you no longer get tutorial messages
             % and bonuses.  You also lose your newbie string.
             Send(self,@SetPlayerFlag,#flag=PFLAG_TUTORIAL,#value=TRUE);
-            if psHonor <> $ AND StringEqual(psHonor,player_newbie_honor_string)
-            {
-               Send(self,@SetHonorString);
-            }
+            Send(self,@RemoveHonorString,#string=player_newbie_honor_string);
 
             Send(self,@SetPlayerFlag,#flag=PFLAG_PKILL_ENABLE,#value=TRUE);
             if dbug = TRUE

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1836,7 +1836,11 @@ messages:
       if psHonor <> $
       {
          if psHonor = GetTempString()
-            OR StringEqual(psHonor,"")
+         {
+            return;
+         }
+
+         if StringEqual(psHonor,"")
          {
             return;
          }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -1578,6 +1578,7 @@ messages:
       piLastLoginTime = 0;
       psUrl = $;
       psHonor = $;
+      plHonor = $;
       piLogoffPenaltyCount = -1;
 
       if pbLogged_on

--- a/kod/object/passive/spell/dmspell/damn.kod
+++ b/kod/object/passive/spell/dmspell/damn.kod
@@ -50,7 +50,7 @@ messages:
    {
       local i, j, oHell;
 
-      oHell = send(SYS,@FindRoomByNum,#num=RID_OUTOFGRACE);
+      oHell = Send(SYS,@FindRoomByNum,#num=RID_OUTOFGRACE);
 
       for j in lTargets
       {
@@ -58,24 +58,24 @@ messages:
 
          if isClass(i,&Battler)
          {
-            send(i,@MsgSendUser,#message_rsc=damn_msg_target,
+            Send(i,@MsgSendUser,#message_rsc=damn_msg_target,
                  #parm1=Send(who,@GetIndef),#parm2=Send(who,@GetTrueName));
-            send(who,@MsgSendUser,#message_rsc=damn_msg_DM,
+            Send(who,@MsgSendUser,#message_rsc=damn_msg_DM,
                  #parm1=Send(i,@GetDef),#parm2=Send(i,@GetTrueName));
 
-            send(SYS,@UtilGoNearSquare,#what=i,#where=oHell,#new_row=4,#new_col=3);
+            Send(SYS,@UtilGoNearSquare,#what=i,#where=oHell,#new_row=4,#new_col=3);
 
             if isClass(i,&Player)
             {
                % (example)  She was sent to hell by GuidePixie.
 
                ClearTempString();
-               AppendTempString(send(i,@GetHeShe,#cap=TRUE));
+               AppendTempString(Send(i,@GetHeShe,#cap=TRUE));
                AppendTempString(damn_last_annoyed);
-               AppendTempString(send(who,@GetTrueName));
+               AppendTempString(Send(who,@GetTrueName));
                AppendTempString(damn_dot);
 
-               send(i,@SetHonorString,#string=GetTempString());
+               Send(i,@AddHonorString,#string=GetTempString());
             }
 
             continue;
@@ -85,20 +85,20 @@ messages:
          {
             Send(SYS,@UtilGoNearSquare,#what=i,#where=oHell,#new_row=4,#new_col=3);
 
-            i = send(i,@GetGhostedPlayer);
-            send(who,@MsgSendUser,#message_rsc=damn_msg_DM,
+            i = Send(i,@GetGhostedPlayer);
+            Send(who,@MsgSendUser,#message_rsc=damn_msg_DM,
                  #parm1=Send(i,@GetDef),#parm2=Send(i,@GetTrueName));
-            send(i,@SetSaveLocation,#rid=RID_OUTOFGRACE,#row=4,#col=3);
+            Send(i,@SetSaveLocation,#rid=RID_OUTOFGRACE,#row=4,#col=3);
 
             % (example)  She was sent to hell by GuidePixie.
 
             ClearTempString();
-            AppendTempString(send(self,@GetHeShe,#cap=TRUE));
+            AppendTempString(Send(self,@GetHeShe,#cap=TRUE));
             AppendTempString(damn_last_annoyed);
-            AppendTempString(send(who,@GetTrueName));
-	    AppendTempString(damn_dot);
+            AppendTempString(Send(who,@GetTrueName));
+            AppendTempString(damn_dot);
 
-            send(i,@SetHonorString,#string=GetTempString());
+            Send(i,@AddHonorString,#string=GetTempString());
 
             continue;
          }
@@ -110,7 +110,6 @@ messages:
 
       propagate;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/dmspell/dmrescue.kod
+++ b/kod/object/passive/spell/dmspell/dmrescue.kod
@@ -39,7 +39,7 @@ messages:
 
    CastSpell(who=$,lTargets=$)
    {
-      local i, j, oRoom, oHell, sHonor;
+      local i, j, oRoom, oHell;
 
       % Unless the player is a 'SeniorGuide' or above, all they can
       % do with this spell is send players home from OoG.
@@ -67,13 +67,8 @@ messages:
             Send(SYS,@UtilGoToSquare,#what=j,#where=oRoom,
                  #row=Send(i,@GetSaveRow),#col=Send(i,@GetSaveCol));
 
-            sHonor = Send(i,@GetHonorString);
-            if sHonor <> $
-               AND StringContain(sHonor,damn_last_annoyed)
-            {
-               ClearTempString();
-               Send(i,@SetHonorString,#string=GetTempString());
-            }
+            % If they have the damned string, this will remove it.
+            Send(i,@RemoveHonorString,#string=damn_last_annoyed);
 
             continue;
          }
@@ -82,13 +77,8 @@ messages:
          {
             Send(i,@AdminGoToSafety);
 
-            sHonor = Send(i,@GetHonorString);
-            if sHonor <> $
-               AND StringContain(sHonor,damn_last_annoyed)
-            {
-               ClearTempString();
-               Send(i,@SetHonorString,#string=GetTempString());
-            }
+            % If they have the damned string, this will remove it.
+            Send(i,@RemoveHonorString,#string=damn_last_annoyed);
 
             continue;
          }


### PR DESCRIPTION
There are several issues with having only a single honor string for players (and numerous bugs in the current psHonor system). Players now have a plHonor list which can contain several strings, all of which are appended to the player's bio. psHonor has to be left in until players can have their psHonor string added to the plHonor list via admin command (SetHonorStrings message, which ignores broken psHonor strings).