### PR TITLE
Config option (settings.kod) for LoS skip handling (safespots?)

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -3076,11 +3076,13 @@
 
    %%% Line of Sight (LOS) testing
 
-   % Determines which version of LOS we're using.
-   LOS_OLD = 0
-   LOS_NEW_MONSTER = 1
-   LOS_NEW_PLAYER = 2
-   LOS_NEW_BOTH = 3
+   % Values for dealing with some safespots in LoS.
+   %  These are basically "steps" on the high-res grid
+   %  which can be skipped at the dest end for still successful LoS.
+   %  Skipping the last step (LOS_SKIP_1) removes any safe-spot.
+   %  Skipping none of the tiny steps (LOS_SKIP_0) allows rare safe-spots at room edges/corners.
+   LOS_SKIP_0 = 0
+   LOS_SKIP_1 = 1
 
    % String limits
    MIN_CHAR_NAME_LEN = 3

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -2310,7 +2310,7 @@ messages:
    
    LineOfSightInternal(obj1 = $, obj2 = $)
    {
-      local r, c, r2, c2, dr, dc, iRow, iCol, iAtan;
+      local r, c, r2, c2, dr, dc, iRow, iCol, iAtan, iSkip;
 
       % no LOS if not in same room
       if Send(obj1,@GetOwner) <> Send(obj2,@GetOwner)
@@ -2362,10 +2362,15 @@ messages:
       r2 = r;
       c2 = c;
 
-      % we don't care about the last step to eliminate safe-spots
-      % this might allow a creature to hit through a wall if
-      % its target is on an adjacent highres square (unlikely?)
-      while abs(dr) > 1 OR abs(dc) > 1
+      % get config setting for amount of steps to skip at the end
+      % of LoS line, this modifies safespots
+      iSkip = Send(Send(SYS, @GetSettings), @GetLOSSkip);
+
+      % step from the source to the target on the highres grid.
+      % depending on the skip amount, we either must reach
+      % the destination completely (rare safespots)
+      % or an adjacent/close square is enough (no safespots)
+      while abs(dr) > iSkip OR abs(dc) > iSkip
       {
          % Figure out which direction we need to move
          % our 2D ray next (=step N,NE,E,SE,S,...)

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -142,8 +142,8 @@ properties:
    % Miscellaneous
    %
 
-   % Line of Sight (LOS) check.  What are we using?
-   piLOS = LOS_OLD
+   % Enables or disables some safe-spots, see blakston.khd comments.
+   piLOSSkip = LOS_SKIP_1
 
    % How many summoned objects can be in a room
    piPlayerSummonedObjectLimit = 18
@@ -433,9 +433,9 @@ messages:
    % Miscellaneous
    %
 
-   GetLOS()
+   GetLOSSkip()
    {
-      return piLOS;
+      return piLOSSkip;
    }
 
    GetPlayerSummonedObjectLimit()


### PR DESCRIPTION
When we introduced the high resolution grid, we also made small modifications to the LOS code.

Right now LOS is granted even in case the last step on the LOS line fails (SKIP=1). Additionally to the higher resolution grid already getting rid of many safe-spots and allowing monsters to step through tiny mazes, this small additionally change made sure there are absolutelty no safe-spots anymore. However it also tends to make creatures hit through zero-thickness walls like half-transparent fences for example.

This change here now brings some flexibility. It turns the static code skipping the last step into a configuration value in settings.kod (I replaced the deprecated LOS settings there, which are not in use anymore). By default this piLOSSkip in settings.kod should be LOS_SKIP_1 (=absolutelty no safespots, as live on 103).

Turning this value into LOS_SKIP_0 could bring:
(a) a very few safespots back (?)
(b) stop monsters from hitting through non-thickness walls
(c) change rather nothing :)