### PR TITLE
Client changes to load ROO v.14 (draft).

### DIFF
--- a/clientd3d/bsp.h
+++ b/clientd3d/bsp.h
@@ -85,29 +85,29 @@
 /* plane defined by ax + by + c = 0. (x and y are in fineness units.) */
 typedef struct
 {
-   double a, b, c;
+   float a, b, c;
 } Plane,Plane2D;
 
 /* 3D plane defined by ax + by + cz + d */
 typedef struct
 {
-    double a, b, c, d;
+    float a, b, c, d;
 } Plane3D;
 
 /* box defined by its top left and bottom right coordinates (in fineness) */
 typedef struct
 {
-   double x0,y0,x1,y1;
+   float x0,y0,x1,y1;
 } Box;
 
 typedef struct
 {
-   double x,y;
+   float x,y;
 } Pnt,Pnt2D,Vector2D;
 
 typedef struct
 {
-   double x,y,z;
+   float x,y,z;
 } Pnt3D,Vector3D;
 
 typedef struct ObjectData
@@ -182,7 +182,7 @@ typedef struct WallData
 
    Plane separator;
    
-   double length;                 /* length of wall; 1 grid square = 64 */
+   float length;                 /* length of wall; 1 grid square = 64 */
    
    // Since I doubled the number of heights stored here, I'm changing
    // these heights to shorts to take up half the space. No room (except godroom)
@@ -218,7 +218,7 @@ typedef struct WallData
    long  zz0Neg;        /* height of bottom of lower wall */
    long  zz1Neg;        /* height of top of lower wall / bottom of normal wall */
 
-   double x0, y0, x1, y1;         /* coordinates of wall start and end */
+   float x0, y0, x1, y1;         /* coordinates of wall start and end */
 
    Bool seen;                  /* True iff part of this wall has been drawn */
 

--- a/clientd3d/bsp.h
+++ b/clientd3d/bsp.h
@@ -79,6 +79,7 @@
 
 #define ABS(x) ((x) > 0 ? (x) : (-(x)))
 #define SGN(x) ((x) == 0 ? 0 : ((x) > 0 ? 1 : -1))
+#define SGNDOUBLE(x) (((x) <= 0.001 && (x) >= -0.001) ? 0 : ((x) > 0.001 ? 1 : -1))
 
 #pragma warning( disable : 4201 )		// nonstandard extension used : nameless struct/union (a union in this case )
 

--- a/clientd3d/bsp.h
+++ b/clientd3d/bsp.h
@@ -85,29 +85,29 @@
 /* plane defined by ax + by + c = 0. (x and y are in fineness units.) */
 typedef struct
 {
-   long a, b, c;
+   double a, b, c;
 } Plane,Plane2D;
 
 /* 3D plane defined by ax + by + cz + d */
 typedef struct
 {
-    FixedPoint a, b, c, d;
+    double a, b, c, d;
 } Plane3D;
 
 /* box defined by its top left and bottom right coordinates (in fineness) */
 typedef struct
 {
-   long x0,y0,x1,y1;
+   double x0,y0,x1,y1;
 } Box;
 
 typedef struct
 {
-   long x,y;
+   double x,y;
 } Pnt,Pnt2D,Vector2D;
 
 typedef struct
 {
-   FixedPoint x,y,z;
+   double x,y,z;
 } Pnt3D,Vector3D;
 
 typedef struct ObjectData
@@ -182,7 +182,7 @@ typedef struct WallData
 
    Plane separator;
    
-   int length;                 /* length of wall; 1 grid square = 64 */
+   double length;                 /* length of wall; 1 grid square = 64 */
    
    // Since I doubled the number of heights stored here, I'm changing
    // these heights to shorts to take up half the space. No room (except godroom)
@@ -218,7 +218,7 @@ typedef struct WallData
    long  zz0Neg;        /* height of bottom of lower wall */
    long  zz1Neg;        /* height of top of lower wall / bottom of normal wall */
 
-   int x0, y0, x1, y1;         /* coordinates of wall start and end */
+   double x0, y0, x1, y1;         /* coordinates of wall start and end */
 
    Bool seen;                  /* True iff part of this wall has been drawn */
 

--- a/clientd3d/bspload.c
+++ b/clientd3d/bspload.c
@@ -263,10 +263,11 @@ Bool LoadNodes(file_node *f, room_type *room, int num_nodes)
       if (CliMappedFileRead(f, &type, 1) != 1) return False;
       node->type = (BSPnodetype) type;
 
-      if (CliMappedFileRead(f, &node->bbox.x0, 4) != 4) return False;
-      if (CliMappedFileRead(f, &node->bbox.y0, 4) != 4) return False;
-      if (CliMappedFileRead(f, &node->bbox.x1, 4) != 4) return False;
-      if (CliMappedFileRead(f, &node->bbox.y1, 4) != 4) return False;
+      // These are now loaded as doubles.
+      if (CliMappedFileRead(f, &node->bbox.x0, 8) != 8) return False;
+      if (CliMappedFileRead(f, &node->bbox.y0, 8) != 8) return False;
+      if (CliMappedFileRead(f, &node->bbox.x1, 8) != 8) return False;
+      if (CliMappedFileRead(f, &node->bbox.y1, 8) != 8) return False;
 
 //      debug(("Loading node %d ", i));
 
@@ -275,16 +276,18 @@ Bool LoadNodes(file_node *f, room_type *room, int num_nodes)
       case BSPinternaltype:
 	 inode = &node->u.internal;
 	 
-	 if (CliMappedFileRead(f, &inode->separator.a, 4) != 4) return False;
-	 if (CliMappedFileRead(f, &inode->separator.b, 4) != 4) return False;
-	 if (CliMappedFileRead(f, &inode->separator.c, 4) != 4) return False;
+	 // Loaded as doubles.
+	 if (CliMappedFileRead(f, &inode->separator.a, 8) != 8) return False;
+	 if (CliMappedFileRead(f, &inode->separator.b, 8) != 8) return False;
+	 if (CliMappedFileRead(f, &inode->separator.c, 8) != 8) return False;
+
+	 // Don't add these to room security (as of roo version 14).
+	 //security += inode->separator.a + inode->separator.b + inode->separator.c;
 
 	 if (CliMappedFileRead(f, &inode->pos_num, 2) != 2) return False;
 	 if (CliMappedFileRead(f, &inode->neg_num, 2) != 2) return False;
 	 if (CliMappedFileRead(f, &inode->wall_num, 2) != 2) return False;
-
-	 security += inode->separator.a + inode->separator.b + inode->separator.c + 
-	    inode->wall_num;
+	 security += inode->wall_num;
 
 	 break;
 
@@ -298,9 +301,11 @@ Bool LoadNodes(file_node *f, room_type *room, int num_nodes)
 	 leaf->poly.npts = num_points;
 	 for (j=0; j < num_points; j++)
 	 {
-	    if (CliMappedFileRead(f, &leaf->poly.p[j].x, 4) != 4) return False;
-	    if (CliMappedFileRead(f, &leaf->poly.p[j].y, 4) != 4) return False;
-	    security += leaf->poly.p[j].x + leaf->poly.p[j].y;
+		 // Loaded as doubles.
+		if (CliMappedFileRead(f, &leaf->poly.p[j].x, 8) != 8) return False;
+		if (CliMappedFileRead(f, &leaf->poly.p[j].y, 8) != 8) return False;
+		// Don't add these to room security (as of roo version 14).
+		//security += leaf->poly.p[j].x + leaf->poly.p[j].y;
 	 }
 	 leaf->poly.p[num_points] = leaf->poly.p[0];	 
 	 break;
@@ -340,15 +345,16 @@ Bool LoadWalls(file_node *f, room_type *room, int num_walls)
       if (CliMappedFileRead(f, &wall->neg_sidedef_num, 2) != 2) return False;
       security += wall->pos_sidedef_num + wall->neg_sidedef_num;
 
-      if (CliMappedFileRead(f, &wall->x0, 4) != 4) return False;
-      if (CliMappedFileRead(f, &wall->y0, 4) != 4) return False;
-      if (CliMappedFileRead(f, &wall->x1, 4) != 4) return False;
-      if (CliMappedFileRead(f, &wall->y1, 4) != 4) return False;
-      security += wall->x0 + wall->y0 + wall->x1 + wall->y1;
+      // Loaded as doubles.
+      if (CliMappedFileRead(f, &wall->x0, 8) != 8) return False;
+      if (CliMappedFileRead(f, &wall->y0, 8) != 8) return False;
+      if (CliMappedFileRead(f, &wall->x1, 8) != 8) return False;
+      if (CliMappedFileRead(f, &wall->y1, 8) != 8) return False;
+      // Don't add these to room security (as of roo version 14).
+      //security += wall->x0 + wall->y0 + wall->x1 + wall->y1;
       
-      // Get wall length
-      if (CliMappedFileRead(f, &word, 2) != 2) return False;
-      wall->length = word;
+      // Get wall length, loaded as double.
+      if (CliMappedFileRead(f, &wall->length, 8) != 8) return False;
       
       // Get texture offsets
       if (CliMappedFileRead(f, &wall->pos_xoffset, 2) != 2) return False;
