### PR TITLE
Stop mouselook and tab repeat toggle on key held down. Increment client min version to 26.

### DIFF
--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -48,7 +48,7 @@ typedef unsigned char Bool;
 enum {False = 0, True = 1};
 
 #define MAJOR_REV 50   /* Major version of client program */
-#define MINOR_REV 25  /* Minor version of client program; must be in [0, 99] */
+#define MINOR_REV 26  /* Minor version of client program; must be in [0, 99] */
 
 #define MAXAMOUNT 9     /* Max # of digits in a server integer */
 #define MAXSTRINGLEN 512 /* Max length of a string loaded from string table */

--- a/clientd3d/intrface.h
+++ b/clientd3d/intrface.h
@@ -106,10 +106,11 @@ enum { A_NOACTION = 0,
 #define IsAttackAction(action) ( (action) == A_ATTACK || (action) == A_ATTACKCLOSEST)
 #define IsViewAction(action)   ( (action) == A_LOOKUP || (action) == A_LOOKDOWN)
 #define IsMapMoveAction(action)      ( (action) == A_MAPZOOMIN || (action) == A_MAPZOOMOUT)
-
+#define IsTabAction(action) ( (action) == A_TABFWD || (action) == A_TABBACK)
+#define IsMouseLookAction(action) ( (action) == A_MOUSELOOK)
 // True iff action should cause auto-repeat
 #define RepeatAction(a) (IsMoveAction(a) || IsTurnAction(a) || IsCursorAction(a) || \
-			 IsViewAction(a) || IsMapMoveAction(a))
+			 IsViewAction(a) || IsMapMoveAction(a) || IsTabAction(a) || IsMouseLookAction(a))
 
 #ifdef __cplusplus
 extern "C" {

--- a/clientd3d/key.c
+++ b/clientd3d/key.c
@@ -171,7 +171,7 @@ int TranslateKey(UINT vk_key, KeyTable table, void **data)
  * HandleKeys:  Check state of keyboard and perform actions that correspond
  *   to keys that are down.
  */
-void HandleKeys(void)
+void HandleKeys(Bool poll)
 {
    Bool norepeat;
    BYTE keys[NUM_KEYS];
@@ -217,7 +217,11 @@ void HandleKeys(void)
 	 action = TranslateKey(i, table, &action_data);
 	 if (action == A_NOACTION)
 	    continue;
-	 
+
+   // Don't constantly toggle tab or mouselook if key held down.
+   if ((IsTabAction(action) || IsMouseLookAction(action)) && poll)
+      continue;
+
 	 // Perform action at most once
 	 already_done = False;
 	 for (j=0; j < num_actions; j++)

--- a/clientd3d/key.h
+++ b/clientd3d/key.h
@@ -53,7 +53,7 @@ M59EXPORT void KeyRemoveTable(int game_state, KeyTable table);
 
 M59EXPORT int  TranslateKey(UINT vk_key, KeyTable table, void **data);
 M59EXPORT void KeySetLastNorepeatTime(void);
-void HandleKeys(void);
+void HandleKeys(Bool poll);
 int  KeysDown(void);
 void KeyUpHack(int vk);
 

--- a/clientd3d/statgame.c
+++ b/clientd3d/statgame.c
@@ -174,7 +174,7 @@ Bool GameKey(HWND hwnd, UINT vk, BOOL fDown, int cRepeat, UINT flags)
 	 return True;
       else return False;
 
-   HandleKeys();    // Handle key right away; don't wait for idle processing to get it
+   HandleKeys(0);    // Handle key right away; don't wait for idle processing to get it
 
    /* 
     *  Special case for ALT key:  since the key is used for movement, it would
@@ -289,7 +289,7 @@ void GameIdle(void)
    MoveUpdateServer();       // Update our position on server, if necessary
 
    AnimationTimerProc(hMain, 0);
-   HandleKeys();
+   HandleKeys(1);
 
    // Are we the active foreground application?
    AnimationTimerAbort();

--- a/clientd3d/winmsg.c
+++ b/clientd3d/winmsg.c
@@ -214,10 +214,14 @@ void MainChar(HWND hwnd,char ch,int cRepeat)
 /****************************************************************************/
 void MainMouseLButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT keyFlags)
 {
+	// Send it to HandleKeys first in case user set a keybind to one
+	// of the mouse buttons.
+	HandleKeys(0);
+
 	/* See if a module wants to handle mouse click */
 	if (ModuleEvent(EVENT_MOUSECLICK, hwnd, fDoubleClick, x, y, keyFlags) == False)
 		return;
-	
+
 	switch (state)
 	{
 	case STATE_GAME:
@@ -228,10 +232,14 @@ void MainMouseLButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT keyFl
 /****************************************************************************/
 void MainMouseMButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT keyFlags)
 {
+	// Send it to HandleKeys first in case user set a keybind to one
+	// of the mouse buttons.
+	HandleKeys(0);
+
 	/* See if a module wants to handle mouse click */
 	if (ModuleEvent(EVENT_MOUSECLICK, hwnd, fDoubleClick, x, y, keyFlags) == False)
 		return;
-	
+
 	switch (state)
 	{
 	case STATE_GAME:
@@ -242,10 +250,14 @@ void MainMouseMButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT keyFl
 /****************************************************************************/
 void MainMouseRButtonDown(HWND hwnd, BOOL fDoubleClick, int x, int y, UINT keyFlags)
 {
+	// Send it to HandleKeys first in case user set a keybind to one
+	// of the mouse buttons.
+	HandleKeys(0);
+
 	/* See if a module wants to handle mouse click */
 	if (ModuleEvent(EVENT_MOUSECLICK, hwnd, fDoubleClick, x, y, keyFlags) == False)
 		return;
-	
+
 	switch (state)
 	{
 	case STATE_GAME:

--- a/keybind/m59BindForm.cs
+++ b/keybind/m59BindForm.cs
@@ -613,6 +613,7 @@ namespace m59bind
                 returnString = keyPrompt;
                 capturing = true;
             }
+            configChanged = true;
 
             return returnString;
         }


### PR DESCRIPTION
This change causes mouselook toggle and tab keys to be treated as repeat actions, so both can be repeated instantly. It also stops the idle keyboard polling from performing either of those actions, the net result being that mouselook/tab window can always be toggled, but will not toggle repeatedly if the key is held down. Client min version incremented.

NOTE: only applies to main graphics window, so holding down tab on stats/inventory list or chat box will always bring focus back to graphics window.