### PR TITLE
Rearrange messages to remove compiler error.

### DIFF
--- a/kod/util/gameeventengine.kod
+++ b/kod/util/gameeventengine.kod
@@ -68,6 +68,18 @@ messages:
       return;
    }
 
+   NewYear()
+   {
+      local i;
+
+      for i in plActiveEvents
+      {
+         Send(i,@NewYear);
+      }
+
+      return;
+   }
+
    NewMinute()
    {
       local i;
@@ -110,19 +122,7 @@ messages:
 
       for i in plActiveEvents
       {
-         Send(i,@Update);
-      }
-
-      return;
-   }
-
-   NewYear()
-   {
-      local i;
-
-      for i in plActiveEvents
-      {
-         Send(i,@NewYear);
+         Send(i,@NewMonth);
       }
 
       return;


### PR DESCRIPTION
Compiler thinks there are duplicate parameters in ScheduleEventInMinutes if NewYear precedes it. Rearranging the NewX() messages fixes this (but is indicative of a serious issue in the compiler).