@@ -495,14 +501,13 @@ SlopeData *LoadSlopeInfo(file_node *f) {
     size = sizeof(SlopeData);
     new_slope = (SlopeData *) SafeMalloc(size);
     memset(new_slope, 0, size);
+    // Load coefficients of plane equation, as doubles for higher precision.
+    if (CliMappedFileRead(f, &new_slope->plane.a, 8) != 8) return (SlopeData *)NULL;
+    if (CliMappedFileRead(f, &new_slope->plane.b, 8) != 8) return (SlopeData *)NULL;
+    if (CliMappedFileRead(f, &new_slope->plane.c, 8) != 8) return (SlopeData *)NULL;
+    if (CliMappedFileRead(f, &new_slope->plane.d, 8) != 8) return (SlopeData *)NULL;
 
-    // load coefficients of plane equation
-    if (CliMappedFileRead(f, &new_slope->plane.a, 4) != 4) return (SlopeData *)NULL;
-    if (CliMappedFileRead(f, &new_slope->plane.b, 4) != 4) return (SlopeData *)NULL;
-    if (CliMappedFileRead(f, &new_slope->plane.c, 4) != 4) return (SlopeData *)NULL;
-    if (CliMappedFileRead(f, &new_slope->plane.d, 4) != 4) return (SlopeData *)NULL;
-
-//    dprintf("loaded equation a = %d, b = %d, c = %d, d = %d\n", new_slope->plane.a, new_slope->plane.b, new_slope->plane.c, new_slope->plane.d);
+    //dprintf("loaded equation a = %d, b = %d, c = %d, d = %d\n", new_slope->plane.a, new_slope->plane.b, new_slope->plane.c, new_slope->plane.d);
     
     if (new_slope->plane.c == 0) {
 	debug(("Error: loaded plane equation equal to a vertical slope\n"));
@@ -676,13 +681,13 @@ Bool LoadSectors(file_node *f, room_type *room, int num_sectors)
 #define OVERFLOWAMOUNT (MAXLONG>>(LOG_FINENESS*2))
 
 Bool RoomSwizzle(room_type *room, BSPTree tree, 
-		 int num_nodes, int num_walls, int num_sidedefs, int num_sectors)
+      int num_nodes, int num_walls, int num_sidedefs, int num_sectors)
 {
    BSPinternal *inode;
    BSPleaf *leaf;
    WallData *wall;
-   long   a,b,c,x0,y0,x1,y1,norm_size;
-   long   a2,b2;
+   double norm_size, a2, b2, a, b, c;
+   double x0, y0, x1, y1;
 
    if (tree == NULL)
       return True;
@@ -707,133 +712,143 @@ Bool RoomSwizzle(room_type *room, BSPTree tree,
       a2 = a*a; // get a bead on general scale of normal vector
       b2 = b*b;
 
-      if ((a2 > OVERFLOWAMOUNT) || (b2 > OVERFLOWAMOUNT) || (a2+b2 > OVERFLOWAMOUNT)) {
-	  a = inode->separator.a;
-	  b = inode->separator.b;
+      if ((a2 > OVERFLOWAMOUNT) || (b2 > OVERFLOWAMOUNT) || (a2+b2 > OVERFLOWAMOUNT))
+      {
+         a = inode->separator.a;
+         b = inode->separator.b;
 
-	  norm_size = (long)sqrt((float) a2 + b2);
-	  if ((a2 < 0) || (b2 < 0) || (norm_size <= 0)) {
-	      norm_size = 1;
-	      debug(("RoomSwizzle: still getting overflow in normalization math!\n"));
-	  }
-
+         norm_size = sqrt(a2 + b2);
+         if ((a2 < 0) || (b2 < 0) || (norm_size <= 0))
+         {
+            norm_size = 1;
+            debug(("RoomSwizzle: still getting overflow in normalization math!\n"));
+         }
       }
-      else {
-	  a <<= LOG_FINENESS;
-	  b <<= LOG_FINENESS;
-
-	  norm_size = (long)sqrt((float) a*a + b*b);
+      else
+      {
+         //a <<= LOG_FINENESS;
+         //b <<= LOG_FINENESS;
+         a *= FINENESS;
+         b *= FINENESS;
+         norm_size = sqrtl((long double)a*(long double)a + (long double)b*(long double)b);
       }
 
       // normalize a & b (w.round to closest int)
-      a = ((a << LOG_FINENESS)+(norm_size>>1))/norm_size;
-      b = ((b << LOG_FINENESS)+(norm_size>>1))/norm_size;
+      a = ((a * FINENESS) + (norm_size / 2)) / norm_size;
+      b = ((b * FINENESS) + (norm_size / 2)) / norm_size;
       
       inode->separator.a = a;
       inode->separator.b = b;
 
       // re-calc c
       // take average over endpoints of wall (reduce error ?)
-      inode->separator.c = -((a*x1+b*y1)+(a*x0+b*y0))/2;
+      inode->separator.c = -((a*x1+b*y1)+(a*x0+b*y0))/2.0;
+
+      //inode->separator.c = c;
 
       if (inode->pos_num == 0)
-	 inode->pos_side = NULL;
+         inode->pos_side = NULL;
+      else if (inode->pos_num < 0 || inode->pos_num > num_nodes)
+      {
+         debug(("RoomSwizzle got node #%d; max is %d\n", inode->pos_num, num_nodes));
+         inode->pos_side = NULL;
+      }
       else
-	 if (inode->pos_num < 0 || inode->pos_num > num_nodes)
-	 {
-	    debug(("RoomSwizzle got node #%d; max is %d\n", inode->pos_num, num_nodes));
-	    inode->pos_side = NULL;
-	 }
-	 else inode->pos_side = &room->nodes[inode->pos_num - 1];
+         inode->pos_side = &room->nodes[inode->pos_num - 1];
 
       if (inode->neg_num == 0)
-	 inode->neg_side = NULL;
+         inode->neg_side = NULL;
+      else if (inode->neg_num < 0 || inode->neg_num > num_nodes)
+      {
+         debug(("RoomSwizzle got node #%d; max is %d", inode->neg_num, num_nodes));
+         inode->neg_side = NULL;
+      }
       else
-	 if (inode->neg_num < 0 || inode->neg_num > num_nodes)
-	 {
-	    debug(("RoomSwizzle got node #%d; max is %d", inode->neg_num, num_nodes));
-	    inode->neg_side = NULL;
-	 }
-	 else inode->neg_side = &room->nodes[inode->neg_num - 1];
+         inode->neg_side = &room->nodes[inode->neg_num - 1];
 
       if (inode->wall_num == 0)
-	 inode->walls_in_plane = NULL;
+         inode->walls_in_plane = NULL;
+      else if (inode->wall_num < 0 || inode->wall_num > num_walls)
+      {
+         debug(("RoomSwizzle got wall #%d; max is %d\n", inode->wall_num, num_walls));
+         inode->walls_in_plane = NULL;
+      }
       else
-	 if (inode->wall_num < 0 || inode->wall_num > num_walls)
-	 {
-	    debug(("RoomSwizzle got wall #%d; max is %d\n", inode->wall_num, num_walls));
-	    inode->walls_in_plane = NULL;
-	 }
-	 else inode->walls_in_plane = &room->walls[inode->wall_num - 1];
+         inode->walls_in_plane = &room->walls[inode->wall_num - 1];
 
       // Swizzle wall list
       if (inode->walls_in_plane != NULL)
       {
-	 // Set next pointers to build up list
-	 for (wall = inode->walls_in_plane; wall->next_num != 0; wall = wall->next)
-	 {
-	    if (wall->next_num < 0 || wall->next_num > num_walls)
-	    {
-	       debug(("RoomSwizzle got wall #%d; max is %d\n", wall->next_num, num_walls));
-	       return False;
-	    }
-	    else wall->next = &room->walls[wall->next_num - 1];
-	 }
-	 wall->next = NULL;
+         // Set next pointers to build up list
+         for (wall = inode->walls_in_plane; wall->next_num != 0; wall = wall->next)
+         {
+            if (wall->next_num < 0 || wall->next_num > num_walls)
+            {
+               debug(("RoomSwizzle got wall #%d; max is %d\n", wall->next_num, num_walls));
+               return False;
+            }
+            else
+               wall->next = &room->walls[wall->next_num - 1];
+         }
+         wall->next = NULL;
 
-	 // Set sidedef and sector pointers
-	 for (wall = inode->walls_in_plane; wall != NULL; wall = wall->next)
-	 {
-	    if (wall->pos_sidedef_num > num_sidedefs)
-	    {
-	       debug(("RoomSwizzle found wall referencing sidedef %d; max is %d\n", 
-		       wall->pos_sidedef_num, num_sidedefs));
-	       return False;
-	    }
-	    if (wall->pos_sidedef_num == 0)
-	       wall->pos_sidedef = NULL;
-	    else wall->pos_sidedef = &room->sidedefs[wall->pos_sidedef_num - 1];
+         // Set sidedef and sector pointers
+         for (wall = inode->walls_in_plane; wall != NULL; wall = wall->next)
+         {
+            if (wall->pos_sidedef_num > num_sidedefs)
+            {
+               debug(("RoomSwizzle found wall referencing sidedef %d; max is %d\n", 
+                  wall->pos_sidedef_num, num_sidedefs));
+               return False;
+            }
+            if (wall->pos_sidedef_num == 0)
+               wall->pos_sidedef = NULL;
+            else
+               wall->pos_sidedef = &room->sidedefs[wall->pos_sidedef_num - 1];
 
-	    if (wall->neg_sidedef_num > num_sidedefs)
-	    {
-	       debug(("RoomSwizzle found wall referencing sidedef %d; max is %d\n", 
-		       wall->neg_sidedef_num, num_sidedefs));
-	       return False;
-	    }
-	    if (wall->neg_sidedef_num == 0)
-	       wall->neg_sidedef = NULL;
-	    else wall->neg_sidedef = &room->sidedefs[wall->neg_sidedef_num - 1];
+            if (wall->neg_sidedef_num > num_sidedefs)
+            {
+               debug(("RoomSwizzle found wall referencing sidedef %d; max is %d\n", 
+                  wall->neg_sidedef_num, num_sidedefs));
+               return False;
+            }
+            if (wall->neg_sidedef_num == 0)
+               wall->neg_sidedef = NULL;
+            else
+               wall->neg_sidedef = &room->sidedefs[wall->neg_sidedef_num - 1];
 
-	    if (wall->pos_sector_num > num_sectors)
-	    {
-	       debug(("RoomSwizzle found wall referencing sector %d; max is %d\n", 
-		       wall->pos_sector_num, num_sectors));
-	       return False;
-	    }
+            if (wall->pos_sector_num > num_sectors)
+            {
+               debug(("RoomSwizzle found wall referencing sector %d; max is %d\n", 
+                  wall->pos_sector_num, num_sectors));
+               return False;
+            }
 
-	    if (wall->pos_sector_num == 0)
-	       wall->pos_sector = NULL;
-	    else wall->pos_sector = &room->sectors[wall->pos_sector_num - 1];
+            if (wall->pos_sector_num == 0)
+               wall->pos_sector = NULL;
+            else
+               wall->pos_sector = &room->sectors[wall->pos_sector_num - 1];
 
-	    if (wall->neg_sector_num > num_sectors)
-	    {
-	       debug(("RoomSwizzle found wall referencing sector %d; max is %d\n", 
-		       wall->neg_sector_num, num_sectors));
-	       return False;
-	    }
+            if (wall->neg_sector_num > num_sectors)
+            {
+               debug(("RoomSwizzle found wall referencing sector %d; max is %d\n", 
+                  wall->neg_sector_num, num_sectors));
+               return False;
+            }
 
-	    if (wall->neg_sector_num == 0)
-	       wall->neg_sector = NULL;
-	    else wall->neg_sector = &room->sectors[wall->neg_sector_num - 1];
+            if (wall->neg_sector_num == 0)
+               wall->neg_sector = NULL;
+            else
+               wall->neg_sector = &room->sectors[wall->neg_sector_num - 1];
 
-	    SetWallHeights(wall);
-	 }
+            SetWallHeights(wall);
+         }
       }
 
       if (RoomSwizzle(room, inode->pos_side, num_nodes, num_walls, num_sidedefs, num_sectors) == False)
-	 return False;
+         return False;
       if (RoomSwizzle(room, inode->neg_side, num_nodes, num_walls, num_sidedefs, num_sectors) == False)
-	 return False;
+         return False;
       break;
       
    case BSPleaftype:
@@ -841,19 +856,19 @@ Bool RoomSwizzle(room_type *room, BSPTree tree,
 
       if (leaf->sector_num > num_sectors)
       {
-	 debug(("RoomSwizzle found leaf referencing sector %d; max is %d\n", 
-		 leaf->sector, num_sectors));
-	 return False;
+         debug(("RoomSwizzle found leaf referencing sector %d; max is %d\n", 
+            leaf->sector, num_sectors));
+         return False;
       }
       if (leaf->sector_num == 0)
       {
-	 debug(("RoomSwizzle found leaf without sector reference\n"));
-	 return False;
+         debug(("RoomSwizzle found leaf without sector reference\n"));
+         return False;
       }
       leaf->sector = &room->sectors[leaf->sector_num - 1];
       break;
    }
-   
+
    return True;
 }
 

--- a/clientd3d/bspload.c
+++ b/clientd3d/bspload.c
@@ -22,7 +22,7 @@
 #include "client.h"
 #include "d3dcache.h"
 
-static const int ROO_VERSION = 10;
+static const int ROO_VERSION = 14;
 
 static BYTE room_magic[] = { 0x52, 0x4F, 0x4F, 0xB1 };
 
@@ -263,11 +263,11 @@ Bool LoadNodes(file_node *f, room_type *room, int num_nodes)
       if (CliMappedFileRead(f, &type, 1) != 1) return False;
       node->type = (BSPnodetype) type;
 
-      // These are now loaded as doubles.
-      if (CliMappedFileRead(f, &node->bbox.x0, 8) != 8) return False;
-      if (CliMappedFileRead(f, &node->bbox.y0, 8) != 8) return False;
-      if (CliMappedFileRead(f, &node->bbox.x1, 8) != 8) return False;
-      if (CliMappedFileRead(f, &node->bbox.y1, 8) != 8) return False;
+      // These are now loaded as floats.
+      if (CliMappedFileRead(f, &node->bbox.x0, 4) != 4) return False;
+      if (CliMappedFileRead(f, &node->bbox.y0, 4) != 4) return False;
+      if (CliMappedFileRead(f, &node->bbox.x1, 4) != 4) return False;
+      if (CliMappedFileRead(f, &node->bbox.y1, 4) != 4) return False;
 
 //      debug(("Loading node %d ", i));
 
@@ -276,10 +276,10 @@ Bool LoadNodes(file_node *f, room_type *room, int num_nodes)
       case BSPinternaltype:
 	 inode = &node->u.internal;
 	 
-	 // Loaded as doubles.
-	 if (CliMappedFileRead(f, &inode->separator.a, 8) != 8) return False;
-	 if (CliMappedFileRead(f, &inode->separator.b, 8) != 8) return False;
-	 if (CliMappedFileRead(f, &inode->separator.c, 8) != 8) return False;
+	 // Loaded as floats.
+	 if (CliMappedFileRead(f, &inode->separator.a, 4) != 4) return False;
+	 if (CliMappedFileRead(f, &inode->separator.b, 4) != 4) return False;
+	 if (CliMappedFileRead(f, &inode->separator.c, 4) != 4) return False;
 
 	 // Don't add these to room security (as of roo version 14).
 	 //security += inode->separator.a + inode->separator.b + inode->separator.c;
@@ -301,9 +301,9 @@ Bool LoadNodes(file_node *f, room_type *room, int num_nodes)
 	 leaf->poly.npts = num_points;
 	 for (j=0; j < num_points; j++)
 	 {
-		 // Loaded as doubles.
-		if (CliMappedFileRead(f, &leaf->poly.p[j].x, 8) != 8) return False;
-		if (CliMappedFileRead(f, &leaf->poly.p[j].y, 8) != 8) return False;
+		 // Loaded as floats.
+		if (CliMappedFileRead(f, &leaf->poly.p[j].x, 4) != 4) return False;
+		if (CliMappedFileRead(f, &leaf->poly.p[j].y, 4) != 4) return False;
 		// Don't add these to room security (as of roo version 14).
 		//security += leaf->poly.p[j].x + leaf->poly.p[j].y;
 	 }
@@ -345,16 +345,16 @@ Bool LoadWalls(file_node *f, room_type *room, int num_walls)
       if (CliMappedFileRead(f, &wall->neg_sidedef_num, 2) != 2) return False;
       security += wall->pos_sidedef_num + wall->neg_sidedef_num;
 
-      // Loaded as doubles.
-      if (CliMappedFileRead(f, &wall->x0, 8) != 8) return False;
-      if (CliMappedFileRead(f, &wall->y0, 8) != 8) return False;
-      if (CliMappedFileRead(f, &wall->x1, 8) != 8) return False;
-      if (CliMappedFileRead(f, &wall->y1, 8) != 8) return False;
+      // Loaded as floats.
+      if (CliMappedFileRead(f, &wall->x0, 4) != 4) return False;
+      if (CliMappedFileRead(f, &wall->y0, 4) != 4) return False;
+      if (CliMappedFileRead(f, &wall->x1, 4) != 4) return False;
+      if (CliMappedFileRead(f, &wall->y1, 4) != 4) return False;
       // Don't add these to room security (as of roo version 14).
       //security += wall->x0 + wall->y0 + wall->x1 + wall->y1;
       
-      // Get wall length, loaded as double.
-      if (CliMappedFileRead(f, &wall->length, 8) != 8) return False;
+      // Get wall length, loaded as float.
+      if (CliMappedFileRead(f, &wall->length, 4) != 4) return False;
       
       // Get texture offsets
       if (CliMappedFileRead(f, &wall->pos_xoffset, 2) != 2) return False;
@@ -501,13 +501,14 @@ SlopeData *LoadSlopeInfo(file_node *f) {
     size = sizeof(SlopeData);
     new_slope = (SlopeData *) SafeMalloc(size);
     memset(new_slope, 0, size);
-    // Load coefficients of plane equation, as doubles for higher precision.
-    if (CliMappedFileRead(f, &new_slope->plane.a, 8) != 8) return (SlopeData *)NULL;
-    if (CliMappedFileRead(f, &new_slope->plane.b, 8) != 8) return (SlopeData *)NULL;
-    if (CliMappedFileRead(f, &new_slope->plane.c, 8) != 8) return (SlopeData *)NULL;
-    if (CliMappedFileRead(f, &new_slope->plane.d, 8) != 8) return (SlopeData *)NULL;
+    // Load coefficients of plane equation as floats.
+    if (CliMappedFileRead(f, &new_slope->plane.a, 4) != 4) return (SlopeData *)NULL;
+    if (CliMappedFileRead(f, &new_slope->plane.b, 4) != 4) return (SlopeData *)NULL;
+    if (CliMappedFileRead(f, &new_slope->plane.c, 4) != 4) return (SlopeData *)NULL;
+    if (CliMappedFileRead(f, &new_slope->plane.d, 4) != 4) return (SlopeData *)NULL;
 
-    //dprintf("loaded equation a = %d, b = %d, c = %d, d = %d\n", new_slope->plane.a, new_slope->plane.b, new_slope->plane.c, new_slope->plane.d);
+    //dprintf("loaded equation a = %6.4f, b = %6.4f, c = %6.4f, d = %6.4f\n",
+    //  new_slope->plane.a, new_slope->plane.b, new_slope->plane.c, new_slope->plane.d);
     
     if (new_slope->plane.c == 0) {
 	debug(("Error: loaded plane equation equal to a vertical slope\n"));
@@ -518,9 +519,13 @@ SlopeData *LoadSlopeInfo(file_node *f) {
 	new_slope->plane.d = 0;
     }
     
-    // load x & y of texture origin
-    if (CliMappedFileRead(f, &new_slope->p0.x, 4) != 4) return (SlopeData *)NULL;
-    if (CliMappedFileRead(f, &new_slope->p0.y, 4) != 4) return (SlopeData *)NULL;
+    // Load x & y of texture origin. These are saved as integers, so load them
+    // into a temp variable first and them save them.
+    int payload;
+    if (CliMappedFileRead(f, &payload, 4) != 4) return (SlopeData *)NULL;
+    new_slope->p0.x = payload;
+    if (CliMappedFileRead(f, &payload, 4) != 4) return (SlopeData *)NULL;
+    new_slope->p0.y = payload;
     
     // calculate z of texture origin from x, y, and plane equation
     new_slope->p0.z = (-new_slope->plane.a*new_slope->p0.x - new_slope->plane.b*new_slope->p0.y - new_slope->plane.d)/new_slope->plane.c;
@@ -686,8 +691,8 @@ Bool RoomSwizzle(room_type *room, BSPTree tree,
    BSPinternal *inode;
    BSPleaf *leaf;
    WallData *wall;
-   double norm_size, a2, b2, a, b, c;
-   double x0, y0, x1, y1;
+   float norm_size, a2, b2, a, b, c;
+   float x0, y0, x1, y1;
 
    if (tree == NULL)
       return True;
@@ -742,7 +747,7 @@ Bool RoomSwizzle(room_type *room, BSPTree tree,
 
       // re-calc c
       // take average over endpoints of wall (reduce error ?)
-      inode->separator.c = -((a*x1+b*y1)+(a*x0+b*y0))/2.0;
+      inode->separator.c = -((a*x1+b*y1)+(a*x0+b*y0))/2.0f;
 
       //inode->separator.c = c;
 
@@ -1149,7 +1154,7 @@ void RoomSetupFlickerAnimation(RoomAnimate *ra, BYTE original_light, WORD server
  *****************************************************************************/
 
 // Make sure wall height can be stored in two bytes. Used by SetWallHeights below.
-#define WALL_HEIGHT_CHECK(z) if ((z) > 65535) {debug(("SetWallHeights: got wall taller than 65535."));\
+#define WALL_HEIGHT_CHECK(z) if ((z) > 65535) {debug(("SetWallHeights: got wall taller than 65535. %li",z));\
     debug((" Shorten ceiling height or change\nshort to long in WallData struct in bsp.h\n"));\
     (z) = 65535;}
 

--- a/clientd3d/d3dcache.h
+++ b/clientd3d/d3dcache.h
@@ -92,66 +92,41 @@ do	\
 #endif
 
 #define CHUNK_XYZ_SET(_pChunk, _index, _x, _y, _z)	\
-do	\
-{	\
 	_pChunk->xyz[_index].x = _x;	\
 	_pChunk->xyz[_index].y = _y;	\
-	_pChunk->xyz[_index].z = _z;	\
-} while (0)
+	_pChunk->xyz[_index].z = _z;
 
 #define CHUNK_BGRA_SET(_pChunk, _index, _b, _g, _r, _a)	\
-do	\
-{	\
-	_pChunk->bgra[_index].b = _b;	\
+_pChunk->bgra[_index].b = _b;	\
 	_pChunk->bgra[_index].g = _g;	\
 	_pChunk->bgra[_index].r = _r;	\
-	_pChunk->bgra[_index].a = _a;	\
-} while (0)
+	_pChunk->bgra[_index].a = _a;
 
 #define CHUNK_ST0_SET(_pChunk, _index, _s, _t)	\
-do	\
-{	\
 	_pChunk->st0[_index].s = _s;	\
-	_pChunk->st0[_index].t = _t;	\
-} while (0)
+	_pChunk->st0[_index].t = _t;
 
 #define CHUNK_ST1_SET(_pChunk, _index, _s, _t)	\
-do	\
-{	\
 	_pChunk->st1[_index].s = _s;	\
-	_pChunk->st1[_index].t = _t;	\
-} while (0)
+	_pChunk->st1[_index].t = _t;
 
 #define CHUNK_INDEX_SET(_pChunk, _index, _value)	\
-do	\
-{	\
-	_pChunk->indices[_index] = _value;	\
-} while (0)
+	_pChunk->indices[_index] = _value;
 
 #define CACHE_UNLOCK(_pCache)	\
-do	\
-{	\
-	int	i;	\
 	IDirect3DVertexBuffer9_Unlock((_pCache)->xyzBuffer.pVBuffer);	\
-	for (i = 0; i < TEMP_NUM_STAGES; i++)	\
+	for (int i = 0; i < TEMP_NUM_STAGES; i++)	\
 		IDirect3DVertexBuffer9_Unlock((_pCache)->stBuffer[i].pVBuffer);	\
 	IDirect3DVertexBuffer9_Unlock((_pCache)->bgraBuffer.pVBuffer);	\
-	IDirect3DIndexBuffer9_Unlock((_pCache)->indexBuffer.pIBuffer);	\
-} while (0)
+	IDirect3DIndexBuffer9_Unlock((_pCache)->indexBuffer.pIBuffer);
 
 #define CACHE_BGRA_LOCK(_pCache)	\
-do	\
-{	\
 	IDirect3DVertexBuffer9_Lock((_pCache)->bgraBuffer.pVBuffer,	\
                               0, 0, (void **)&(_pCache)->bgraBuffer.u.pBGRA, \
-                              D3DLOCK_DISCARD);             \
-} while (0)
+                              D3DLOCK_DISCARD);
 
 #define CACHE_BGRA_UNLOCK(_pCache)	\
-do	\
-{	\
-	IDirect3DVertexBuffer9_Unlock((_pCache)->bgraBuffer.pVBuffer);	\
-} while (0)
+	IDirect3DVertexBuffer9_Unlock((_pCache)->bgraBuffer.pVBuffer);
 
 typedef struct d3d_texture_cache_entry
 {

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -1472,7 +1472,7 @@ void D3DRenderWorldDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DParam
 void D3DRenderLMapsPostDraw(BSPnode *tree, Draw3DParams *params)
 {
 	long		side;
-	double	a, b;
+	float	a, b;
 
 	if (!tree)
 		return;
@@ -1614,7 +1614,7 @@ void D3DRenderLMapsPostDraw(BSPnode *tree, Draw3DParams *params)
 void D3DRenderLMapsDynamicPostDraw(BSPnode *tree, Draw3DParams *params)
 {
 	long		side;
-	double	a, b;
+	float	a, b;
 
 	if (!tree)
 		return;
@@ -5911,7 +5911,7 @@ int D3DRenderWallExtract(WallData *pWall, PDIB pDib, unsigned int *flags, custom
 	if (pBGRA)
 	{
 		int	i;
-		double a, b;
+		float a, b;
 		int	distX, distY, distance;
 		long	lightScale;
 		long lo_end = FINENESS-shade_amount;
@@ -6019,16 +6019,16 @@ void D3DRenderFloorExtract(BSPnode *pNode, PDIB pDib, custom_xyz *pXYZ, custom_s
 		{
 			if (pSector->sloped_floor)
 			{
-				pXYZ[count].x = (float)pNode->u.leaf.poly.p[count].x;
-				pXYZ[count].y = (float)pNode->u.leaf.poly.p[count].y;
+				pXYZ[count].x = pNode->u.leaf.poly.p[count].x;
+				pXYZ[count].y = pNode->u.leaf.poly.p[count].y;
 				pXYZ[count].z = (-pSector->sloped_floor->plane.a * pXYZ[count].x -
 					pSector->sloped_floor->plane.b * pXYZ[count].y -
 					pSector->sloped_floor->plane.d) * oneOverC;
 			}
 			else
 			{
-				pXYZ[count].x = (float)pNode->u.leaf.poly.p[count].x;
-				pXYZ[count].y = (float)pNode->u.leaf.poly.p[count].y;
+				pXYZ[count].x = pNode->u.leaf.poly.p[count].x;
+				pXYZ[count].y = pNode->u.leaf.poly.p[count].y;
 				pXYZ[count].z = (float)pSector->floor_height;
 			}
 

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -38,51 +38,34 @@ inline DWORD F2DW( FLOAT f ) { return *((DWORD*)&f); }
 #define D3DRENDER_REDRAW_ALL	0x00000002
 
 #define D3DRENDER_SET_ALPHATEST_STATE(_pDevice, _enable, _refValue, _compareFunc)	\
-do	\
-{	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, _enable);	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF, _refValue);	\
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAFUNC, _compareFunc);	\
-} while (0)
+	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAFUNC, _compareFunc);
 
 #define D3DRENDER_SET_ALPHABLEND_STATE(_pDevice, _enable, _srcBlend, _dstBlend)	\
-do	\
-{	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHABLENDENABLE, _enable);	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_SRCBLEND, _srcBlend);	\
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_DESTBLEND, _dstBlend);	\
-} while (0)
+	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_DESTBLEND, _dstBlend);
 
 #define D3DRENDER_SET_STENCIL_STATE(_pDevice, _enable, _stencilFunc, _refValue, _pass, _fail, _zfail)	\
-do	\
-{	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_STENCILENABLE, _enable);	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_STENCILFUNC, _stencilFunc);	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_STENCILREF, _refValue);	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_STENCILPASS, _pass);	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_STENCILFAIL, _fail);	\
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_STENCILZFAIL, _zfail);	\
-} while (0)
+	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_STENCILZFAIL, _zfail);
 
 #define D3DRENDER_SET_COLOR_STAGE(_pDevice, _stage, _opValue, _arg0Value, _arg1Value)	\
