### PR TITLE
Disable part of the wireframe hack in HW renderer.

### DIFF
--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -854,8 +854,10 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 		IDirect3DDevice9_SetTextureStageState(gpD3DDevice, 1, D3DTSS_COLOROP, D3DTOP_DISABLE);
 		IDirect3DDevice9_SetTextureStageState(gpD3DDevice, 1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
 
+      // This is disabled as it seems to draw sky texture in-between wall
+      // textures on some maps. No errant effects noted from disabling this.
 		// no look through/sky texture walls
-		if (1)
+		if (0)
 		{
 			// for no look through and sky texture, we take all map and procedurally generated
 			// polys and render them, drawing only where there is no alpha.  for no look


### PR DESCRIPTION
This code block was causing sky texture to be drawn between some texture junctions. Turning it off doesn't seem to actually break anything else, but fixes the errant sky drawing.

Edit: this causes a few extra lines in Marion (which already seems poorly rendered) however it fixes lines elsewhere (e.g. this one Diggie found: https://i.imgur.com/kTi7KOV.jpg).