### PR TITLE
Remove enfeeble from daemon skeletons, lower dement chance/spellpower.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/skel/daemskel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/skel/daemskel.kod
@@ -13,9 +13,8 @@ DaemonSkeleton is Skeleton
 constants:
 
    include blakston.khd
-   
-   PALSY_CHANCE = 10
-   DEMENTIA_CHANCE = 10
+
+   DEMENTIA_CHANCE = 20
 
 resources:
 
@@ -90,31 +89,17 @@ messages:
    {
       local oSpell;
 
-      oSpell = Send(SYS,@FindSpellByNum,#num=SID_ENFEEBLE);
-      if NOT Send(what,@IsEnchanted,#what=oSpell)
-         AND Random(1,PALSY_CHANCE) = 1
-      {
-         if who <> $
-         {
-            Send(oSpell,@CastSpell,#who=who,#lTargets=[what],#iSpellPower=50);
-         }
-         else
-         {
-            Send(oSpell,@DoSpell,#what=self,#oTarget=what,#iSpellPower=50);
-         }
-      }
-
       oSpell = Send(SYS,@FindSpellByNum,#num=SID_DEMENT);
-      if NOT Send(what,@IsEnchanted,#what=oSpell) 
+      if NOT Send(what,@IsEnchanted,#what=oSpell)
          AND Random(1,DEMENTIA_CHANCE) = 1
       {
          if who <> $
          {
-            Send(oSpell,@CastSpell,#who=who,#lTargets=[what],#iSpellPower=50);
+            Send(oSpell,@CastSpell,#who=who,#lTargets=[what],#iSpellPower=15);
          }
          else
          {
-            Send(oSpell,@DoSpell,#what=self,#oTarget=what,#iSpellPower=50);
+            Send(oSpell,@DoSpell,#what=self,#oTarget=what,#iSpellPower=15);
          }
       }
 


### PR DESCRIPTION
Due to the large amount of complaints from players regarding daemon skeleton on-hit effects, have removed enfeeble entirely from being cast by them, and lowered the effectiveness/duration/chance of dement casts. Dement will cast 5% of the time (down from 10%), at 15 spellpower (down from 50).