-do	\
-{	\
 	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_COLOROP,	_opValue);	\
 	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_COLORARG1, _arg0Value);	\
-	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_COLORARG2, _arg1Value);	\
-} while (0)
+	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_COLORARG2, _arg1Value);
 
 #define D3DRENDER_SET_ALPHA_STAGE(_pDevice, _stage, _opValue, _arg0Value, _arg1Value)	\
-do	\
-{	\
 	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_ALPHAOP,	_opValue);	\
 	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_ALPHAARG1, _arg0Value);	\
-	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_ALPHAARG2, _arg1Value);	\
-} while (0)
+	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_ALPHAARG2, _arg1Value);
 
 #define D3DRENDER_SET_STREAMS(_pDevice, _pCache, _numStages)	\
-do	\
-{	\
 	int	_i = 0;	\
 	int	_j;	\
 	IDirect3DDevice9_SetStreamSource(_pDevice, _i++,	\
@@ -92,20 +75,16 @@ do	\
 	for (_j = 0; _j < _numStages; _j++)	\
 		IDirect3DDevice9_SetStreamSource(_pDevice, _i++,	\
 			(_pCache)->stBuffer[_j].pVBuffer, 0, sizeof(custom_st));	\
-	IDirect3DDevice9_SetIndices(_pDevice, (_pCache)->indexBuffer.pIBuffer);	\
-} while (0)
+	IDirect3DDevice9_SetIndices(_pDevice, (_pCache)->indexBuffer.pIBuffer);
 
 #define D3DRENDER_CLEAR_STREAMS(_pDevice, _numStages)	\
-do	\
-{	\
 	int	_i = 0;	\
 	int	_j;	\
 	IDirect3DDevice9_SetStreamSource(_pDevice, _i++, NULL, 0, 0);	\
 	IDirect3DDevice9_SetStreamSource(_pDevice, _i++, NULL, 0, 0);	\
 	for (_j = 0; _j < _numStages; _j++)	\
 		IDirect3DDevice9_SetStreamSource(_pDevice, _i++, NULL, 0, 0);	\
-	IDirect3DDevice9_SetIndices(_pDevice, NULL);	\
-} while (0)
+	IDirect3DDevice9_SetIndices(_pDevice, NULL);
 
 typedef struct d_light
 {

--- a/clientd3d/draw3d.c
+++ b/clientd3d/draw3d.c
@@ -737,18 +737,18 @@ BYTE *GetLightPalette(int distance, BYTE sector_light, long scale, int lightOffs
    // See if sector is affected by ambient light
    if (sector_light > 127)
    {
-      row = ((FINENESS/2) << LOG_VIEWER_DISTANCE) / distance;
+      row = ((FINENESS >> 1) << LOG_VIEWER_DISTANCE) / distance;
       if (row < 1)
 	 row = 1;
-      if (row > MAXY / 2)
-	 row = MAXY / 2;
+      if (row > MAXY >> 1)
+	 row = MAXY >> 1;
 
       index = ((int) light_rows[row] + (int) sector_light - LIGHT_NEUTRAL) * 
-	 LIGHT_LEVELS / MAX_LIGHT;  // Scale from 0-255 to # of palettes
+         LIGHT_LEVELS >> 8;  // Scale from 0-255 to # of palettes - bit shift for speed
 
    }
    else index = LIGHT_INDEX(distance, (int) p->viewer_light, 0) * LIGHT_LEVELS / MAX_LIGHT
-      + (int) sector_light / 2;
+      + (int) (sector_light >> 1);
 
    if ((scale != FINENESS) && (sector_light > 127))
        index = (scale * index)>>LOG_FINENESS;
@@ -777,18 +777,18 @@ int GetLightPaletteIndex(int distance, BYTE sector_light, long scale, int lightO
    // See if sector is affected by ambient light
    if (sector_light > 127)
    {
-      row = ((FINENESS/2) << LOG_VIEWER_DISTANCE) / distance;
+      row = ((FINENESS >> 1) << LOG_VIEWER_DISTANCE) / distance;
       if (row < 1)
 	 row = 1;
-      if (row > MAXY / 2)
-	 row = MAXY / 2;
+      if (row > MAXY >> 1)
+	 row = MAXY >> 1;
 
       index = ((int) light_rows[row] + (int) sector_light - LIGHT_NEUTRAL) * 
-	 LIGHT_LEVELS / MAX_LIGHT;  // Scale from 0-255 to # of palettes
+	 LIGHT_LEVELS >> 8;  // Scale from 0-255 to # of palettes - bit shift for speed
 
    }
    else index = LIGHT_INDEX(distance, (int) p->viewer_light, 0) * LIGHT_LEVELS / MAX_LIGHT
-      + (int) sector_light / 2;
+      + (int) (sector_light >> 1);
 
    if ((scale != FINENESS) && (sector_light > 127))
        index = (scale * index)>>LOG_FINENESS;

--- a/clientd3d/draw3d.h
+++ b/clientd3d/draw3d.h
@@ -24,7 +24,7 @@
 /* Given a distance x, return palette index to use.  Must have x > 0 */
 /* "v" is strength of light source at viewer; "a" strength of ambient light */
 #define LIGHT_INDEX(x, v, a) (min(MAX_LIGHT - 1, \
-				  (4*FINENESS*FINENESS) / (x) * (v) / KOD_LIGHT_LEVELS + (a)))
+				  (4 << 20) / (x) * (v) / KOD_LIGHT_LEVELS + (a)))
 
 #define LIGHT_NEUTRAL 192       // Light level of sector drawn at ambient light level
 

