### PR TITLE
Allow potion/scroll use during attack cooldown.

### DIFF
--- a/kod/object/item/passitem/spelitem/wand.kod
+++ b/kod/object/item/passitem/spelitem/wand.kod
@@ -29,6 +29,8 @@ resources:
       "You carefully aim your wand at %s%s, but you suddenly "
       "realize your target is gone."
    Wand_fails = "You point your wand but nothing happens."
+   wand_cannot_use_yet = \
+      "You cannot use that item yet."
 
 classvars:
 
@@ -59,6 +61,20 @@ properties:
    piGoBadTime = -1
 
 messages:
+
+   ReqNewApply(what=$,apply_on=$)
+   {
+      % Wands can be used as attacks - check the attack timer.
+      if IsClass(what,&Player)
+         AND NOT Send(what,@CheckAttackTimer)
+      {
+         Send(what,@MsgSendUser,#message_rsc=wand_cannot_use_yet);
+
+         return FALSE;
+      }
+
+      propagate;
+   }
 
    CastSpell(what=$,apply_on=$)
    {

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -838,11 +838,14 @@ messages:
 
             return FALSE;
          }
-      }
 
-      if NOT Send(who,@IsOkayAttackTime,#seconds=viPostCast_Time)
-      {
-         return FALSE;
+         % Don't check the attack time for itemcast spells. The items
+         % themselves will allow or disallow this - for instance a
+         % potion can be used during the cooldown, but a wand cannot.
+         if NOT Send(who,@IsOkayAttackTime,#seconds=viPostCast_Time)
+         {
+            return FALSE;
+         }
       }
 
       oRoom = Send(who,@GetOwner);


### PR DESCRIPTION
Discussed in IRC - currently the default behavior for using an item during attack cooldown is to have it fail with no extra info, and remove 1 from piHits. This change prevents wands from being used during the cooldown (without removing durability), but allows potions and scrolls.

Perhaps it isn't realistic to drink a potion or read a scroll during attack cooldown, but the presented argument was that it would open up some strategy with regard to fast item use (while still preventing
double attacks using lightning or other offensive wands).