--- a/clientd3d/drawbsp.c
+++ b/clientd3d/drawbsp.c
@@ -34,7 +34,7 @@
 
 // inline utility macros
 #define SWAP(a,b,tmp) (tmp)=(a);(a)=(b);(b)=(tmp)
-#define LERP(a,b,t)   ((a) + ((((b)-(a)) * (t)) / FINENESS))
+#define LERP(a,b,t)   ((a) + ((((b)-(a)) * (t)) >> LOG_FINENESS))
 
 static ID   viewer_id;          /* Id of player's object */
 static long viewer_angle;       /* Angle of viewing in pseudo degrees */
@@ -507,8 +507,8 @@ static void AddObjects(room_type *room)
       d->ncones_ptr    = &d->ncones;
 
       /* set center field */
-      a = (left_a * dx + left_b * dy) / FINENESS;
-      b = (right_a * dx + right_b * dy) / FINENESS;
+      a = (left_a * dx + left_b * dy) >> (FIX_DECIMAL - 6);
+      b = (right_a * dx + right_b * dy) >> (FIX_DECIMAL - 6);
       if (a + b <= 0)
       {
 	 debug(("a+b <= 0! (AddObjects) %ld\n",a+b));
@@ -595,8 +595,8 @@ static void AddObjects(room_type *room)
       d->draw.obj      = NULL;
 
       /* set center field */
-      a = (left_a * dx + left_b * dy) / FINENESS;
-      b = (right_a * dx + right_b * dy) / FINENESS;
+      a = (left_a * dx + left_b * dy) >> (FIX_DECIMAL - 6);
+      b = (right_a * dx + right_b * dy) >> (FIX_DECIMAL - 6);
       if (a + b <= 0)
       {
 	 debug(("a+b <= 0! (AddObjects) %ld\n",a+b));
@@ -2296,8 +2296,8 @@ static void WalkObjects(ObjectData *objects)
       
       x = object->x0 - viewer_x;
       y = object->y0 - viewer_y;
-      a = (left_a * x + left_b * y) / FINENESS;
-      b = (right_a * x + right_b * y) / FINENESS;
+      a = (left_a * x + left_b * y) >> (FIX_DECIMAL - 6);
+      b = (right_a * x + right_b * y) >> (FIX_DECIMAL - 6);
       if (a + b <= 0)
       {
 	 debug(("a+b <= 0! (WalkObjects(1)) %ld\n",a+b));
@@ -2307,8 +2307,8 @@ static void WalkObjects(ObjectData *objects)
       
       x = object->x1 - viewer_x;
       y = object->y1 - viewer_y;
-      a = (left_a * x + left_b * y) / FINENESS;
-      b = (right_a * x + right_b * y) / FINENESS;
+      a = (left_a * x + left_b * y) >> (FIX_DECIMAL - 6);
+      b = (right_a * x + right_b * y) >> (FIX_DECIMAL - 6);
       if (a + b <= 0)
       {
 	 debug(("a+b <= 0! (WalkObjects(2)) %ld\n",a+b));
@@ -3094,13 +3094,13 @@ void doDrawWall(DrawWallStruct *wall, ViewCone *c)
       if (z1 <= 0)
 	 z1 = 1.0f;
 
-      f = ((-z0) * (FINENESS * 4)) / (z1 - z0);
+      f = ((-z0) * (FINENESS << 2)) / (z1 - z0);
       if (f < oldf)
 	f = oldf;
       oldf = f;
       
       // Compute extent of wall on screen
-      d = d0 + (((d1-d0)*f) / (FINENESS * 4));
+      d = d0 + (((d1-d0)*f) / (FINENESS << 2));
       if (d <= 1.0)
 	d = 1.0f;
 
@@ -3163,10 +3163,10 @@ void doDrawWall(DrawWallStruct *wall, ViewCone *c)
 	 xGraphicOffset >>= horzDownScale;
       }
       if (backwards)
-	 textpos = (long)(((( FRACTION-1 - f) * length) / (FINENESS * 4)) + xGraphicOffset)
+	 textpos = (long)(((( FRACTION-1 - f) * length) / (FINENESS << 2)) + xGraphicOffset)
 	    % (bitmap_height);
       else
-         textpos = (long)(((f * length) / (FINENESS * 4)) + xGraphicOffset)
+         textpos = (long)(((f * length) / (FINENESS << 2)) + xGraphicOffset)
 	    % (bitmap_height);
       
       // Make textpos positive

--- a/clientd3d/drawbsp.c
+++ b/clientd3d/drawbsp.c
@@ -1488,13 +1488,13 @@ static Bool add_dn(DrawItem *item_template, long a, long b, long d, long col0, l
  * lie. These values are use to interpolate the height(s) at each endpoint
  * of a wall that bounds a sloped sector.
  */
-int world_to_screen(double x0, double y0, double x1, double y1,
+int world_to_screen(float x0, float y0, float x1, float y1,
 		    long *t0, long *t1, /* special parameters for sloped walls */
-		    long *col0, double *d0, long *col1, double *d1)
+          long *col0, float *d0, long *col1, float *d1)
 {
-  double left0,right0,left1,right1;
-  double x,y;
-  long t,tleft,tright;
+   float left0, right0, left1, right1;
+   float x, y;
+    long t,tleft,tright;
   
   /* go to viewer-relative coords */
   x0 -= viewer_x;
@@ -1512,9 +1512,9 @@ int world_to_screen(double x0, double y0, double x1, double y1,
   /* make sure left and right are not both zero.  If they are,   */
   /* move them to a point that maps to the center of the screen. */
   if (right0 <= 0.001 && right0 >= -0.001)
-     right0 = 1.0;
+     right0 = 1.0f;
   if (right1 <= 0.001 && right1 >= -0.001)
-     right1 = 1.0;
+     right1 = 1.0f;
   
   if (left0 < 0)
   {
@@ -2017,7 +2017,7 @@ Bool Bbox_shadowed(long x0, long y0, long x1, long y1)
 static void WalkWall(WallData *wall, long side)
 {
    long col0,col1;
-   double d0,d1;
+   float d0,d1;
    ConeTreeNode *c, *next;
    long toprow0,toprow1,botrow0,botrow1;
    long a,b,d;
@@ -2387,11 +2387,11 @@ static void WalkLeaf(BSPleaf *leaf)
 {
    long i;
    long col0,col1;
-   double d0, d1;
+   float d0, d1;
    long row0,row1;
    DrawItem item_template;
    long a,b,d;
-   long x0,y0,x1,y1;
+   float x0,y0,x1,y1;
    long t0,t1,height,height0,height1;
    SlopeData *sloped_floor = leaf->sector->sloped_floor;  // only a tiny bit faster but much easier to read
    SlopeData *sloped_ceiling = leaf->sector->sloped_ceiling;
@@ -2842,17 +2842,17 @@ void doDrawWall(DrawWallStruct *wall, ViewCone *c)
    long clipstart,clipend;
    long textpos;
    long a,b;
-   double d0,d1;
+   float d0,d1;
    long xoffset, yoffset;
    WallData *BSPwall = wall->wall;
    PDIB bmap;
    BYTE *bits, light;
    int backwards, transparent, bitmap_height, bitmap_width;
-   double x0, y0, x1, y1;
+   float x0, y0, x1, y1;
    long  num_steps, total_steps;
-   double d,f;
-   double z0, z1;
-   double oldf = 0.0;
+   float d, f;
+   float z0, z1;
+   float oldf = 0.0;
    BOOL hasMipMaps = FALSE;
    grid_bitmap_type grid = NULL;
    Animate *pAnim = NULL;
@@ -3090,9 +3090,9 @@ void doDrawWall(DrawWallStruct *wall, ViewCone *c)
       z1 = (a * x1 + b * y1) / FINENESS;
       
       if (z0 > 0)
-	 z0 = 0;
+	 z0 = 0.0f;
       if (z1 <= 0)
-	 z1 = 1;
+	 z1 = 1.0f;
 
       f = ((-z0) * (FINENESS * 4)) / (z1 - z0);
       if (f < oldf)
@@ -3102,7 +3102,7 @@ void doDrawWall(DrawWallStruct *wall, ViewCone *c)
       // Compute extent of wall on screen
       d = d0 + (((d1-d0)*f) / (FINENESS * 4));
       if (d <= 1.0)
-	d = 1.0;
+	d = 1.0f;
 
       rowstart = horizon + ((viewer_height - top) << LOG_VIEWER_DISTANCE) / d;
       rowend = horizon + ((viewer_height - bottom) << LOG_VIEWER_DISTANCE) / d;

--- a/clientd3d/effect.c
+++ b/clientd3d/effect.c
@@ -15,6 +15,8 @@
 
 Effects effects;
 
+extern Bool gD3DRedrawAll;
+
 static void EffectFlash(int duration);
 /****************************************************************************/
 /*
@@ -88,6 +90,8 @@ Bool PerformEffect(WORD effect, char *ptr, int len)
 
    case EFFECT_SEE:
       effects.blind = False;
+      // Redraw new graphics to load the room correctly.
+      gD3DRedrawAll |= D3DRENDER_REDRAW_ALL;
       RedrawAll();
       break;
 

--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -361,8 +361,9 @@ void RedrawForce(void)
    lastEndFrame = endFrame;
    timeEndPeriod(1);
 
+   // As far as I can tell, we don't need to do this here.
    // Try to redraw new graphics
-   gD3DRedrawAll |= D3DRENDER_REDRAW_ALL;
+   //gD3DRedrawAll |= D3DRENDER_REDRAW_UPDATE;
 
    if (config.showFPS)
    {

--- a/clientd3d/move.c
+++ b/clientd3d/move.c
@@ -167,28 +167,28 @@ void UserMovePlayer(int action)
    if (player.viewID)
    {
       if (player.viewFlags & REMOTE_VIEW_CONTROL)
-	 return;
+         return;
       if (!(player.viewFlags & REMOTE_VIEW_MOVE))
-	 return;
+         return;
    }
    // Find out how far to move based on time elapsed:  always move at a rate of 
    // constant rate per MOVE_DELAY milliseconds.
    switch (action)
    {
-	case A_FORWARDFAST:
-	case A_BACKWARDFAST:
-	case A_SLIDELEFTFAST:
-	case A_SLIDERIGHTFAST:
-	case A_SLIDELEFTFORWARDFAST:
-	case A_SLIDERIGHTFORWARDFAST:
-	case A_SLIDELEFTBACKWARDFAST:
-	case A_SLIDERIGHTBACKWARDFAST:
-		move_distance = 2 * MOVEUNITS;
-	break;
+   case A_FORWARDFAST:
+   case A_BACKWARDFAST:
+   case A_SLIDELEFTFAST:
+   case A_SLIDERIGHTFAST:
+   case A_SLIDELEFTFORWARDFAST:
+   case A_SLIDERIGHTFORWARDFAST:
+   case A_SLIDELEFTBACKWARDFAST:
+   case A_SLIDERIGHTBACKWARDFAST:
+      move_distance = 2 * MOVEUNITS;
+   break;
 
-	default:
-		move_distance = MOVEUNITS;
-	break;
+   default:
+      move_distance = MOVEUNITS;
+   break;
    }
 
    now = timeGetTime();
@@ -238,25 +238,25 @@ void UserMovePlayer(int action)
       angle = (player.angle + 3 * NUMDEGREES / 4) % NUMDEGREES;  /* angle + 3pi/2 */
       break;
    case A_SLIDERIGHT:
-	case A_SLIDERIGHTFAST:
+   case A_SLIDERIGHTFAST:
       angle = (player.angle + NUMDEGREES / 4) % NUMDEGREES;  /* angle + pi/2 */
       break;
-	case A_SLIDELEFTFORWARD:
-	case A_SLIDELEFTFORWARDFAST:
-		angle = (player.angle + 7 * NUMDEGREES / 8) % NUMDEGREES;
-		break;
-	case A_SLIDELEFTBACKWARD:
-	case A_SLIDELEFTBACKWARDFAST:
-		angle = (player.angle + 5 * NUMDEGREES / 8) % NUMDEGREES;
-		break;
-	case A_SLIDERIGHTFORWARD:
-	case A_SLIDERIGHTFORWARDFAST:
-		angle = (player.angle + 1 * NUMDEGREES / 8) % NUMDEGREES;
-		break;
-	case A_SLIDERIGHTBACKWARD:
-	case A_SLIDERIGHTBACKWARDFAST:
-		angle = (player.angle + 3 * NUMDEGREES / 8) % NUMDEGREES;
-		break;
+   case A_SLIDELEFTFORWARD:
+   case A_SLIDELEFTFORWARDFAST:
+      angle = (player.angle + 7 * NUMDEGREES / 8) % NUMDEGREES;
+      break;
+   case A_SLIDELEFTBACKWARD:
+   case A_SLIDELEFTBACKWARDFAST:
+      angle = (player.angle + 5 * NUMDEGREES / 8) % NUMDEGREES;
+      break;
+   case A_SLIDERIGHTFORWARD:
+   case A_SLIDERIGHTFORWARDFAST:
+      angle = (player.angle + 1 * NUMDEGREES / 8) % NUMDEGREES;
+      break;
+   case A_SLIDERIGHTBACKWARD:
+   case A_SLIDERIGHTBACKWARDFAST:
+      angle = (player.angle + 3 * NUMDEGREES / 8) % NUMDEGREES;
+      break;
    default:
       debug(("Bad action type in UserMovePlayer\n"));
       return;
@@ -294,66 +294,68 @@ void UserMovePlayer(int action)
       leaf = BSPFindLeafByPoint(current_room.tree, x, y);
       if (leaf == NULL || leaf->sector == NULL)
       {
-	 x = last_x;
-	 y = last_y;
-	 z = last_z;
-	 break;
+         x = last_x;
+         y = last_y;
+         z = last_z;
+         break;
       }
 
       if (lastBlockingNode)
       {
-	 lastBlockingWall = IntersectNode(lastBlockingNode,last_x,last_y,x,y,z);
-	 if (lastBlockingWall)
-	 {
-	    SlideAlongWall(lastBlockingWall,last_x,last_y,&x,&y);
-	 }
-	 else
-	    lastBlockingNode = NULL;
+         lastBlockingWall = IntersectNode(lastBlockingNode,last_x,last_y,x,y,z);
+         if (lastBlockingWall)
+         {
+            SlideAlongWall(lastBlockingWall,last_x,last_y,&x,&y);
+         }
+         else
+            lastBlockingNode = NULL;
       }
       else
       {
-	 lastBlockingNode = FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall);
-	 if (lastBlockingNode)
-	 {
-	    SlideAlongWall(lastBlockingWall,last_x,last_y,&x,&y);
-	 }
+         lastBlockingNode = FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall);
+         if (lastBlockingNode)
+         {
+            SlideAlongWall(lastBlockingWall,last_x,last_y,&x,&y);
+         }
       }
       if (FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall))
       {
-	 SlideAlongWall(lastBlockingWall,last_x,last_y,&x,&y);
-	 if (FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall))
-	 {
-	    FindOffsets(MIN_SIDE_MOVE, (angle + 3 * NUMDEGREES / 4) % NUMDEGREES, &dx, &dy);
-	    x = last_x + dx;
-	    y = last_y + dy;
-	    if (FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall))
-	    {
-	       FindOffsets(MIN_SIDE_MOVE, (angle + NUMDEGREES / 4) % NUMDEGREES, &dx, &dy);
-	       x = last_x + dx;
-	       y = last_y + dy;
-	       if (FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall))
-	       {
-		  x = last_x;
-		  y = last_y;
-		  z = last_z;
-		  break;
-	       }
-	    }
-	 }
+         SlideAlongWall(lastBlockingWall,last_x,last_y,&x,&y);
+         if (FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall))
+         {
+            FindOffsets(MIN_SIDE_MOVE, (angle + 3 * NUMDEGREES / 4) % NUMDEGREES, &dx, &dy);
+            x = last_x + dx;
+            y = last_y + dy;
+            if (FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall))
+            {
+               FindOffsets(MIN_SIDE_MOVE, (angle + NUMDEGREES / 4) % NUMDEGREES, &dx, &dy);
+               x = last_x + dx;
+               y = last_y + dy;
+               if (FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall))
+               {
+                  x = last_x;
+                  y = last_y;
+                  z = last_z;
+                  break;
+               }
+            }
+         }
       }
-      
+
       // Don't try to slide to current location
       if (x == last_x && y == last_y)
-		  x = x;
+         x = x;
 //	 break;
       
       // Get around integer divide yuckiness
       if (y < 0)
-	 row = -1;
-      else row = y / FINENESS;
+         row = -1;
+      else
+         row = y / FINENESS;
       if (x < 0)
-	 col = -1;
-      else col = x / FINENESS;
+         col = -1;
+      else
+         col = x / FINENESS;
 
       // See if trying to move off room.
       if (!IsInRoom(row, col, current_room))
@@ -385,17 +387,17 @@ void UserMovePlayer(int action)
 
       if (retval == MOVE_BLOCKED)
       {
-	 //	 debug(("Move blocked by object\n"));
-	 x = last_x;
-	 y = last_y;
-	 z = last_z;
-	 bounce = False;
-	 break;
+         // debug(("Move blocked by object\n"));
+         x = last_x;
+         y = last_y;
+         z = last_z;
+         bounce = False;
+         break;
       }
       else if (retval == MOVE_CHANGED)
       {
-	 // Stop at this modified move
-	 break;
+         // Stop at this modified move
+         break;
       }
 
       last_x = x;
@@ -428,11 +430,11 @@ void UserMovePlayer(int action)
       // Only set motion if not already moving that direction
       if (z > player_obj->motion.z && player_obj->motion.v_z <= 0)
       {
-	 player_obj->motion.v_z = CLIMB_VELOCITY_0;
+         player_obj->motion.v_z = CLIMB_VELOCITY_0;
       }
       else if (z < player_obj->motion.z && player_obj->motion.v_z >= 0)
       {
-	 player_obj->motion.v_z = FALL_VELOCITY_0;
+         player_obj->motion.v_z = FALL_VELOCITY_0;
       }
    }
    else player_obj->motion.z = z;
@@ -494,10 +496,10 @@ BSPnode *FindIntersection(BSPnode *node, int xOld, int yOld, int xNew, int yNew,
       BSPinternal *inode = &node->u.internal;
       BSPnode *nodeIntersect = FindIntersection(inode->pos_side, xOld, yOld, xNew, yNew, z, wallIntersect);
       if (nodeIntersect)
-	 return nodeIntersect;
+         return nodeIntersect;
       nodeIntersect = FindIntersection(inode->neg_side, xOld, yOld, xNew, yNew, z, wallIntersect);
       if (nodeIntersect)
-	 return nodeIntersect;
+         return nodeIntersect;
       return NULL;
    }
 }
@@ -506,8 +508,7 @@ WallData *IntersectNode(BSPnode *node, int old_x, int old_y, int new_x, int new_
 {
    BSPinternal *inode;
    WallData *wall;
-   int a, b, c, plane_distance, old_distance;
-   int newDistance;
+   float a, b, c, plane_distance, old_distance, newDistance;
 
    if (node == NULL || node->type == BSPleaftype)
       return NULL;
@@ -527,7 +528,7 @@ WallData *IntersectNode(BSPnode *node, int old_x, int old_y, int new_x, int new_
    c = inode->separator.c;
    plane_distance = (a * new_x + b * new_y + c);
    old_distance = (a * old_x + b * old_y + c);
-   newDistance = ABS(plane_distance) >> LOG_FINENESS;
+   newDistance = ABS(plane_distance) / FINENESS;
    if ((newDistance > min_distance) || (ABS(plane_distance) > ABS(old_distance)))
       return NULL;
 
@@ -536,85 +537,86 @@ WallData *IntersectNode(BSPnode *node, int old_x, int old_y, int new_x, int new_
    {
       Sidedef *sidedef;
       Sector *other_sector;
-      int below_height, d0, d1, dx, dy, lenWall2;
-      int minx = min(wall->x0, wall->x1) - min_distance;
-      int maxx = max(wall->x0, wall->x1) + min_distance;
-      int miny = min(wall->y0, wall->y1) - min_distance;
-      int maxy = max(wall->y0, wall->y1) + min_distance;
-	 
+      int below_height;
+      float d0, d1, dx, dy, lenWall2;
+      float minx = min(wall->x0, wall->x1) - min_distance;
+      float maxx = max(wall->x0, wall->x1) + min_distance;
+      float miny = min(wall->y0, wall->y1) - min_distance;
+      float maxy = max(wall->y0, wall->y1) + min_distance;
+
       // See if we are near the wall itself, and not just the wall's plane
       if ((new_x >= minx) && (new_x <= maxx) && (new_y >= miny) && (new_y <= maxy))
       {
-	 // Skip floor->ceiling wall if player can walk through it
-	 if (SGN(old_distance) > 0)
-	 {
-	    sidedef = wall->pos_sidedef;
-	    other_sector = wall->neg_sector;
-	 }
-	 else
-	 {
-	    sidedef = wall->neg_sidedef;
-	    other_sector = wall->pos_sector;
-	 }
-	 if (sidedef == NULL)
-	    continue;
+         // Skip floor->ceiling wall if player can walk through it
+         if (SGNDOUBLE(old_distance) > 0)
+         {
+            sidedef = wall->pos_sidedef;
+            other_sector = wall->neg_sector;
+         }
+         else
+         {
+            sidedef = wall->neg_sidedef;
+            other_sector = wall->pos_sector;
+         }
+         if (sidedef == NULL)
+            continue;
 
-	 // Check for wading on far side of wall; reduce effective height of wall if found
-	 below_height = 0;
-	 if (other_sector != NULL)
-	    below_height = sector_depths[SectorDepth(other_sector->flags)];
+         // Check for wading on far side of wall; reduce effective height of wall if found
+         below_height = 0;
+         if (other_sector != NULL)
+            below_height = sector_depths[SectorDepth(other_sector->flags)];
 
-	 // Can't step up too far; watch bumping your head; see if passable
-	 if ((sidedef->below_bmap == NULL || 
-		 (sidedef->below_bmap != NULL && 
-	       (wall->z1 - below_height - z) <= MAX_STEP_HEIGHT))
-		&&
-		(sidedef->above_bmap == NULL || 
-		 (sidedef->above_bmap != NULL && wall->z2 - z >= player.height)) 
-		&&
-		(sidedef->flags & WF_PASSABLE))
-	    continue;
+         // Can't step up too far; watch bumping your head; see if passable
+         if ((sidedef->below_bmap == NULL || 
+            (sidedef->below_bmap != NULL && 
+            (wall->z1 - below_height - z) <= MAX_STEP_HEIGHT))
+            &&
+            (sidedef->above_bmap == NULL || 
+            (sidedef->above_bmap != NULL && wall->z2 - z >= player.height)) 
+            &&
+            (sidedef->flags & WF_PASSABLE))
+            continue;
 
-	 // If distance to either vertex is > wall length, then destination of move is
-	 // past end of wall; use distance to closer vertex as distance to line
-	 dx = new_x - wall->x0;
-	 dy = new_y - wall->y0;
-	 d0 = dx * dx + dy * dy;
+         // If distance to either vertex is > wall length, then destination of move is
+         // past end of wall; use distance to closer vertex as distance to line
+         dx = new_x - wall->x0;
+         dy = new_y - wall->y0;
+         d0 = dx * dx + dy * dy;
 
-	 dx = new_x - wall->x1;
-	 dy = new_y - wall->y1;
-	 d1 = dx * dx + dy * dy;
+         dx = new_x - wall->x1;
+         dy = new_y - wall->y1;
+         d1 = dx * dx + dy * dy;
 
-	 // Recheck distance to wall based on distance to closest vertex
-	 //len = FinenessKodToClient(wall->length);
-	 //lenWall2 = len * len;
-	 dx = wall->x1 - wall->x0;
-	 dy = wall->y1 - wall->y0;
-	 lenWall2 = dx * dx + dy * dy;
-	 if (d0 > lenWall2) // d1 is closest vertex
-	 {
-	    int dx = old_x - wall->x1;
-	    int dy = old_y - wall->y1;
-	    int oldEndDist = dx * dx + dy * dy;
-	    if ((d1 < min_distance2) && (d1 <= oldEndDist))
-	    {
-	       return wall;
-	    }
-	 }
-	 else if (d1 > lenWall2) // d0 is closest vertex
-	 {
-	    int dx = old_x - wall->x0;
-	    int dy = old_y - wall->y0;
-	    int oldEndDist = dx * dx + dy * dy;
-	    if ((d0 < min_distance2) && (d0 <= oldEndDist))
-	    {
-	       return wall;
-	    }
-	 }
-	 else // within wall range!
-	 {
-	    return wall;
-	 }
+         // Recheck distance to wall based on distance to closest vertex
+         //len = FinenessKodToClient(wall->length);
+         //lenWall2 = len * len;
+         dx = wall->x1 - wall->x0;
+         dy = wall->y1 - wall->y0;
+         lenWall2 = dx * dx + dy * dy;
+         if (d0 > lenWall2) // d1 is closest vertex
+         {
+            float dx = old_x - wall->x1;
+            float dy = old_y - wall->y1;
+            float oldEndDist = dx * dx + dy * dy;
+            if ((d1 < min_distance2) && (d1 <= oldEndDist))
+            {
+               return wall;
+            }
+         }
+         else if (d1 > lenWall2) // d0 is closest vertex
+         {
+            float dx = old_x - wall->x0;
+            float dy = old_y - wall->y0;
+            float oldEndDist = dx * dx + dy * dy;
+            if ((d0 < min_distance2) && (d0 <= oldEndDist))
+            {
+               return wall;
+            }
+         }
+         else // within wall range!
+         {
+            return wall;
+         }
       }
    }
    return NULL;
@@ -937,19 +939,19 @@ void UserTurnPlayer(int action)
    if (player.viewID)
    {
       if (!(player.viewFlags & REMOTE_VIEW_TURN))
-	 return;
+         return;
       if (player.viewFlags & REMOTE_VIEW_CONTROL)
       {
-	 room_contents_node *viewObject = GetRoomObjectById(player.viewID);
-	 if (viewObject)
-	 {
-	    viewObject->angle += delta;
-	    if (viewObject->angle < 0)
-	       viewObject->angle += NUMDEGREES;
-	    viewObject->angle = viewObject->angle % NUMDEGREES;
-	    RedrawAll();
-	    return;
-	 }
+         room_contents_node *viewObject = GetRoomObjectById(player.viewID);
+         if (viewObject)
+         {
+            viewObject->angle += delta;
+            if (viewObject->angle < 0)
+               viewObject->angle += NUMDEGREES;
+            viewObject->angle = viewObject->angle % NUMDEGREES;
+            RedrawAll();
+            return;
+         }
       }
    }
 
@@ -973,19 +975,19 @@ void UserTurnPlayerMouse(int delta)
    if (player.viewID)
    {
       if (!(player.viewFlags & REMOTE_VIEW_TURN))
-	 return;
+         return;
       if (player.viewFlags & REMOTE_VIEW_CONTROL)
       {
-	 room_contents_node *viewObject = GetRoomObjectById(player.viewID);
-	 if (viewObject)
-	 {
-	    viewObject->angle += delta;
-	    if (viewObject->angle < 0)
-	       viewObject->angle += NUMDEGREES;
-	    viewObject->angle = viewObject->angle % NUMDEGREES;
-	    RedrawAll();
-	    return;
-	 }
+         room_contents_node *viewObject = GetRoomObjectById(player.viewID);
+         if (viewObject)
+         {
+            viewObject->angle += delta;
+            if (viewObject->angle < 0)
+               viewObject->angle += NUMDEGREES;
+            viewObject->angle = viewObject->angle % NUMDEGREES;
+            RedrawAll();
+            return;
+         }
       }
    }
 
@@ -1008,17 +1010,17 @@ void UserFlipPlayer(void)
    if (player.viewID)
    {
       if (!(player.viewFlags & REMOTE_VIEW_TURN))
-	 return;
+         return;
       if (player.viewFlags & REMOTE_VIEW_CONTROL)
       {
-	 room_contents_node *viewObject = GetRoomObjectById(player.viewID);
-	 if (viewObject)
-	 {
-	    viewObject->angle += NUMDEGREES / 2;
-	    viewObject->angle = viewObject->angle % NUMDEGREES;
-	    RedrawAll();
-	    return;
-	 }
+         room_contents_node *viewObject = GetRoomObjectById(player.viewID);
+         if (viewObject)
+         {
+            viewObject->angle += NUMDEGREES / 2;
+            viewObject->angle = viewObject->angle % NUMDEGREES;
+            RedrawAll();
+            return;
+         }
       }
    }
 
@@ -1028,7 +1030,6 @@ void UserFlipPlayer(void)
    MoveUpdateServer();
    RedrawAll();
 }
-
 
 // Move at most HEIGHT_INCREMENT per HEIGHT_DELAY milliseconds
 #define HEIGHT_INCREMENT (MAXY / 4)    
@@ -1050,7 +1051,8 @@ void BounceUser(int dt)
      bounce_time += ((float) dt) / MOVE_DELAY;  /* In radians */
      bounce_height = (long) (BOUNCE_HEIGHT * sin(bounce_time));
    }
-   else bounce_height = 0;
+   else
+      bounce_height = 0;
 }
 /************************************************************************/
 /*


### PR DESCRIPTION
Load room data as doubles instead of integers, use in calculations (D3D casts the result of these calcs to floats).I don't think there's much benefit to having the extra precision in software mode, but I have converted it for now anyway.

Fixes slope errors (gaps) and 99% of polygon cracks (i.e. wireframes).

The D3D header edits are to clean up compiler warnings (I'm not sure why they wrote the defines that way, I can't see a purpose to it as opposed to just defining).

Added a few variables to keep track of drawing time in D3DRenderBegin.

Wireframe is *on* for now, as there are still a few stray sky pixels being drawn between polygons (interestingly, not on sloped surfaces).

Fixed lighting errors caused by a division in the light range instead of a multiplication. Was the cause of some polygons not receiving lighting from static, dynamic or projectile lights.