### PR TITLE
Client changes to load ROO v.14, graphics fixes, D3D refactoring.

### DIFF
--- a/clientd3d/bsp.h
+++ b/clientd3d/bsp.h
@@ -242,6 +242,9 @@ typedef struct WallData
    /* positive side of wall must be on right when going from 0 to 1 */
 
    Bool seen;                  /* True iff part of this wall has been drawn */
+   Bool drawbelow;     // True if D3D renderer should draw this wall.
+   Bool drawabove;     // True if D3D renderer should draw this wall.
+   Bool drawnormal;    // True if D3D renderer should draw this wall.
 
    // for bowtie handling
    BYTE bowtie_bits;           /* flags set indicating a bowtie & it's orientation */
@@ -366,6 +369,9 @@ typedef struct BSPnode
    custom_st floor_stBase[MAX_NPTS];
    custom_bgra floor_bgra[MAX_NPTS];
    PDIB floor_pDib;
+
+   Bool drawfloor;   // True if D3D renderer should draw this floor.
+   Bool drawceiling; // True if D3D renderer should draw this ceiling.
 
 } BSPnode, *BSPTree;
 

--- a/clientd3d/bsp.h
+++ b/clientd3d/bsp.h
@@ -83,6 +83,22 @@
 
 #pragma warning( disable : 4201 )		// nonstandard extension used : nameless struct/union (a union in this case )
 
+// D3D types
+typedef struct custom_xyz
+{
+   float	x, y, z;
+} custom_xyz;
+
+typedef struct custom_st
+{
+   float	s, t;
+} custom_st;
+
+typedef struct custom_bgra
+{
+   unsigned char	b, g, r, a;
+} custom_bgra;
+
 /* plane defined by ax + by + c = 0. (x and y are in fineness units.) */
 typedef struct
 {
@@ -169,6 +185,8 @@ typedef struct {
    RoomAnimate *animate;       /* Animation structure for wall */
 } Sidedef;
 
+#define MAX_NPTS 20
+
 typedef struct WallData
 {
    union {
@@ -220,6 +238,8 @@ typedef struct WallData
    long  zz1Neg;        /* height of top of lower wall / bottom of normal wall */
 
    float x0, y0, x1, y1;         /* coordinates of wall start and end */
+   /* (x0,y0) and (x1,y1) must satisfy separator plane equation */
+   /* positive side of wall must be on right when going from 0 to 1 */
 
    Bool seen;                  /* True iff part of this wall has been drawn */
 
@@ -247,9 +267,41 @@ typedef struct WallData
       Sidedef *neg_sidedef;     /* Sidedef on - side (NULL if none) */
       WORD     neg_sidedef_num; /* Sidedef number (used during loading) */
    };
-   
-   /* (x0,y0) and (x1,y1) must satisfy separator plane equation */
-   /* positive side of wall must be on right when going from 0 to 1 */
+
+   // The following data structres are used by D3D to calculate and store
+   // information about the walls, to prevent having to recalculate multiple
+   // times a frame.
+   custom_xyz pos_normal_xyz[4];
+   custom_xyz pos_below_xyz[4];
+   custom_xyz pos_above_xyz[4];
+
+   custom_st pos_normal_stBase[4];
+   custom_st pos_below_stBase[4];
+   custom_st pos_above_stBase[4];
+
+   custom_bgra pos_normal_bgra[4];
+   custom_bgra pos_below_bgra[4];
+   custom_bgra pos_above_bgra[4];
+
+   unsigned int pos_normal_d3dFlags;
+   unsigned int pos_below_d3dFlags;
+   unsigned int pos_above_d3dFlags;
+
+   custom_xyz neg_normal_xyz[4];
+   custom_xyz neg_below_xyz[4];
+   custom_xyz neg_above_xyz[4];
+
+   custom_st neg_normal_stBase[4];
+   custom_st neg_below_stBase[4];
+   custom_st neg_above_stBase[4];
+
+   custom_bgra neg_normal_bgra[4];
+   custom_bgra neg_below_bgra[4];
+   custom_bgra neg_above_bgra[4];
+
+   unsigned int neg_normal_d3dFlags;
+   unsigned int neg_below_d3dFlags;
+   unsigned int neg_above_d3dFlags;
 } WallData, *WallList, *WallDataList;
 
 typedef struct
@@ -268,8 +320,6 @@ typedef struct
       WORD neg_num;               /* number of node on + side (used during loading) */
    };
 } BSPinternal;
-
-#define MAX_NPTS 20
 
 typedef struct {
    int npts;                   /* # of points in polygon */
@@ -304,6 +354,19 @@ typedef struct BSPnode
       BSPinternal internal;
       BSPleaf leaf;
    } u;
+
+   // The following data structres are used by D3D to calculate and store
+   // information about the ceiling and floor, to prevent having to
+   // recalculate multiple times a frame.
+   custom_xyz ceiling_xyz[MAX_NPTS];
+   custom_st ceiling_stBase[MAX_NPTS];
+   custom_bgra ceiling_bgra[MAX_NPTS];
+   PDIB ceiling_pDib;
+   custom_xyz floor_xyz[MAX_NPTS];
+   custom_st floor_stBase[MAX_NPTS];
+   custom_bgra floor_bgra[MAX_NPTS];
+   PDIB floor_pDib;
+
 } BSPnode, *BSPTree;
 
 #pragma warning( default : 4201 )		// nonstandard extension used : nameless struct/union (a union in this case )

--- a/clientd3d/bsp.h
+++ b/clientd3d/bsp.h
@@ -85,29 +85,29 @@
 /* plane defined by ax + by + c = 0. (x and y are in fineness units.) */
 typedef struct
 {
-   double a, b, c;
+   float a, b, c;
 } Plane,Plane2D;
 
 /* 3D plane defined by ax + by + cz + d */
 typedef struct
 {
-    double a, b, c, d;
+    float a, b, c, d;
 } Plane3D;
 
 /* box defined by its top left and bottom right coordinates (in fineness) */
 typedef struct
 {
-   double x0,y0,x1,y1;
+   float x0,y0,x1,y1;
 } Box;
 
 typedef struct
 {
-   double x,y;
+   float x,y;
 } Pnt,Pnt2D,Vector2D;
 
 typedef struct
 {
-   double x,y,z;
+   float x,y,z;
 } Pnt3D,Vector3D;
 
 typedef struct ObjectData
@@ -182,7 +182,7 @@ typedef struct WallData
 
    Plane separator;
    
-   double length;                 /* length of wall; 1 grid square = 64 */
+   float length;                 /* length of wall; 1 grid square = 64 */
    
    // Since I doubled the number of heights stored here, I'm changing
    // these heights to shorts to take up half the space. No room (except godroom)
@@ -218,7 +218,7 @@ typedef struct WallData
    long  zz0Neg;        /* height of bottom of lower wall */
    long  zz1Neg;        /* height of top of lower wall / bottom of normal wall */
 
-   double x0, y0, x1, y1;         /* coordinates of wall start and end */
+   float x0, y0, x1, y1;         /* coordinates of wall start and end */
 
    Bool seen;                  /* True iff part of this wall has been drawn */
 

--- a/clientd3d/bsp.h
+++ b/clientd3d/bsp.h
@@ -79,6 +79,7 @@
 
 #define ABS(x) ((x) > 0 ? (x) : (-(x)))
 #define SGN(x) ((x) == 0 ? 0 : ((x) > 0 ? 1 : -1))
+#define SGNDOUBLE(x) (((x) <= 0.001 && (x) >= -0.001) ? 0 : ((x) > 0.001 ? 1 : -1))
 
 #pragma warning( disable : 4201 )		// nonstandard extension used : nameless struct/union (a union in this case )
 

--- a/clientd3d/bsp.h
+++ b/clientd3d/bsp.h
@@ -85,29 +85,29 @@
 /* plane defined by ax + by + c = 0. (x and y are in fineness units.) */
 typedef struct
 {
-   long a, b, c;
+   double a, b, c;
 } Plane,Plane2D;
 
 /* 3D plane defined by ax + by + cz + d */
 typedef struct
 {
-    FixedPoint a, b, c, d;
+    double a, b, c, d;
 } Plane3D;
 
 /* box defined by its top left and bottom right coordinates (in fineness) */
 typedef struct
 {
-   long x0,y0,x1,y1;
+   double x0,y0,x1,y1;
 } Box;
 
 typedef struct
 {
-   long x,y;
+   double x,y;
 } Pnt,Pnt2D,Vector2D;
 
 typedef struct
 {
-   FixedPoint x,y,z;
+   double x,y,z;
 } Pnt3D,Vector3D;
 
 typedef struct ObjectData
@@ -182,7 +182,7 @@ typedef struct WallData
 
    Plane separator;
    
-   int length;                 /* length of wall; 1 grid square = 64 */
+   double length;                 /* length of wall; 1 grid square = 64 */
    
    // Since I doubled the number of heights stored here, I'm changing
    // these heights to shorts to take up half the space. No room (except godroom)
@@ -218,7 +218,7 @@ typedef struct WallData
    long  zz0Neg;        /* height of bottom of lower wall */
    long  zz1Neg;        /* height of top of lower wall / bottom of normal wall */
 
-   int x0, y0, x1, y1;         /* coordinates of wall start and end */
+   double x0, y0, x1, y1;         /* coordinates of wall start and end */
 
    Bool seen;                  /* True iff part of this wall has been drawn */
 

--- a/clientd3d/bspload.c
+++ b/clientd3d/bspload.c
@@ -263,10 +263,11 @@ Bool LoadNodes(file_node *f, room_type *room, int num_nodes)
       if (CliMappedFileRead(f, &type, 1) != 1) return False;
       node->type = (BSPnodetype) type;
 
-      if (CliMappedFileRead(f, &node->bbox.x0, 4) != 4) return False;
-      if (CliMappedFileRead(f, &node->bbox.y0, 4) != 4) return False;
-      if (CliMappedFileRead(f, &node->bbox.x1, 4) != 4) return False;
-      if (CliMappedFileRead(f, &node->bbox.y1, 4) != 4) return False;
+      // These are now loaded as doubles.
+      if (CliMappedFileRead(f, &node->bbox.x0, 8) != 8) return False;
+      if (CliMappedFileRead(f, &node->bbox.y0, 8) != 8) return False;
+      if (CliMappedFileRead(f, &node->bbox.x1, 8) != 8) return False;
+      if (CliMappedFileRead(f, &node->bbox.y1, 8) != 8) return False;
 
 //      debug(("Loading node %d ", i));
 
@@ -275,16 +276,18 @@ Bool LoadNodes(file_node *f, room_type *room, int num_nodes)
       case BSPinternaltype:
 	 inode = &node->u.internal;
 	 
-	 if (CliMappedFileRead(f, &inode->separator.a, 4) != 4) return False;
-	 if (CliMappedFileRead(f, &inode->separator.b, 4) != 4) return False;
-	 if (CliMappedFileRead(f, &inode->separator.c, 4) != 4) return False;
+	 // Loaded as doubles.
+	 if (CliMappedFileRead(f, &inode->separator.a, 8) != 8) return False;
+	 if (CliMappedFileRead(f, &inode->separator.b, 8) != 8) return False;
+	 if (CliMappedFileRead(f, &inode->separator.c, 8) != 8) return False;
+
+	 // Don't add these to room security (as of roo version 14).
+	 //security += inode->separator.a + inode->separator.b + inode->separator.c;
 
 	 if (CliMappedFileRead(f, &inode->pos_num, 2) != 2) return False;
 	 if (CliMappedFileRead(f, &inode->neg_num, 2) != 2) return False;
 	 if (CliMappedFileRead(f, &inode->wall_num, 2) != 2) return False;
-
-	 security += inode->separator.a + inode->separator.b + inode->separator.c + 
-	    inode->wall_num;
+	 security += inode->wall_num;
 
 	 break;
 
@@ -298,9 +301,11 @@ Bool LoadNodes(file_node *f, room_type *room, int num_nodes)
 	 leaf->poly.npts = num_points;
 	 for (j=0; j < num_points; j++)
 	 {
-	    if (CliMappedFileRead(f, &leaf->poly.p[j].x, 4) != 4) return False;
-	    if (CliMappedFileRead(f, &leaf->poly.p[j].y, 4) != 4) return False;
-	    security += leaf->poly.p[j].x + leaf->poly.p[j].y;
+		 // Loaded as doubles.
+		if (CliMappedFileRead(f, &leaf->poly.p[j].x, 8) != 8) return False;
+		if (CliMappedFileRead(f, &leaf->poly.p[j].y, 8) != 8) return False;
+		// Don't add these to room security (as of roo version 14).
+		//security += leaf->poly.p[j].x + leaf->poly.p[j].y;
 	 }
 	 leaf->poly.p[num_points] = leaf->poly.p[0];	 
 	 break;
@@ -340,15 +345,16 @@ Bool LoadWalls(file_node *f, room_type *room, int num_walls)
       if (CliMappedFileRead(f, &wall->neg_sidedef_num, 2) != 2) return False;
       security += wall->pos_sidedef_num + wall->neg_sidedef_num;
 
-      if (CliMappedFileRead(f, &wall->x0, 4) != 4) return False;
-      if (CliMappedFileRead(f, &wall->y0, 4) != 4) return False;
-      if (CliMappedFileRead(f, &wall->x1, 4) != 4) return False;
-      if (CliMappedFileRead(f, &wall->y1, 4) != 4) return False;
-      security += wall->x0 + wall->y0 + wall->x1 + wall->y1;
+      // Loaded as doubles.
+      if (CliMappedFileRead(f, &wall->x0, 8) != 8) return False;
+      if (CliMappedFileRead(f, &wall->y0, 8) != 8) return False;
+      if (CliMappedFileRead(f, &wall->x1, 8) != 8) return False;
+      if (CliMappedFileRead(f, &wall->y1, 8) != 8) return False;
+      // Don't add these to room security (as of roo version 14).
+      //security += wall->x0 + wall->y0 + wall->x1 + wall->y1;
       
-      // Get wall length
-      if (CliMappedFileRead(f, &word, 2) != 2) return False;
-      wall->length = word;
+      // Get wall length, loaded as double.
+      if (CliMappedFileRead(f, &wall->length, 8) != 8) return False;
       
       // Get texture offsets
       if (CliMappedFileRead(f, &wall->pos_xoffset, 2) != 2) return False;
@@ -495,14 +501,13 @@ SlopeData *LoadSlopeInfo(file_node *f) {
     size = sizeof(SlopeData);
     new_slope = (SlopeData *) SafeMalloc(size);
     memset(new_slope, 0, size);
+    // Load coefficients of plane equation, as doubles for higher precision.
+    if (CliMappedFileRead(f, &new_slope->plane.a, 8) != 8) return (SlopeData *)NULL;
+    if (CliMappedFileRead(f, &new_slope->plane.b, 8) != 8) return (SlopeData *)NULL;
+    if (CliMappedFileRead(f, &new_slope->plane.c, 8) != 8) return (SlopeData *)NULL;
+    if (CliMappedFileRead(f, &new_slope->plane.d, 8) != 8) return (SlopeData *)NULL;
 
-    // load coefficients of plane equation
-    if (CliMappedFileRead(f, &new_slope->plane.a, 4) != 4) return (SlopeData *)NULL;
-    if (CliMappedFileRead(f, &new_slope->plane.b, 4) != 4) return (SlopeData *)NULL;
-    if (CliMappedFileRead(f, &new_slope->plane.c, 4) != 4) return (SlopeData *)NULL;
-    if (CliMappedFileRead(f, &new_slope->plane.d, 4) != 4) return (SlopeData *)NULL;
-
-//    dprintf("loaded equation a = %d, b = %d, c = %d, d = %d\n", new_slope->plane.a, new_slope->plane.b, new_slope->plane.c, new_slope->plane.d);
+    //dprintf("loaded equation a = %d, b = %d, c = %d, d = %d\n", new_slope->plane.a, new_slope->plane.b, new_slope->plane.c, new_slope->plane.d);
     
     if (new_slope->plane.c == 0) {
 	debug(("Error: loaded plane equation equal to a vertical slope\n"));
@@ -676,13 +681,13 @@ Bool LoadSectors(file_node *f, room_type *room, int num_sectors)
 #define OVERFLOWAMOUNT (MAXLONG>>(LOG_FINENESS*2))
 
 Bool RoomSwizzle(room_type *room, BSPTree tree, 
-		 int num_nodes, int num_walls, int num_sidedefs, int num_sectors)
+      int num_nodes, int num_walls, int num_sidedefs, int num_sectors)
 {
    BSPinternal *inode;
    BSPleaf *leaf;
    WallData *wall;
-   long   a,b,c,x0,y0,x1,y1,norm_size;
-   long   a2,b2;
+   double norm_size, a2, b2, a, b, c;
+   double x0, y0, x1, y1;
 
    if (tree == NULL)
       return True;
@@ -707,133 +712,143 @@ Bool RoomSwizzle(room_type *room, BSPTree tree,
       a2 = a*a; // get a bead on general scale of normal vector
       b2 = b*b;
 
-      if ((a2 > OVERFLOWAMOUNT) || (b2 > OVERFLOWAMOUNT) || (a2+b2 > OVERFLOWAMOUNT)) {
-	  a = inode->separator.a;
-	  b = inode->separator.b;
+      if ((a2 > OVERFLOWAMOUNT) || (b2 > OVERFLOWAMOUNT) || (a2+b2 > OVERFLOWAMOUNT))
+      {
+         a = inode->separator.a;
+         b = inode->separator.b;
 
-	  norm_size = (long)sqrt((float) a2 + b2);
-	  if ((a2 < 0) || (b2 < 0) || (norm_size <= 0)) {
-	      norm_size = 1;
-	      debug(("RoomSwizzle: still getting overflow in normalization math!\n"));
-	  }
-
+         norm_size = sqrt(a2 + b2);
+         if ((a2 < 0) || (b2 < 0) || (norm_size <= 0))
+         {
+            norm_size = 1;
+            debug(("RoomSwizzle: still getting overflow in normalization math!\n"));
+         }
       }
-      else {
-	  a <<= LOG_FINENESS;
-	  b <<= LOG_FINENESS;
-
-	  norm_size = (long)sqrt((float) a*a + b*b);
+      else
+      {
+         //a <<= LOG_FINENESS;
+         //b <<= LOG_FINENESS;
+         a *= FINENESS;
+         b *= FINENESS;
+         norm_size = sqrtl((long double)a*(long double)a + (long double)b*(long double)b);
       }
 
       // normalize a & b (w.round to closest int)
-      a = ((a << LOG_FINENESS)+(norm_size>>1))/norm_size;
-      b = ((b << LOG_FINENESS)+(norm_size>>1))/norm_size;
+      a = ((a * FINENESS) + (norm_size / 2)) / norm_size;
+      b = ((b * FINENESS) + (norm_size / 2)) / norm_size;
       
       inode->separator.a = a;
       inode->separator.b = b;
 
       // re-calc c
       // take average over endpoints of wall (reduce error ?)
-      inode->separator.c = -((a*x1+b*y1)+(a*x0+b*y0))/2;
+      inode->separator.c = -((a*x1+b*y1)+(a*x0+b*y0))/2.0;
+
+      //inode->separator.c = c;
 
       if (inode->pos_num == 0)
-	 inode->pos_side = NULL;
+         inode->pos_side = NULL;
+      else if (inode->pos_num < 0 || inode->pos_num > num_nodes)
+      {
+         debug(("RoomSwizzle got node #%d; max is %d\n", inode->pos_num, num_nodes));
+         inode->pos_side = NULL;
+      }
       else
-	 if (inode->pos_num < 0 || inode->pos_num > num_nodes)
-	 {
-	    debug(("RoomSwizzle got node #%d; max is %d\n", inode->pos_num, num_nodes));
-	    inode->pos_side = NULL;
-	 }
-	 else inode->pos_side = &room->nodes[inode->pos_num - 1];
+         inode->pos_side = &room->nodes[inode->pos_num - 1];
 
       if (inode->neg_num == 0)
-	 inode->neg_side = NULL;
+         inode->neg_side = NULL;
+      else if (inode->neg_num < 0 || inode->neg_num > num_nodes)
+      {
+         debug(("RoomSwizzle got node #%d; max is %d", inode->neg_num, num_nodes));
+         inode->neg_side = NULL;
+      }
       else
-	 if (inode->neg_num < 0 || inode->neg_num > num_nodes)
-	 {
-	    debug(("RoomSwizzle got node #%d; max is %d", inode->neg_num, num_nodes));
-	    inode->neg_side = NULL;
-	 }
-	 else inode->neg_side = &room->nodes[inode->neg_num - 1];
+         inode->neg_side = &room->nodes[inode->neg_num - 1];
 
       if (inode->wall_num == 0)
-	 inode->walls_in_plane = NULL;
+         inode->walls_in_plane = NULL;
+      else if (inode->wall_num < 0 || inode->wall_num > num_walls)
+      {
+         debug(("RoomSwizzle got wall #%d; max is %d\n", inode->wall_num, num_walls));
+         inode->walls_in_plane = NULL;
+      }
       else
-	 if (inode->wall_num < 0 || inode->wall_num > num_walls)
-	 {
-	    debug(("RoomSwizzle got wall #%d; max is %d\n", inode->wall_num, num_walls));
-	    inode->walls_in_plane = NULL;
-	 }
-	 else inode->walls_in_plane = &room->walls[inode->wall_num - 1];
+         inode->walls_in_plane = &room->walls[inode->wall_num - 1];
 
       // Swizzle wall list
       if (inode->walls_in_plane != NULL)
       {
-	 // Set next pointers to build up list
-	 for (wall = inode->walls_in_plane; wall->next_num != 0; wall = wall->next)
-	 {
-	    if (wall->next_num < 0 || wall->next_num > num_walls)
-	    {
-	       debug(("RoomSwizzle got wall #%d; max is %d\n", wall->next_num, num_walls));
-	       return False;
-	    }
-	    else wall->next = &room->walls[wall->next_num - 1];
-	 }
-	 wall->next = NULL;
+         // Set next pointers to build up list
+         for (wall = inode->walls_in_plane; wall->next_num != 0; wall = wall->next)
+         {
+            if (wall->next_num < 0 || wall->next_num > num_walls)
+            {
+               debug(("RoomSwizzle got wall #%d; max is %d\n", wall->next_num, num_walls));
+               return False;
+            }
+            else
+               wall->next = &room->walls[wall->next_num - 1];
+         }
+         wall->next = NULL;
 
-	 // Set sidedef and sector pointers
-	 for (wall = inode->walls_in_plane; wall != NULL; wall = wall->next)
-	 {
-	    if (wall->pos_sidedef_num > num_sidedefs)
-	    {
-	       debug(("RoomSwizzle found wall referencing sidedef %d; max is %d\n", 
-		       wall->pos_sidedef_num, num_sidedefs));
-	       return False;
-	    }
-	    if (wall->pos_sidedef_num == 0)
-	       wall->pos_sidedef = NULL;
-	    else wall->pos_sidedef = &room->sidedefs[wall->pos_sidedef_num - 1];
+         // Set sidedef and sector pointers
+         for (wall = inode->walls_in_plane; wall != NULL; wall = wall->next)
+         {
+            if (wall->pos_sidedef_num > num_sidedefs)
+            {
+               debug(("RoomSwizzle found wall referencing sidedef %d; max is %d\n", 
+                  wall->pos_sidedef_num, num_sidedefs));
+               return False;
+            }
+            if (wall->pos_sidedef_num == 0)
+               wall->pos_sidedef = NULL;
+            else
+               wall->pos_sidedef = &room->sidedefs[wall->pos_sidedef_num - 1];
 
-	    if (wall->neg_sidedef_num > num_sidedefs)
-	    {
-	       debug(("RoomSwizzle found wall referencing sidedef %d; max is %d\n", 
-		       wall->neg_sidedef_num, num_sidedefs));
-	       return False;
-	    }
-	    if (wall->neg_sidedef_num == 0)
-	       wall->neg_sidedef = NULL;
-	    else wall->neg_sidedef = &room->sidedefs[wall->neg_sidedef_num - 1];
+            if (wall->neg_sidedef_num > num_sidedefs)
+            {
+               debug(("RoomSwizzle found wall referencing sidedef %d; max is %d\n", 
+                  wall->neg_sidedef_num, num_sidedefs));
+               return False;
+            }
+            if (wall->neg_sidedef_num == 0)
+               wall->neg_sidedef = NULL;
+            else
+               wall->neg_sidedef = &room->sidedefs[wall->neg_sidedef_num - 1];
 
-	    if (wall->pos_sector_num > num_sectors)
-	    {
-	       debug(("RoomSwizzle found wall referencing sector %d; max is %d\n", 
-		       wall->pos_sector_num, num_sectors));
-	       return False;
-	    }
+            if (wall->pos_sector_num > num_sectors)
+            {
+               debug(("RoomSwizzle found wall referencing sector %d; max is %d\n", 
+                  wall->pos_sector_num, num_sectors));
+               return False;
+            }
 
-	    if (wall->pos_sector_num == 0)
-	       wall->pos_sector = NULL;
-	    else wall->pos_sector = &room->sectors[wall->pos_sector_num - 1];
+            if (wall->pos_sector_num == 0)
+               wall->pos_sector = NULL;
+            else
+               wall->pos_sector = &room->sectors[wall->pos_sector_num - 1];
 
-	    if (wall->neg_sector_num > num_sectors)
-	    {
-	       debug(("RoomSwizzle found wall referencing sector %d; max is %d\n", 
-		       wall->neg_sector_num, num_sectors));
-	       return False;
-	    }
+            if (wall->neg_sector_num > num_sectors)
+            {
+               debug(("RoomSwizzle found wall referencing sector %d; max is %d\n", 
+                  wall->neg_sector_num, num_sectors));
+               return False;
+            }
 
-	    if (wall->neg_sector_num == 0)
-	       wall->neg_sector = NULL;
-	    else wall->neg_sector = &room->sectors[wall->neg_sector_num - 1];
+            if (wall->neg_sector_num == 0)
+               wall->neg_sector = NULL;
+            else
+               wall->neg_sector = &room->sectors[wall->neg_sector_num - 1];
 
-	    SetWallHeights(wall);
-	 }
+            SetWallHeights(wall);
+         }
       }
 
       if (RoomSwizzle(room, inode->pos_side, num_nodes, num_walls, num_sidedefs, num_sectors) == False)
-	 return False;
+         return False;
       if (RoomSwizzle(room, inode->neg_side, num_nodes, num_walls, num_sidedefs, num_sectors) == False)
-	 return False;
+         return False;
       break;
       
    case BSPleaftype:
@@ -841,19 +856,19 @@ Bool RoomSwizzle(room_type *room, BSPTree tree,
 
       if (leaf->sector_num > num_sectors)
       {
-	 debug(("RoomSwizzle found leaf referencing sector %d; max is %d\n", 
-		 leaf->sector, num_sectors));
-	 return False;
+         debug(("RoomSwizzle found leaf referencing sector %d; max is %d\n", 
+            leaf->sector, num_sectors));
+         return False;
       }
       if (leaf->sector_num == 0)
       {
-	 debug(("RoomSwizzle found leaf without sector reference\n"));
-	 return False;
+         debug(("RoomSwizzle found leaf without sector reference\n"));
+         return False;
       }
       leaf->sector = &room->sectors[leaf->sector_num - 1];
       break;
    }
-   
+
    return True;
 }
 

--- a/clientd3d/bspload.c
+++ b/clientd3d/bspload.c
@@ -739,9 +739,10 @@ Bool RoomSwizzle(room_type *room, BSPTree tree,
       }
 
       // normalize a & b (w.round to closest int)
-      a = ((a * FINENESS) + (norm_size / 2)) / norm_size;
-      b = ((b * FINENESS) + (norm_size / 2)) / norm_size;
-      
+      //a = ((a * FINENESS) + (norm_size / 2)) / norm_size;
+      //b = ((b * FINENESS) + (norm_size / 2)) / norm_size;
+      a = (a * FINENESS) / norm_size;
+      b = (b * FINENESS) / norm_size;
       inode->separator.a = a;
       inode->separator.b = b;
 

--- a/clientd3d/bspload.c
+++ b/clientd3d/bspload.c
@@ -22,7 +22,7 @@
 #include "client.h"
 #include "d3dcache.h"
 
-static const int ROO_VERSION = 10;
+static const int ROO_VERSION = 14;
 
 static BYTE room_magic[] = { 0x52, 0x4F, 0x4F, 0xB1 };
 
@@ -263,11 +263,11 @@ Bool LoadNodes(file_node *f, room_type *room, int num_nodes)
       if (CliMappedFileRead(f, &type, 1) != 1) return False;
       node->type = (BSPnodetype) type;
 
-      // These are now loaded as doubles.
-      if (CliMappedFileRead(f, &node->bbox.x0, 8) != 8) return False;
-      if (CliMappedFileRead(f, &node->bbox.y0, 8) != 8) return False;
-      if (CliMappedFileRead(f, &node->bbox.x1, 8) != 8) return False;
-      if (CliMappedFileRead(f, &node->bbox.y1, 8) != 8) return False;
+      // These are now loaded as floats.
+      if (CliMappedFileRead(f, &node->bbox.x0, 4) != 4) return False;
+      if (CliMappedFileRead(f, &node->bbox.y0, 4) != 4) return False;
+      if (CliMappedFileRead(f, &node->bbox.x1, 4) != 4) return False;
+      if (CliMappedFileRead(f, &node->bbox.y1, 4) != 4) return False;
 
 //      debug(("Loading node %d ", i));
 
@@ -276,10 +276,10 @@ Bool LoadNodes(file_node *f, room_type *room, int num_nodes)
       case BSPinternaltype:
 	 inode = &node->u.internal;
 	 
-	 // Loaded as doubles.
-	 if (CliMappedFileRead(f, &inode->separator.a, 8) != 8) return False;
-	 if (CliMappedFileRead(f, &inode->separator.b, 8) != 8) return False;
-	 if (CliMappedFileRead(f, &inode->separator.c, 8) != 8) return False;
+	 // Loaded as floats.
+	 if (CliMappedFileRead(f, &inode->separator.a, 4) != 4) return False;
+	 if (CliMappedFileRead(f, &inode->separator.b, 4) != 4) return False;
+	 if (CliMappedFileRead(f, &inode->separator.c, 4) != 4) return False;
 
 	 // Don't add these to room security (as of roo version 14).
 	 //security += inode->separator.a + inode->separator.b + inode->separator.c;
@@ -301,9 +301,9 @@ Bool LoadNodes(file_node *f, room_type *room, int num_nodes)
 	 leaf->poly.npts = num_points;
 	 for (j=0; j < num_points; j++)
 	 {
-		 // Loaded as doubles.
-		if (CliMappedFileRead(f, &leaf->poly.p[j].x, 8) != 8) return False;
-		if (CliMappedFileRead(f, &leaf->poly.p[j].y, 8) != 8) return False;
+		 // Loaded as floats.
+		if (CliMappedFileRead(f, &leaf->poly.p[j].x, 4) != 4) return False;
+		if (CliMappedFileRead(f, &leaf->poly.p[j].y, 4) != 4) return False;
 		// Don't add these to room security (as of roo version 14).
 		//security += leaf->poly.p[j].x + leaf->poly.p[j].y;
 	 }
@@ -345,16 +345,16 @@ Bool LoadWalls(file_node *f, room_type *room, int num_walls)
       if (CliMappedFileRead(f, &wall->neg_sidedef_num, 2) != 2) return False;
       security += wall->pos_sidedef_num + wall->neg_sidedef_num;
 
-      // Loaded as doubles.
-      if (CliMappedFileRead(f, &wall->x0, 8) != 8) return False;
-      if (CliMappedFileRead(f, &wall->y0, 8) != 8) return False;
-      if (CliMappedFileRead(f, &wall->x1, 8) != 8) return False;
-      if (CliMappedFileRead(f, &wall->y1, 8) != 8) return False;
+      // Loaded as floats.
+      if (CliMappedFileRead(f, &wall->x0, 4) != 4) return False;
+      if (CliMappedFileRead(f, &wall->y0, 4) != 4) return False;
+      if (CliMappedFileRead(f, &wall->x1, 4) != 4) return False;
+      if (CliMappedFileRead(f, &wall->y1, 4) != 4) return False;
       // Don't add these to room security (as of roo version 14).
       //security += wall->x0 + wall->y0 + wall->x1 + wall->y1;
       
-      // Get wall length, loaded as double.
-      if (CliMappedFileRead(f, &wall->length, 8) != 8) return False;
+      // Get wall length, loaded as float.
+      if (CliMappedFileRead(f, &wall->length, 4) != 4) return False;
       
       // Get texture offsets
       if (CliMappedFileRead(f, &wall->pos_xoffset, 2) != 2) return False;
@@ -501,13 +501,14 @@ SlopeData *LoadSlopeInfo(file_node *f) {
     size = sizeof(SlopeData);
     new_slope = (SlopeData *) SafeMalloc(size);
     memset(new_slope, 0, size);
-    // Load coefficients of plane equation, as doubles for higher precision.
-    if (CliMappedFileRead(f, &new_slope->plane.a, 8) != 8) return (SlopeData *)NULL;
-    if (CliMappedFileRead(f, &new_slope->plane.b, 8) != 8) return (SlopeData *)NULL;
-    if (CliMappedFileRead(f, &new_slope->plane.c, 8) != 8) return (SlopeData *)NULL;
-    if (CliMappedFileRead(f, &new_slope->plane.d, 8) != 8) return (SlopeData *)NULL;
+    // Load coefficients of plane equation as floats.
+    if (CliMappedFileRead(f, &new_slope->plane.a, 4) != 4) return (SlopeData *)NULL;
+    if (CliMappedFileRead(f, &new_slope->plane.b, 4) != 4) return (SlopeData *)NULL;
+    if (CliMappedFileRead(f, &new_slope->plane.c, 4) != 4) return (SlopeData *)NULL;
+    if (CliMappedFileRead(f, &new_slope->plane.d, 4) != 4) return (SlopeData *)NULL;
 
-    //dprintf("loaded equation a = %d, b = %d, c = %d, d = %d\n", new_slope->plane.a, new_slope->plane.b, new_slope->plane.c, new_slope->plane.d);
+    //dprintf("loaded equation a = %6.4f, b = %6.4f, c = %6.4f, d = %6.4f\n",
+    //  new_slope->plane.a, new_slope->plane.b, new_slope->plane.c, new_slope->plane.d);
     
     if (new_slope->plane.c == 0) {
 	debug(("Error: loaded plane equation equal to a vertical slope\n"));
@@ -518,9 +519,13 @@ SlopeData *LoadSlopeInfo(file_node *f) {
 	new_slope->plane.d = 0;
     }
     
-    // load x & y of texture origin
-    if (CliMappedFileRead(f, &new_slope->p0.x, 4) != 4) return (SlopeData *)NULL;
-    if (CliMappedFileRead(f, &new_slope->p0.y, 4) != 4) return (SlopeData *)NULL;
+    // Load x & y of texture origin. These are saved as integers, so load them
+    // into a temp variable first and them save them.
+    int payload;
+    if (CliMappedFileRead(f, &payload, 4) != 4) return (SlopeData *)NULL;
+    new_slope->p0.x = payload;
+    if (CliMappedFileRead(f, &payload, 4) != 4) return (SlopeData *)NULL;
+    new_slope->p0.y = payload;
     
     // calculate z of texture origin from x, y, and plane equation
     new_slope->p0.z = (-new_slope->plane.a*new_slope->p0.x - new_slope->plane.b*new_slope->p0.y - new_slope->plane.d)/new_slope->plane.c;
@@ -686,8 +691,8 @@ Bool RoomSwizzle(room_type *room, BSPTree tree,
    BSPinternal *inode;
    BSPleaf *leaf;
    WallData *wall;
-   double norm_size, a2, b2, a, b, c;
-   double x0, y0, x1, y1;
+   float norm_size, a2, b2, a, b, c;
+   float x0, y0, x1, y1;
 
    if (tree == NULL)
       return True;
@@ -742,7 +747,7 @@ Bool RoomSwizzle(room_type *room, BSPTree tree,
 
       // re-calc c
       // take average over endpoints of wall (reduce error ?)
-      inode->separator.c = -((a*x1+b*y1)+(a*x0+b*y0))/2.0;
+      inode->separator.c = -((a*x1+b*y1)+(a*x0+b*y0))/2.0f;
 
       //inode->separator.c = c;
 
@@ -1149,7 +1154,7 @@ void RoomSetupFlickerAnimation(RoomAnimate *ra, BYTE original_light, WORD server
  *****************************************************************************/
 
 // Make sure wall height can be stored in two bytes. Used by SetWallHeights below.
-#define WALL_HEIGHT_CHECK(z) if ((z) > 65535) {debug(("SetWallHeights: got wall taller than 65535."));\
+#define WALL_HEIGHT_CHECK(z) if ((z) > 65535) {debug(("SetWallHeights: got wall taller than 65535. %li",z));\
     debug((" Shorten ceiling height or change\nshort to long in WallData struct in bsp.h\n"));\
     (z) = 65535;}
 

--- a/clientd3d/cache.c
+++ b/clientd3d/cache.c
@@ -84,8 +84,8 @@ void CacheInitialize(void)
   statex.dwLength = sizeof statex;
   GlobalMemoryStatusEx (&statex);
   
-  // Set aside up to 1/4 of free memory for caches
-  mem_available = statex.ullAvailPhys / 4;
+  // Set aside up to 1/2 of free memory for caches
+  mem_available = statex.ullAvailPhys / 2;
   
   object_cache.max_size = max(mem_available / 2, config.ObjectCacheMin );
   grid_cache.max_size   = max(mem_available / 2, config.GridCacheMin );

--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -48,7 +48,7 @@ typedef unsigned char Bool;
 enum {False = 0, True = 1};
 
 #define MAJOR_REV 50   /* Major version of client program */
-#define MINOR_REV 26  /* Minor version of client program; must be in [0, 99] */
+#define MINOR_REV 27  /* Minor version of client program; must be in [0, 99] */
 
 #define MAXAMOUNT 9     /* Max # of digits in a server integer */
 #define MAXSTRINGLEN 512 /* Max length of a string loaded from string table */

--- a/clientd3d/client.rc
+++ b/clientd3d/client.rc
@@ -375,6 +375,7 @@ BEGIN
     GROUPBOX        "Oberfläche",IDC_STATIC,5,196,245,64,WS_GROUP
     CONTROL         "Toolbar anzeigen",1165,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,209,70,9
     CONTROL         "Übertragungsrate anzeigen",147,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,88,209,100,9
+    CONTROL         "FPS anzeigen",1211,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,189,209,56,9
     CONTROL         "Tooltips anzeigen",1147,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,220,65,9
     CONTROL         "Dynamische Karte",1198,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,88,220,79,10
     CONTROL         "Kartenanmerkungen",1202,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,168,220,80,9
@@ -942,7 +943,7 @@ BEGIN
     LISTBOX         IDC_QUANLIST,143,118,22,20,LBS_OWNERDRAWFIXED | LBS_HASSTRINGS | LBS_WANTKEYBOARDINPUT | NOT WS_VISIBLE | WS_TABSTOP
 END
 
-IDD_SETTINGS DIALOGEX 0, 0, 257, 295
+IDD_SETTINGS DIALOGEX 0, 0, 263, 295
 STYLE DS_SETFONT | DS_MODALFRAME | DS_3DLOOK | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
 CAPTION "Meridian 59 Preferences"
 FONT 8, "MS Sans Serif", 0, 0, 0x0
@@ -952,42 +953,43 @@ BEGIN
     CONTROL         "Red Highlight",IDC_TARGETHALO1,"Button",BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,16,37,70,10
     CONTROL         "Blue Highlight",IDC_TARGETHALO2,"Button",BS_AUTORADIOBUTTON,16,48,70,10
     CONTROL         "Green Highlight",IDC_TARGETHALO3,"Button",BS_AUTORADIOBUTTON,16,59,70,10
-    GROUPBOX        "Special Effects",IDC_STATIC,104,6,147,70,WS_GROUP
-    CONTROL         """Bounce"" as you walk",IDC_BOUNCE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,111,17,132,9
-    CONTROL         "Show your pain when you get hurt",IDC_PAIN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,111,28,132,9
+    GROUPBOX        "Special Effects",IDC_STATIC,110,6,147,70,WS_GROUP
+    CONTROL         """Bounce"" as you walk",IDC_BOUNCE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,118,17,132,9
+    CONTROL         "Show your pain when you get hurt",IDC_PAIN,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,118,28,132,9
     CONTROL         "Draw player names over their heads",IDC_DRAWNAMES,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,111,39,132,9
-    CONTROL         "Show amounts for inventory items",IDC_INVNUM,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,111,50,132,9
-    CONTROL         "Show weather effects",IDC_WEATHER,"Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_GROUP | WS_TABSTOP,111,61,132,9
-    GROUPBOX        "Game Options",IDC_STATIC,6,79,245,28,WS_GROUP
-    CONTROL         "Receive temporary angel on death",IDC_TEMPSAFE,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,13,91,130,9
-    CONTROL         "Join building groups",IDC_GROUPING,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,150,91,100,9
-    GROUPBOX        "Audio Effects",IDC_STATIC,6,109,245,66,WS_GROUP
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,118,39,132,9
+    CONTROL         "Show amounts for inventory items",IDC_INVNUM,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,118,50,132,9
+    CONTROL         "Show weather effects",IDC_WEATHER,"Button",BS_AUTOCHECKBOX | BS_MULTILINE | WS_GROUP | WS_TABSTOP,118,61,132,9
+    GROUPBOX        "Game Options",IDC_STATIC,6,79,251,28,WS_GROUP
+    CONTROL         "Receive temporary angel on death",IDC_TEMPSAFE,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,13,91,123,9
+    CONTROL         "Join building groups",IDC_GROUPING,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,150,91,75,9
+    GROUPBOX        "Audio Effects",IDC_STATIC,6,109,251,66,WS_GROUP
     CONTROL         "Music",IDC_MUSIC,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,122,35,9
     CONTROL         "Sounds",IDC_SOUNDFX,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,52,122,44,9
     CONTROL         "Steady Sounds",IDC_LOOPSOUNDS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,97,122,64,9
-    CONTROL         "Atmospheric Sounds",IDC_RANDSOUNDS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,165,122,80,9
+    CONTROL         "Atmospheric Sounds",IDC_RANDSOUNDS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,167,122,80,9
     LTEXT           "Sound volume",IDC_STATIC,13,139,50,10
-    CONTROL         "",IDC_SOUND_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,69,136,173,15
+    CONTROL         "",IDC_SOUND_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,69,136,178,15
     LTEXT           "Music volume",IDC_STATIC,13,156,53,10
-    CONTROL         "",IDC_MUSIC_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,69,154,173,15
+    CONTROL         "",IDC_MUSIC_VOLUME,"msctls_trackbar32",TBS_BOTH | TBS_NOTICKS | WS_TABSTOP,69,154,178,15
     GROUPBOX        "Interface Features",IDC_STATIC,5,178,245,59,WS_GROUP
     CONTROL         "Show toolbar",IDC_TOOLBAR,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,189,62,9
     CONTROL         "Show tooltips",IDC_TOOLTIPS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,200,62,9
     CONTROL         "Lock text window in place when scrolling back",IDC_SCROLLLOCK,
-                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,211,163,9
+                    "Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,211,159,9
     CONTROL         "Filter text profanity",IDC_PROFANE,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,13,223,77,9
     CONTROL         "Show latency meter",IDS_LATENCY0,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,88,189,77,9
     CONTROL         "Show dynamic map",IDC_DRAWMAP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,88,200,79,10
-    CONTROL         "Show colored text",IDC_COLORCODES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,172,189,72,10
-    CONTROL         "Map annotations",IDC_MAP_ANNOTATIONS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,172,200,72,10
+    CONTROL         "Show colored text",IDC_COLORCODES,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,176,189,69,10
+    CONTROL         "Map annotations",IDC_MAP_ANNOTATIONS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,176,200,72,10
+    CONTROL         "Show FPS",IDC_SHOWFPS,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,176,211,50,9
     PUSHBUTTON      "&Profanity Options and Policy...",IDC_PROFANESETTINGS,101,221,142,12
-    GROUPBOX        "Web Browser",IDC_STATIC,6,238,245,31,WS_GROUP
+    GROUPBOX        "Web Browser",IDC_STATIC,6,238,251,31,WS_GROUP
     LTEXT           "Application:",IDC_STATIC,13,251,45,8
     EDITTEXT        IDC_BROWSER,59,249,136,12,ES_AUTOHSCROLL
-    PUSHBUTTON      "&Search...",IDC_FIND,197,249,49,12
+    PUSHBUTTON      "&Search...",IDC_FIND,200,248,49,14
     DEFPUSHBUTTON   "OK",IDOK,145,277,50,12,WS_GROUP
-    PUSHBUTTON      "Cancel",IDCANCEL,201,277,50,12,WS_GROUP
+    PUSHBUTTON      "Cancel",IDCANCEL,207,277,50,12,WS_GROUP
 END
 
 IDD_COLOR DIALOG 0, 0, 201, 92
@@ -1349,7 +1351,7 @@ BEGIN
     IDD_SETTINGS, DIALOG
     BEGIN
         LEFTMARGIN, 6
-        RIGHTMARGIN, 251
+        RIGHTMARGIN, 257
         TOPMARGIN, 6
         BOTTOMMARGIN, 259
     END

--- a/clientd3d/config.c
+++ b/clientd3d/config.c
@@ -106,9 +106,9 @@ static char INIDebug[]        = "Debug";
 static char INISecurity[]     = "Security";
 static char INITechnical[]    = "Technical";
 
+static char INIShowFPS[] = "ShowFPS";
 #ifndef NODPRINTFS
 static char INIShowMapBlocking[]= "ShowMapBlocking";
-static char INIShowFPS[]     = "ShowFPS";
 static char INIShowUnseenWalls[] = "ShowUnseenWalls";
 static char INIShowUnseenMonsters[] = "ShowUnseenMonsters";
 static char INIAvoidDownloadAskDialog[] = "AvoidDownloadAskDialog";
@@ -270,7 +270,6 @@ void ConfigLoad(void)
    config.debug    = False;
    config.security = True;
    config.showMapBlocking = FALSE;
-   config.showFPS = FALSE;
    config.showUnseenWalls = FALSE;
    config.showUnseenMonsters = FALSE;
    config.avoidDownloadAskDialog = FALSE;
@@ -280,7 +279,6 @@ void ConfigLoad(void)
    config.debug				= GetConfigInt(special_section, INIDebug, False, ini_file);
    config.security			= GetConfigInt(special_section, INISecurity, True, ini_file);
    config.showMapBlocking	= GetConfigInt(special_section, INIShowMapBlocking, 0, ini_file);
-   config.showFPS			= GetConfigInt(special_section, INIShowFPS, 0, ini_file);
    config.showUnseenWalls	= GetConfigInt(special_section, INIShowUnseenWalls, 0, ini_file);
    config.showUnseenMonsters = GetConfigInt(special_section, INIShowUnseenMonsters, 0, ini_file);
    config.avoidDownloadAskDialog = GetConfigInt(special_section, INIAvoidDownloadAskDialog, 0, ini_file);
@@ -288,7 +286,7 @@ void ConfigLoad(void)
    config.clearCache		= GetConfigInt(special_section, INIClearCache, False, ini_file);
    //config.quickstart = GetConfigInt(special_section, INIQuickStart, 0, ini_file);
 #endif
-
+   config.showFPS = GetConfigInt(special_section, INIShowFPS, False, ini_file);
    config.timeout	= GetConfigInt(misc_section, INITimeout, DefaultTimeout, ini_file);
    config.technical = GetConfigInt(special_section, INITechnical, False, ini_file);
 
@@ -360,8 +358,8 @@ void ConfigSave(void)
    WriteConfigInt(misc_section, INIServerHigh, config.server_high, ini_file);
    WriteConfigInt(misc_section, INIServerGuest, config.server_guest, ini_file);
    WriteConfigInt(misc_section, INILastPass, config.lastPasswordChange, ini_file);
-
-   // "Special" section options NOT saved, so that they're not normally visible
+   WriteConfigInt(special_section, INIShowFPS, config.showFPS, ini_file);
+   // "Special" section options NOT saved, so that they're not normally visible (except FPS)
 
    WritePrivateProfileString(interface_section, INIOldProfane, NULL, ini_file); // remove old string
 }

--- a/clientd3d/d3dcache.h
+++ b/clientd3d/d3dcache.h
@@ -92,66 +92,41 @@ do	\
 #endif
 
 #define CHUNK_XYZ_SET(_pChunk, _index, _x, _y, _z)	\
-do	\
-{	\
 	_pChunk->xyz[_index].x = _x;	\
 	_pChunk->xyz[_index].y = _y;	\
-	_pChunk->xyz[_index].z = _z;	\
-} while (0)
+	_pChunk->xyz[_index].z = _z;
 
 #define CHUNK_BGRA_SET(_pChunk, _index, _b, _g, _r, _a)	\
-do	\
-{	\
-	_pChunk->bgra[_index].b = _b;	\
+_pChunk->bgra[_index].b = _b;	\
 	_pChunk->bgra[_index].g = _g;	\
 	_pChunk->bgra[_index].r = _r;	\
-	_pChunk->bgra[_index].a = _a;	\
-} while (0)
+	_pChunk->bgra[_index].a = _a;
 
 #define CHUNK_ST0_SET(_pChunk, _index, _s, _t)	\
-do	\
-{	\
 	_pChunk->st0[_index].s = _s;	\
-	_pChunk->st0[_index].t = _t;	\
-} while (0)
+	_pChunk->st0[_index].t = _t;
 
 #define CHUNK_ST1_SET(_pChunk, _index, _s, _t)	\
-do	\
-{	\
 	_pChunk->st1[_index].s = _s;	\
-	_pChunk->st1[_index].t = _t;	\
-} while (0)
+	_pChunk->st1[_index].t = _t;
 
 #define CHUNK_INDEX_SET(_pChunk, _index, _value)	\
-do	\
-{	\
-	_pChunk->indices[_index] = _value;	\
-} while (0)
+	_pChunk->indices[_index] = _value;
 
 #define CACHE_UNLOCK(_pCache)	\
-do	\
-{	\
-	int	i;	\
 	IDirect3DVertexBuffer9_Unlock((_pCache)->xyzBuffer.pVBuffer);	\
-	for (i = 0; i < TEMP_NUM_STAGES; i++)	\
+	for (int i = 0; i < TEMP_NUM_STAGES; i++)	\
 		IDirect3DVertexBuffer9_Unlock((_pCache)->stBuffer[i].pVBuffer);	\
 	IDirect3DVertexBuffer9_Unlock((_pCache)->bgraBuffer.pVBuffer);	\
-	IDirect3DIndexBuffer9_Unlock((_pCache)->indexBuffer.pIBuffer);	\
-} while (0)
+	IDirect3DIndexBuffer9_Unlock((_pCache)->indexBuffer.pIBuffer);
 
 #define CACHE_BGRA_LOCK(_pCache)	\
-do	\
-{	\
 	IDirect3DVertexBuffer9_Lock((_pCache)->bgraBuffer.pVBuffer,	\
                               0, 0, (void **)&(_pCache)->bgraBuffer.u.pBGRA, \
-                              D3DLOCK_DISCARD);             \
-} while (0)
+                              D3DLOCK_DISCARD);
 
 #define CACHE_BGRA_UNLOCK(_pCache)	\
-do	\
-{	\
-	IDirect3DVertexBuffer9_Unlock((_pCache)->bgraBuffer.pVBuffer);	\
-} while (0)
+	IDirect3DVertexBuffer9_Unlock((_pCache)->bgraBuffer.pVBuffer);
 
 typedef struct d3d_texture_cache_entry
 {

--- a/clientd3d/d3dparticle.c
+++ b/clientd3d/d3dparticle.c
@@ -72,7 +72,7 @@ void D3DParticleEmitterUpdate(emitter *pEmitter, float posX, float posY, float p
 }
 
 void D3DParticleSystemUpdate(particle_system *pParticleSystem, d3d_render_pool_new *pPool,
-							 d3d_render_cache_system *pCacheSystem)
+							 d3d_render_cache_system *pCacheSystem, Draw3DParams *params)
 {
 	int						curParticle;
 	list_type				list;
@@ -146,7 +146,8 @@ void D3DParticleSystemUpdate(particle_system *pParticleSystem, d3d_render_pool_n
 
 					continue;
 				}
-
+            if (IsHidden(params, round(pParticle->pos.x), round(pParticle->pos.y), round(pParticle->pos.x), round(pParticle->pos.y)))
+               continue;
 				pPacket = D3DRenderPacketFindMatch(pPool, NULL, NULL, 0, 0, 0);
 				assert(pPacket);
 				pPacket->pMaterialFctn = &D3DMaterialParticlePacket;

--- a/clientd3d/d3dparticle.c
+++ b/clientd3d/d3dparticle.c
@@ -146,7 +146,8 @@ void D3DParticleSystemUpdate(particle_system *pParticleSystem, d3d_render_pool_n
 
 					continue;
 				}
-            if (IsHidden(params, round(pParticle->pos.x), round(pParticle->pos.y), round(pParticle->pos.x), round(pParticle->pos.y)))
+            // If this particle is hidden from the player's view, don't let D3D try to draw it.
+            if (IsHidden(params, (long)pParticle->pos.x, (long)pParticle->pos.y, (long)pParticle->pos.x, (long)pParticle->pos.y))
                continue;
 				pPacket = D3DRenderPacketFindMatch(pPool, NULL, NULL, 0, 0, 0);
 				assert(pPacket);

--- a/clientd3d/d3dparticle.h
+++ b/clientd3d/d3dparticle.h
@@ -71,6 +71,6 @@ void	D3DParticleEmitterInit(particle_system *pParticleSystem, float posX, float 
 void	D3DParticleEmitterUpdate(emitter *pEmitter, float posX, float posY, float posZ);
 //void	D3DParticleSystemRoomInit(particle_system *pParticleSystem, room_type *room);
 void	D3DParticleSystemUpdate(particle_system *pParticleSystem, d3d_render_pool_new *pPool,
-							 d3d_render_cache_system *pCacheSystem);
+							 d3d_render_cache_system *pCacheSystem, Draw3DParams *params);
 
 #endif

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -7160,18 +7160,18 @@ void D3DRenderObjectsDraw(d3d_render_pool_new *pPool, room_type *room,
 				) &&
 				D3DRENDER_CLIP(topLeft.z, 1.0f))
 			{
-				tempLeft   = (topLeft.x * w / 2) + (w / 2);
-				tempRight  = (bottomRight.x * w / 2) + (w / 2);
-				tempTop    = (topLeft.y * -h / 2) + (h / 2);
-				tempBottom = (bottomRight.y * -h / 2) + (h / 2);
+            tempLeft = (topLeft.x * w / 2) + (w >> 1);
+            tempRight = (bottomRight.x * w / 2) + (w >> 1);
+            tempTop = (topLeft.y * -h / 2) + (h >> 1);
+            tempBottom = (bottomRight.y * -h / 2) + (h >> 1);
 
-				if (config.large_area)
-				{
-					tempLeft /= 2;
-					tempRight /= 2;
-					tempTop /= 2;
-					tempBottom /= 2;
-				}
+            if (config.large_area)
+            {
+               tempLeft >>= 1;
+               tempRight >>= 1;
+               tempTop >>= 1;
+               tempBottom >>= 1;
+            }
 
 				distX = pRNode->motion.x - player.x;
 				distY = pRNode->motion.y - player.y;
@@ -7865,17 +7865,17 @@ void D3DRenderOverlaysDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DPa
 							) &&
 							D3DRENDER_CLIP(topLeft.z, 1.0f))
 						{
-							tempLeft   = (topLeft.x * w / 2) + (w / 2);
-							tempRight  = (bottomRight.x * w / 2) + (w / 2);
-							tempTop    = (topLeft.y * -h / 2) + (h / 2);
-							tempBottom = (bottomRight.y * -h / 2) + (h / 2);
+							tempLeft   = (topLeft.x * w / 2) + (w >> 1);
+							tempRight  = (bottomRight.x * w / 2) + (w >> 1);
+							tempTop    = (topLeft.y * -h / 2) + (h >> 1);
+							tempBottom = (bottomRight.y * -h / 2) + (h >> 1);
 
 							if (config.large_area)
 							{
-								tempLeft /= 2;
-								tempRight /= 2;
-								tempTop /= 2;
-								tempBottom /= 2;
+								tempLeft >>= 1;
+								tempRight >>= 1;
+								tempTop >>= 1;
+								tempBottom >>= 1;
 							}
 
 							distX = pRNode->motion.x - player.x;
@@ -10447,10 +10447,10 @@ float D3DRenderFogEndCalc(d3d_render_chunk_new *pChunk)
 	// note: sectors with the no ambient flag attenuate twice as fast in the old client.
 	// bug or not, it needs to be emulated here...
 	if (pChunk->flags & D3DRENDER_NOAMBIENT)
-		end = (16384 + (light * FINENESS) + (p->viewer_light * 64));
+		end = (16384 + (light * FINENESS) + (p->viewer_light << 6));
 	else
-		end = (32768 + (max(0, light - LIGHT_NEUTRAL) * FINENESS) + (p->viewer_light * 64) +
-		(current_room.ambient_light * FINENESS));
+		end = (32768 + (max(0, light - LIGHT_NEUTRAL) * FINENESS) + (p->viewer_light << 6) +
+		(current_room.ambient_light << LOG_FINENESS));
 
 	return end;
 }

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -898,7 +898,7 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 		// this pass is a gigantic hack used to cover up the cracks
 		// caused by all the t-junctions in the old geometry.  the entire world is drawn
 		// in wireframe, with zwrite disabled.  welcome to my hell
-		if (0)
+		if (1)
 		{
 			gWireframe = TRUE;
 			IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, FALSE);
@@ -4741,8 +4741,8 @@ void D3DRenderLMapPostFloorAdd(BSPnode *pNode, d3d_render_pool_new *pPool, d_lig
 		invZScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.z;
 
 		unlit = 0;
-		lightRange = (pDLightCache->dLights[numLights].xyzScale.x / 1.5f) *
-			(pDLightCache->dLights[numLights].xyzScale.x / 1.5f);// * 2.0f;
+		lightRange = (pDLightCache->dLights[numLights].xyzScale.x * 2.0f) *
+			(pDLightCache->dLights[numLights].xyzScale.x * 2.0f);// * 2.0f;
 
 //		continue;
 
@@ -4763,7 +4763,8 @@ void D3DRenderLMapPostFloorAdd(BSPnode *pNode, d3d_render_pool_new *pPool, d_lig
 
 		if (unlit < pNode->u.leaf.poly.npts)
 		{
-			if (1)
+			// Disabled, causes some polys not to be lit when they should be.
+         if (0)
 			{
 				custom_xyz	lightVec, normal;
 				float		cosAngle;
@@ -4913,8 +4914,8 @@ void D3DRenderLMapPostCeilingAdd(BSPnode *pNode, d3d_render_pool_new *pPool, d_l
 
 		unlit = 0;
 
-		lightRange = (pDLightCache->dLights[numLights].xyzScale.x / 1.5f) *
-			(pDLightCache->dLights[numLights].xyzScale.x / 1.5f);// * 2.0f;
+		lightRange = (pDLightCache->dLights[numLights].xyzScale.x * 2.0f) *
+			(pDLightCache->dLights[numLights].xyzScale.x * 2.0f);// * 2.0f;
 
 //		continue;
 
@@ -4935,7 +4936,8 @@ void D3DRenderLMapPostCeilingAdd(BSPnode *pNode, d3d_render_pool_new *pPool, d_l
 
 		if (unlit < pNode->u.leaf.poly.npts)
 		{
-			if (1)
+         // Disabled, causes some polys not to be lit when they should be.
+         if (0)
 			{
 				custom_xyz	lightVec, normal;
 				float		cosAngle;
@@ -5151,8 +5153,8 @@ void D3DRenderLMapPostWallAdd(WallData *pWall, d3d_render_pool_new *pPool, unsig
 		invZScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.z;
 
 		unlit = 0;
-		lightRange = (pDLightCache->dLights[numLights].xyzScale.x / 1.5f) *
-			(pDLightCache->dLights[numLights].xyzScale.x / 1.5f);// * 2.0f;
+		lightRange = (pDLightCache->dLights[numLights].xyzScale.x * 2.0f) *
+			(pDLightCache->dLights[numLights].xyzScale.x * 2.0f);// * 2.0f;
 
 //		continue;
 
@@ -5190,7 +5192,9 @@ void D3DRenderLMapPostWallAdd(WallData *pWall, d3d_render_pool_new *pPool, unsig
 			// check to see if dot product is necessary
 //			if ((pDLightCache->dLights[numLights].xyz.z < xyz[0].z) &&
 //				(pDLightCache->dLights[numLights].xyz.z > xyz[1].z))
-			if (1)
+
+         // Disabled, causes some polys not to be lit when they should be.
+         if (0)
 			{
 				custom_xyz	lightVec;
 				float		cosAngle;

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -326,22 +326,14 @@ extern void			DrawItemsD3D();
 extern Bool			ComputePlayerOverlayArea(PDIB pdib, char hotspot, AREA *obj_area);
 extern void			UpdateRoom3D(room_type *room, Draw3DParams *params);
 
-static int DistanceGet(int x, int y)
+inline static int DistanceGet(int x, int y)
 {
-	int	distance;
-	float	xf, yf;
-
-	xf = (float)x;
-	yf = (float)y;
-
-	distance = sqrt((double)(xf * xf) + (double)(yf * yf));
-
-	return (int)distance;
+   return (int)sqrt((double)(x * x) + (double)(y * y));;
 }
 
-void *D3DRenderMalloc(unsigned int bytes)
+inline void *D3DRenderMalloc(unsigned int bytes)
 {
-	return malloc(bytes);
+   return malloc(bytes);
 }
 
 /************************************************************************************
@@ -976,14 +968,17 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ZWRITEENABLE, TRUE);
 		IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FILLMODE, D3DFILL_SOLID);
-		D3DCacheFlush(&gLMapCacheSystemStatic, &gLMapPoolStatic, 2, D3DPT_TRIANGLESTRIP);
+
+      D3DCacheFlush(&gLMapCacheSystemStatic, &gLMapPoolStatic, 2, D3DPT_TRIANGLESTRIP);
 
 		D3DRenderPoolReset(&gLMapPool, &D3DMaterialLMapDynamicPool);
+
 		D3DRenderLMapsPostDraw(room->tree, params);
+      //long timeDynamic = timeGetTime();
 		D3DRenderLMapsDynamicPostDraw(room->tree, params);
-		D3DCacheFill(&gLMapCacheSystem, &gLMapPool, 2);
-		D3DCacheFlush(&gLMapCacheSystem, &gLMapPool, 2, D3DPT_TRIANGLESTRIP);
-		
+      //debug(("Dynamic light maps calculated in %d\n", timeGetTime() - timeDynamic));
+      D3DCacheFill(&gLMapCacheSystem, &gLMapPool, 2);
+      D3DCacheFlush(&gLMapCacheSystem, &gLMapPool, 2, D3DPT_TRIANGLESTRIP);
 		if (gD3DDriverProfile.bFogEnable)
 			IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_FOGENABLE, TRUE);
 
@@ -1634,7 +1629,7 @@ void D3DRenderLMapsDynamicPostDraw(BSPnode *tree, Draw3DParams *params)
 	      
 			if (side < 0)
 			{
-				a = -a;
+            a = -a;
 				b = -b;
 			}
 
@@ -2816,15 +2811,15 @@ void D3DRenderPacketWallMaskAdd(WallData *pWall, d3d_render_pool_new *pPool, uns
 		{
 			pSideDef = pWall->pos_sidedef;
 
-			xyz[0].x = (float)pWall->x0;
-			xyz[3].x = (float)pWall->x1;
-			xyz[1].x = (float)pWall->x0;
-			xyz[2].x = (float)pWall->x1;
+			xyz[0].x = pWall->x0;
+			xyz[3].x = pWall->x1;
+			xyz[1].x = pWall->x0;
+			xyz[2].x = pWall->x1;
 
-			xyz[0].y = (float)pWall->y0;
-			xyz[3].y = (float)pWall->y1;
-			xyz[1].y = (float)pWall->y0;
-			xyz[2].y = (float)pWall->y1;
+			xyz[0].y = pWall->y0;
+			xyz[3].y = pWall->y1;
+			xyz[1].y = pWall->y0;
+			xyz[2].y = pWall->y1;
 
 			xyz[1].z = xyz[0].z;
 			xyz[2].z = xyz[3].z;
@@ -2833,22 +2828,22 @@ void D3DRenderPacketWallMaskAdd(WallData *pWall, d3d_render_pool_new *pPool, uns
 			{
 				case D3DRENDER_WALL_NORMAL:
 				{
-					xyz[0].z = (long)pWall->z2;
-					xyz[3].z = (long)pWall->zz2;
+					xyz[0].z = (float)pWall->z2;
+               xyz[3].z = (float)pWall->zz2;
 				}
 				break;
 
 				case D3DRENDER_WALL_BELOW:
 				{
-					xyz[0].z = (long)pWall->z1;
-					xyz[3].z = (long)pWall->zz1;
+               xyz[0].z = (float)pWall->z1;
+               xyz[3].z = (float)pWall->zz1;
 				}
 				break;
 
 				case D3DRENDER_WALL_ABOVE:
 				{
-					xyz[0].z = (long)pWall->z3;
-					xyz[3].z = (long)pWall->zz3;
+               xyz[0].z = (float)pWall->z3;
+               xyz[3].z = (float)pWall->zz3;
 				}
 				break;
 
@@ -2860,15 +2855,15 @@ void D3DRenderPacketWallMaskAdd(WallData *pWall, d3d_render_pool_new *pPool, uns
 		{
 			pSideDef = pWall->neg_sidedef;
 
-			xyz[0].x = (float)pWall->x1;
-			xyz[3].x = (float)pWall->x0;
-			xyz[1].x = (float)pWall->x1;
-			xyz[2].x = (float)pWall->x0;
+			xyz[0].x = pWall->x1;
+			xyz[3].x = pWall->x0;
+			xyz[1].x = pWall->x1;
+			xyz[2].x = pWall->x0;
 
-			xyz[0].y = (float)pWall->y1;
-			xyz[3].y = (float)pWall->y0;
-			xyz[1].y = (float)pWall->y1;
-			xyz[2].y = (float)pWall->y0;
+			xyz[0].y = pWall->y1;
+			xyz[3].y = pWall->y0;
+			xyz[1].y = pWall->y1;
+			xyz[2].y = pWall->y0;
 
 			xyz[1].z = xyz[0].z;
 			xyz[2].z = xyz[3].z;
@@ -2877,22 +2872,22 @@ void D3DRenderPacketWallMaskAdd(WallData *pWall, d3d_render_pool_new *pPool, uns
 			{
 				case D3DRENDER_WALL_NORMAL:
 				{
-					xyz[0].z = (long)pWall->zz2;
-					xyz[3].z = (long)pWall->z2;
+               xyz[0].z = (float)pWall->zz2;
+               xyz[3].z = (float)pWall->z2;
 				}
 				break;
 
 				case D3DRENDER_WALL_BELOW:
 				{
-					xyz[0].z = (long)pWall->zz1;
-					xyz[3].z = (long)pWall->z1;
+               xyz[0].z = (float)pWall->zz1;
+               xyz[3].z = (float)pWall->z1;
 				}
 				break;
 
 				case D3DRENDER_WALL_ABOVE:
 				{
-					xyz[0].z = (long)pWall->zz3;
-					xyz[3].z = (long)pWall->z3;
+               xyz[0].z = (float)pWall->zz3;
+               xyz[3].z = (float)pWall->z3;
 				}
 				break;
 
@@ -4711,9 +4706,6 @@ void D3DRenderLMapPostFloorAdd(BSPnode *pNode, d3d_render_pool_new *pPool, d_lig
 	int			count;
 	int			numLights;
 
-	d3d_render_packet_new	*pPacket;
-	d3d_render_chunk_new	*pChunk;
-
 	if (pSector->floor)
 	{
 		pDib = pSector->floor;
@@ -4727,22 +4719,15 @@ void D3DRenderLMapPostFloorAdd(BSPnode *pNode, d3d_render_pool_new *pPool, d_lig
 	for (numLights = 0; numLights < pDLightCache->numLights; numLights++)
 	{
 		custom_xyz	vector;
-		float		distance, lightRange;
-		int			unlit;
-		float		falloff, invXScale, invYScale, invZScale,
-					invXScaleHalf, invYScaleHalf, invZScaleHalf;
+		float		lightRange;
+      int unlit = 0;
 
-		invXScale = pDLightCache->dLights[numLights].invXYZScale.x;
-		invYScale = pDLightCache->dLights[numLights].invXYZScale.y;
-		invZScale = pDLightCache->dLights[numLights].invXYZScale.z;
-
-		invXScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.x;
-		invYScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.y;
-		invZScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.z;
-
-		unlit = 0;
-		lightRange = (pDLightCache->dLights[numLights].xyzScale.x * 2.0f) *
-			(pDLightCache->dLights[numLights].xyzScale.x * 2.0f);// * 2.0f;
+      if (pSector->sloped_floor)
+		   lightRange = (pDLightCache->dLights[numLights].xyzScale.x * 3.2f) *
+			   (pDLightCache->dLights[numLights].xyzScale.x * 3.2f);
+      else
+         lightRange = (pDLightCache->dLights[numLights].xyzScale.x * 2.0f) *
+         (pDLightCache->dLights[numLights].xyzScale.x * 2.0f);
 
 //		continue;
 
@@ -4754,12 +4739,29 @@ void D3DRenderLMapPostFloorAdd(BSPnode *pNode, d3d_render_pool_new *pPool, d_lig
 			vector.y = xyz[count].y - pDLightCache->dLights[numLights].xyz.y;
 //			vector.z = (xyz[count].z - pDLightCache->dLights[numLights].xyz.z);// * 4.0f;
 
-			distance = ((vector.x * vector.x) + (vector.y * vector.y));// +
+			//distance = ((vector.x * vector.x) + (vector.y * vector.y));// +
 //				(vector.z * vector.z));
 
-			if (distance > lightRange)
-				unlit++;
+         if ((vector.x * vector.x) + (vector.y * vector.y) < lightRange)
+            break;
+         else
+            unlit++;
 		}
+
+      if (unlit == pNode->u.leaf.poly.npts)
+         continue;
+
+      float falloff;
+      float invXScale = pDLightCache->dLights[numLights].invXYZScale.x;
+      float invYScale = pDLightCache->dLights[numLights].invXYZScale.y;
+      float invZScale = pDLightCache->dLights[numLights].invXYZScale.z;
+
+      float invXScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.x;
+      float invYScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.y;
+      float invZScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.z;
+
+      d3d_render_packet_new	*pPacket;
+      d3d_render_chunk_new	*pChunk;
 
 		if (unlit < pNode->u.leaf.poly.npts)
 		{
@@ -4883,9 +4885,6 @@ void D3DRenderLMapPostCeilingAdd(BSPnode *pNode, d3d_render_pool_new *pPool, d_l
 	int			count;
 	int			numLights;
 
-	d3d_render_packet_new	*pPacket;
-	d3d_render_chunk_new	*pChunk;
-
 	if (pSector->ceiling)
 	{
 		pDib = pSector->ceiling;
@@ -4899,23 +4898,12 @@ void D3DRenderLMapPostCeilingAdd(BSPnode *pNode, d3d_render_pool_new *pPool, d_l
 	for (numLights = 0; numLights < pDLightCache->numLights; numLights++)
 	{
 		custom_xyz	vector;
-		float		distance, lightRange;
-		int			unlit;
-		float		falloff, invXScale, invYScale, invZScale,
-					invXScaleHalf, invYScaleHalf, invZScaleHalf;
+		float lightRange;
 
-		invXScale = pDLightCache->dLights[numLights].invXYZScale.x;
-		invYScale = pDLightCache->dLights[numLights].invXYZScale.y;
-		invZScale = pDLightCache->dLights[numLights].invXYZScale.z;
+		int unlit = 0;
 
-		invXScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.x;
-		invYScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.y;
-		invZScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.z;
-
-		unlit = 0;
-
-		lightRange = (pDLightCache->dLights[numLights].xyzScale.x * 2.0f) *
-			(pDLightCache->dLights[numLights].xyzScale.x * 2.0f);// * 2.0f;
+      lightRange = (pDLightCache->dLights[numLights].xyzScale.x * 2.0f) *
+         (pDLightCache->dLights[numLights].xyzScale.x * 2.0f);
 
 //		continue;
 
@@ -4927,12 +4915,29 @@ void D3DRenderLMapPostCeilingAdd(BSPnode *pNode, d3d_render_pool_new *pPool, d_l
 			vector.y = xyz[count].y - pDLightCache->dLights[numLights].xyz.y;
 //			vector.z = (xyz[count].z - pDLightCache->dLights[numLights].xyz.z);// * 4.0f;
 
-			distance = ((vector.x * vector.x) + (vector.y * vector.y));// +
+			//distance = ((vector.x * vector.x) + (vector.y * vector.y));// +
 //				(vector.z * vector.z));
 
-			if (distance > lightRange)
-				unlit++;
+         if ((vector.x * vector.x) + (vector.y * vector.y) < lightRange)
+            break;
+         else
+            unlit++;
 		}
+
+      if (unlit == pNode->u.leaf.poly.npts)
+         continue;
+
+      float falloff;
+      float invXScale = pDLightCache->dLights[numLights].invXYZScale.x;
+      float invYScale = pDLightCache->dLights[numLights].invXYZScale.y;
+      float invZScale = pDLightCache->dLights[numLights].invXYZScale.z;
+
+      float invXScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.x;
+      float invYScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.y;
+      float invZScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.z;
+
+      d3d_render_packet_new	*pPacket;
+      d3d_render_chunk_new	*pChunk;
 
 		if (unlit < pNode->u.leaf.poly.npts)
 		{
@@ -5138,23 +5143,13 @@ void D3DRenderLMapPostWallAdd(WallData *pWall, d3d_render_pool_new *pPool, unsig
 	for (numLights = 0; numLights < pDLightCache->numLights; numLights++)
 	{
 		custom_xyz	vector;
-		float		distance, lightRange;
+		float lightRange;
 		int			unlit;
 		unsigned int	i;
-		float		falloff, invXScale, invYScale, invZScale,
-					invXScaleHalf, invYScaleHalf, invZScaleHalf;
-
-		invXScale = pDLightCache->dLights[numLights].invXYZScale.x;
-		invYScale = pDLightCache->dLights[numLights].invXYZScale.y;
-		invZScale = pDLightCache->dLights[numLights].invXYZScale.z;
-
-		invXScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.x;
-		invYScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.y;
-		invZScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.z;
 
 		unlit = 0;
-		lightRange = (pDLightCache->dLights[numLights].xyzScale.x * 2.0f) *
-			(pDLightCache->dLights[numLights].xyzScale.x * 2.0f);// * 2.0f;
+      lightRange = (pDLightCache->dLights[numLights].xyzScale.x * 2.0f) *
+         (pDLightCache->dLights[numLights].xyzScale.x * 2.0f);
 
 //		continue;
 
@@ -5165,12 +5160,26 @@ void D3DRenderLMapPostWallAdd(WallData *pWall, d3d_render_pool_new *pPool, unsig
 			vector.y = xyz[i].y - pDLightCache->dLights[numLights].xyz.y;
 //			vector.z = (xyz[i].z - pDLightCache->dLights[numLights].xyz.z);// * 4.0f;
 
-			distance = ((vector.x * vector.x) + (vector.y * vector.y));// +
+			//distance = ((vector.x * vector.x) + (vector.y * vector.y));// +
 //				(vector.z * vector.z));
 
-			if (distance > lightRange)
-				unlit++;
+         if ((vector.x * vector.x) + (vector.y * vector.y) < lightRange)
+            break;
+         else
+            unlit++;
 		}
+
+      if (unlit == 4)
+         continue;
+
+      float falloff;
+      float invXScale = pDLightCache->dLights[numLights].invXYZScale.x;
+      float invYScale = pDLightCache->dLights[numLights].invXYZScale.y;
+      float invZScale = pDLightCache->dLights[numLights].invXYZScale.z;
+
+      float invXScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.x;
+      float invYScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.y;
+      float invZScaleHalf = pDLightCache->dLights[numLights].invXYZScaleHalf.z;
 
 		if (unlit < 4)
 		{
@@ -5553,24 +5562,24 @@ int D3DRenderWallExtract(WallData *pWall, PDIB pDib, unsigned int *flags, custom
 			xOffset = pWall->pos_xoffset;
 			yOffset = pWall->pos_yoffset;
 
-			pXYZ[0].x = (float)pWall->x0;
-			pXYZ[3].x = (float)pWall->x1;
-			pXYZ[1].x = (float)pWall->x0;
-			pXYZ[2].x = (float)pWall->x1;
+			pXYZ[0].x = pWall->x0;
+			pXYZ[3].x = pWall->x1;
+			pXYZ[1].x = pWall->x0;
+			pXYZ[2].x = pWall->x1;
 
-			pXYZ[0].y = (float)pWall->y0;
-			pXYZ[3].y = (float)pWall->y1;
-			pXYZ[1].y = (float)pWall->y0;
-			pXYZ[2].y = (float)pWall->y1;
+			pXYZ[0].y = pWall->y0;
+			pXYZ[3].y = pWall->y1;
+			pXYZ[1].y = pWall->y0;
+			pXYZ[2].y = pWall->y1;
 
 			switch (type)
 			{
 				case D3DRENDER_WALL_NORMAL:
 				{
-					pXYZ[0].z = (long)pWall->z2;
-					pXYZ[3].z = (long)pWall->zz2;
-					pXYZ[1].z = (long)pWall->z1;
-					pXYZ[2].z = (long)pWall->zz1;
+					pXYZ[0].z = (float)pWall->z2;
+					pXYZ[3].z = (float)pWall->zz2;
+					pXYZ[1].z = (float)pWall->z1;
+					pXYZ[2].z = (float)pWall->zz1;
 
 					if (pSideDef->flags & WF_NORMAL_TOPDOWN)
 						drawTopDown = 1;
@@ -5584,17 +5593,17 @@ int D3DRenderWallExtract(WallData *pWall, PDIB pDib, unsigned int *flags, custom
 					if ((pWall->bowtie_bits & BT_BELOW_POS) ||
 						(pWall->bowtie_bits & BT_BELOW_NEG))
 					{
-						pXYZ[0].z = (long)pWall->z1Neg;
-						pXYZ[3].z = (long)pWall->zz1Neg;
+						pXYZ[0].z = (float)pWall->z1Neg;
+						pXYZ[3].z = (float)pWall->zz1Neg;
 					}
 					else
 					{
-						pXYZ[0].z = (long)pWall->z1;
-						pXYZ[3].z = (long)pWall->zz1;
+						pXYZ[0].z = (float)pWall->z1;
+						pXYZ[3].z = (float)pWall->zz1;
 					}
 
-					pXYZ[1].z = (long)pWall->z0;
-					pXYZ[2].z = (long)pWall->zz0;
+					pXYZ[1].z = (float)pWall->z0;
+					pXYZ[2].z = (float)pWall->zz0;
 
 					if (pSideDef->flags & WF_BELOW_TOPDOWN)
 						drawTopDown = 1;
@@ -5605,10 +5614,10 @@ int D3DRenderWallExtract(WallData *pWall, PDIB pDib, unsigned int *flags, custom
 
 				case D3DRENDER_WALL_ABOVE:
 				{
-					pXYZ[0].z = (long)pWall->z3;
-					pXYZ[3].z = (long)pWall->zz3;
-					pXYZ[1].z = (long)pWall->z2;
-					pXYZ[2].z = (long)pWall->zz2;
+               pXYZ[0].z = (float)pWall->z3;
+               pXYZ[3].z = (float)pWall->zz3;
+               pXYZ[1].z = (float)pWall->z2;
+               pXYZ[2].z = (float)pWall->zz2;
 
 					if (pSideDef->flags & WF_ABOVE_BOTTOMUP)
 						drawTopDown = 0;
@@ -5633,24 +5642,24 @@ int D3DRenderWallExtract(WallData *pWall, PDIB pDib, unsigned int *flags, custom
 			xOffset = pWall->neg_xoffset;
 			yOffset = pWall->neg_yoffset;
 
-			pXYZ[0].x = (float)pWall->x1;
-			pXYZ[3].x = (float)pWall->x0;
-			pXYZ[1].x = (float)pWall->x1;
-			pXYZ[2].x = (float)pWall->x0;
+			pXYZ[0].x = pWall->x1;
+			pXYZ[3].x = pWall->x0;
+			pXYZ[1].x = pWall->x1;
+			pXYZ[2].x = pWall->x0;
 
-			pXYZ[0].y = (float)pWall->y1;
-			pXYZ[3].y = (float)pWall->y0;
-			pXYZ[1].y = (float)pWall->y1;
-			pXYZ[2].y = (float)pWall->y0;
+			pXYZ[0].y = pWall->y1;
+			pXYZ[3].y = pWall->y0;
+			pXYZ[1].y = pWall->y1;
+			pXYZ[2].y = pWall->y0;
 
 			switch (type)
 			{
 				case D3DRENDER_WALL_NORMAL:
 				{
-					pXYZ[0].z = (long)pWall->zz2;
-					pXYZ[3].z = (long)pWall->z2;
-					pXYZ[1].z = (long)pWall->zz1;
-					pXYZ[2].z = (long)pWall->z1;
+               pXYZ[0].z = (float)pWall->zz2;
+               pXYZ[3].z = (float)pWall->z2;
+               pXYZ[1].z = (float)pWall->zz1;
+               pXYZ[2].z = (float)pWall->z1;
 
 					if (pSideDef->flags & WF_NORMAL_TOPDOWN)
 						drawTopDown = 1;
@@ -5661,10 +5670,10 @@ int D3DRenderWallExtract(WallData *pWall, PDIB pDib, unsigned int *flags, custom
 
 				case D3DRENDER_WALL_BELOW:
 				{
-					pXYZ[0].z = (long)pWall->zz1;
-					pXYZ[3].z = (long)pWall->z1;
-					pXYZ[1].z = (long)pWall->zz0;
-					pXYZ[2].z = (long)pWall->z0;
+               pXYZ[0].z = (float)pWall->zz1;
+               pXYZ[3].z = (float)pWall->z1;
+               pXYZ[1].z = (float)pWall->zz0;
+               pXYZ[2].z = (float)pWall->z0;
 
 					if (pSideDef->flags & WF_BELOW_TOPDOWN)
 						drawTopDown = 1;
@@ -5675,10 +5684,10 @@ int D3DRenderWallExtract(WallData *pWall, PDIB pDib, unsigned int *flags, custom
 
 				case D3DRENDER_WALL_ABOVE:
 				{
-					pXYZ[0].z = (long)pWall->zz3;
-					pXYZ[3].z = (long)pWall->z3;
-					pXYZ[1].z = (long)pWall->zz2;
-					pXYZ[2].z = (long)pWall->z2;
+               pXYZ[0].z = (float)pWall->zz3;
+               pXYZ[3].z = (float)pWall->z3;
+               pXYZ[1].z = (float)pWall->zz2;
+               pXYZ[2].z = (float)pWall->z2;
 
 					if (pSideDef->flags & WF_ABOVE_BOTTOMUP)
 						drawTopDown = 0;
@@ -5771,16 +5780,16 @@ int D3DRenderWallExtract(WallData *pWall, PDIB pDib, unsigned int *flags, custom
 					*invWidth);
 				pST[2].t = 1.0f - (((float)yOffset * (float)pDib->shrink)
 					* invWidth);
-				pST[1].t -= ((float)pXYZ[1].z - bottom) * (float)pDib->shrink
+				pST[1].t -= (pXYZ[1].z - bottom) * (float)pDib->shrink
 						* invWidthFudge;
-				pST[2].t -= ((float)pXYZ[2].z - bottom) * (float)pDib->shrink
+				pST[2].t -= (pXYZ[2].z - bottom) * (float)pDib->shrink
 						* invWidthFudge;
 			}
 
 			pST[0].t = pST[1].t -
-				((float)(pXYZ[0].z - pXYZ[1].z) * (float)pDib->shrink * invWidthFudge);
+				((pXYZ[0].z - pXYZ[1].z) * (float)pDib->shrink * invWidthFudge);
 			pST[3].t = pST[2].t -
-				((float)(pXYZ[3].z - pXYZ[2].z) * (float)pDib->shrink * invWidthFudge);
+				((pXYZ[3].z - pXYZ[2].z) * (float)pDib->shrink * invWidthFudge);
 		}
 		else	// else, need to place tex origin at top left
 		{
@@ -5989,8 +5998,10 @@ void D3DRenderFloorExtract(BSPnode *pNode, PDIB pDib, custom_xyz *pXYZ, custom_s
 
 	left = top = 0;
 
-	inv128 = 1.0f / (128.0f * PETER_FUDGE);// / pDib->shrink);
-	inv64 = 1.0f / (64.0f * PETER_FUDGE);// / pDib->shrink);
+   //inv128 = 1.0f / (128.0f * PETER_FUDGE);// / pDib->shrink);
+   inv128 = 0.00048828125f;
+   //inv64 = 1.0f / (64.0f * PETER_FUDGE);// / pDib->shrink);
+   inv64 = 0.0009765625f;
 
 	// generate texture coordinates
 	if (pSector->sloped_floor)
@@ -6071,7 +6082,7 @@ void D3DRenderFloorExtract(BSPnode *pNode, PDIB pDib, custom_xyz *pXYZ, custom_s
 					intersectTop.y = pSector->sloped_floor->p0.y +
 						U * (pSector->sloped_floor->p1.y - pSector->sloped_floor->p0.y);
 
-					pST[count].s = (float)sqrt((pXYZ[count].x - intersectTop.x) *
+					pST[count].s = sqrt((pXYZ[count].x - intersectTop.x) *
 									(pXYZ[count].x - intersectTop.x) +
 									(pXYZ[count].z - intersectTop.z) *
 									(pXYZ[count].z - intersectTop.z) +
@@ -6104,7 +6115,7 @@ void D3DRenderFloorExtract(BSPnode *pNode, PDIB pDib, custom_xyz *pXYZ, custom_s
 					intersectLeft.y = pSector->sloped_floor->p0.y +
 						U * (pSector->sloped_floor->p2.y - pSector->sloped_floor->p0.y);
 
-					pST[count].t = (float)sqrt((pXYZ[count].x - intersectLeft.x) *
+					pST[count].t = sqrt((pXYZ[count].x - intersectLeft.x) *
 									(pXYZ[count].x - intersectLeft.x) +
 									(pXYZ[count].z - intersectLeft.z) *
 									(pXYZ[count].z - intersectLeft.z) +
@@ -6118,7 +6129,7 @@ void D3DRenderFloorExtract(BSPnode *pNode, PDIB pDib, custom_xyz *pXYZ, custom_s
 					vectorU.z = pSector->sloped_floor->p1.z - pSector->sloped_floor->p0.z;
 					vectorU.y = pSector->sloped_floor->p1.y - pSector->sloped_floor->p0.y;
 
-					distance = (float)sqrt((vectorU.x * vectorU.x) +
+					distance = sqrt((vectorU.x * vectorU.x) +
 						(vectorU.y * vectorU.y));
 
 					if (distance == 0)
@@ -6132,7 +6143,7 @@ void D3DRenderFloorExtract(BSPnode *pNode, PDIB pDib, custom_xyz *pXYZ, custom_s
 					vectorV.z = pSector->sloped_floor->p2.z - pSector->sloped_floor->p0.z;
 					vectorV.y = pSector->sloped_floor->p2.y - pSector->sloped_floor->p0.y;
 
-					distance = (float)sqrt((vectorV.x * vectorV.x) +
+					distance = sqrt((vectorV.x * vectorV.x) +
 						(vectorV.y * vectorV.y));
 
 					if (distance == 0)
@@ -6145,7 +6156,7 @@ void D3DRenderFloorExtract(BSPnode *pNode, PDIB pDib, custom_xyz *pXYZ, custom_s
 					vector.x = pXYZ[count].x - pSector->sloped_floor->p0.x;
 					vector.y = pXYZ[count].y - pSector->sloped_floor->p0.y;
 
-					distance = (float)sqrt((vector.x * vector.x) +
+					distance = sqrt((vector.x * vector.x) +
 						(vector.y * vector.y));
 
 					if (distance == 0)
@@ -6265,8 +6276,10 @@ void D3DRenderCeilingExtract(BSPnode *pNode, PDIB pDib, custom_xyz *pXYZ, custom
 
 	left = top = 0;
 
-	inv128 = 1.0f / (128.0f * PETER_FUDGE);
-	inv64 = 1.0f / (64.0f * PETER_FUDGE);
+   //inv128 = 1.0f / (128.0f * PETER_FUDGE);// / pDib->shrink);
+   inv128 = 0.00048828125f;
+   //inv64 = 1.0f / (64.0f * PETER_FUDGE);// / pDib->shrink);
+   inv64 = 0.0009765625f;
 
 	// generate texture coordinates
 	for (count = 0; count < pNode->u.leaf.poly.npts; count++)
@@ -6292,16 +6305,16 @@ void D3DRenderCeilingExtract(BSPnode *pNode, PDIB pDib, custom_xyz *pXYZ, custom
 		{
 			if (pSector->sloped_ceiling)
 			{
-				pXYZ[count].x = (float)pNode->u.leaf.poly.p[count].x;
-				pXYZ[count].y = (float)pNode->u.leaf.poly.p[count].y;
+				pXYZ[count].x = pNode->u.leaf.poly.p[count].x;
+				pXYZ[count].y = pNode->u.leaf.poly.p[count].y;
 				pXYZ[count].z = (-pSector->sloped_ceiling->plane.a * pXYZ[count].x -
 					pSector->sloped_ceiling->plane.b * pXYZ[count].y -
 					pSector->sloped_ceiling->plane.d) * oneOverC;
 			}
 			else
 			{
-				pXYZ[count].x = (float)pNode->u.leaf.poly.p[count].x;
-				pXYZ[count].y = (float)pNode->u.leaf.poly.p[count].y;
+				pXYZ[count].x = pNode->u.leaf.poly.p[count].x;
+				pXYZ[count].y = pNode->u.leaf.poly.p[count].y;
 				pXYZ[count].z = (float)pSector->ceiling_height;
 			}
 
@@ -6340,7 +6353,7 @@ void D3DRenderCeilingExtract(BSPnode *pNode, PDIB pDib, custom_xyz *pXYZ, custom
 					intersectTop.y = pSector->sloped_ceiling->p0.y +
 						U * (pSector->sloped_ceiling->p1.y - pSector->sloped_ceiling->p0.y);
 
-					pST[count].s = (float)sqrt((pXYZ[count].x - intersectTop.x) *
+					pST[count].s = sqrt((pXYZ[count].x - intersectTop.x) *
 									(pXYZ[count].x - intersectTop.x) +
 									(pXYZ[count].z - intersectTop.z) *
 									(pXYZ[count].z - intersectTop.z) +
@@ -6373,7 +6386,7 @@ void D3DRenderCeilingExtract(BSPnode *pNode, PDIB pDib, custom_xyz *pXYZ, custom
 					intersectLeft.y = pSector->sloped_ceiling->p0.y +
 						U * (pSector->sloped_ceiling->p2.y - pSector->sloped_ceiling->p0.y);
 
-					pST[count].t = (float)sqrt((pXYZ[count].x - intersectLeft.x) *
+					pST[count].t = sqrt((pXYZ[count].x - intersectLeft.x) *
 									(pXYZ[count].x - intersectLeft.x) +
 									(pXYZ[count].z - intersectLeft.z) *
 									(pXYZ[count].z - intersectLeft.z) +
@@ -6390,7 +6403,7 @@ void D3DRenderCeilingExtract(BSPnode *pNode, PDIB pDib, custom_xyz *pXYZ, custom
 					vectorU.z = pSector->sloped_ceiling->p1.z - pSector->sloped_ceiling->p0.z;
 					vectorU.y = pSector->sloped_ceiling->p1.y - pSector->sloped_ceiling->p0.y;
 
-					distance = (float)sqrt((vectorU.x * vectorU.x) +
+					distance = sqrt((vectorU.x * vectorU.x) +
 						(vectorU.y * vectorU.y));
 
 					if (distance == 0)
@@ -6404,7 +6417,7 @@ void D3DRenderCeilingExtract(BSPnode *pNode, PDIB pDib, custom_xyz *pXYZ, custom
 					vectorV.z = pSector->sloped_ceiling->p2.z - pSector->sloped_ceiling->p0.z;
 					vectorV.y = pSector->sloped_ceiling->p2.y - pSector->sloped_ceiling->p0.y;
 
-					distance = (float)sqrt((vectorV.x * vectorV.x) +
+					distance = sqrt((vectorV.x * vectorV.x) +
 						(vectorV.y * vectorV.y));
 
 					if (distance == 0)
@@ -6417,7 +6430,7 @@ void D3DRenderCeilingExtract(BSPnode *pNode, PDIB pDib, custom_xyz *pXYZ, custom
 					vector.x = pXYZ[count].x - pSector->sloped_ceiling->p0.x;
 					vector.y = pXYZ[count].y - pSector->sloped_ceiling->p0.y;
 
-					distance = (float)sqrt((vector.x * vector.x) +
+					distance = sqrt((vector.x * vector.x) +
 						(vector.y * vector.y));
 
 					if (distance == 0)

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -1472,7 +1472,7 @@ void D3DRenderWorldDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DParam
 void D3DRenderLMapsPostDraw(BSPnode *tree, Draw3DParams *params)
 {
 	long		side;
-	double	a, b;
+	float	a, b;
 
 	if (!tree)
 		return;
@@ -1614,7 +1614,7 @@ void D3DRenderLMapsPostDraw(BSPnode *tree, Draw3DParams *params)
 void D3DRenderLMapsDynamicPostDraw(BSPnode *tree, Draw3DParams *params)
 {
 	long		side;
-	double	a, b;
+	float	a, b;
 
 	if (!tree)
 		return;
@@ -5911,7 +5911,7 @@ int D3DRenderWallExtract(WallData *pWall, PDIB pDib, unsigned int *flags, custom
 	if (pBGRA)
 	{
 		int	i;
-		double a, b;
+		float a, b;
 		int	distX, distY, distance;
 		long	lightScale;
 		long lo_end = FINENESS-shade_amount;
@@ -6019,16 +6019,16 @@ void D3DRenderFloorExtract(BSPnode *pNode, PDIB pDib, custom_xyz *pXYZ, custom_s
 		{
 			if (pSector->sloped_floor)
 			{
-				pXYZ[count].x = (float)pNode->u.leaf.poly.p[count].x;
-				pXYZ[count].y = (float)pNode->u.leaf.poly.p[count].y;
+				pXYZ[count].x = pNode->u.leaf.poly.p[count].x;
+				pXYZ[count].y = pNode->u.leaf.poly.p[count].y;
 				pXYZ[count].z = (-pSector->sloped_floor->plane.a * pXYZ[count].x -
 					pSector->sloped_floor->plane.b * pXYZ[count].y -
 					pSector->sloped_floor->plane.d) * oneOverC;
 			}
 			else
 			{
-				pXYZ[count].x = (float)pNode->u.leaf.poly.p[count].x;
-				pXYZ[count].y = (float)pNode->u.leaf.poly.p[count].y;
+				pXYZ[count].x = pNode->u.leaf.poly.p[count].x;
+				pXYZ[count].y = pNode->u.leaf.poly.p[count].y;
 				pXYZ[count].z = (float)pSector->floor_height;
 			}
 

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -10895,11 +10895,11 @@ Bool IsHidden(Draw3DParams *params, long x0, long y0, long x1, long y1)
    center_a = COS(params->viewer_angle) >> 6;
    center_b = SIN(params->viewer_angle) >> 6;
 
-   left_a = -center_b + ((center_a * gScreenWidth >> 1) >> LOG_VIEWER_DISTANCE);
-   left_b = center_a + ((center_b * gScreenWidth >> 1) >> LOG_VIEWER_DISTANCE);
+   left_a = -center_b + ((center_a * MAXX) >> LOG_VIEWER_DISTANCE);
+   left_b = center_a + ((center_b * MAXX) >> LOG_VIEWER_DISTANCE);
 
-   right_a = center_b + ((center_a * gScreenWidth >> 1) >> LOG_VIEWER_DISTANCE);
-   right_b = -center_a + ((center_b * gScreenWidth >> 1) >> LOG_VIEWER_DISTANCE);
+   right_a = center_b + ((center_a * MAXX) >> LOG_VIEWER_DISTANCE);
+   right_b = -center_a + ((center_b * MAXX) >> LOG_VIEWER_DISTANCE);
 
    x0 -= params->viewer_x;
    y0 -= params->viewer_y;

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -729,18 +729,6 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 
 	p = params;
 
-   // These two functions do the same thing, D3DFillTreeData uses the room's
-   // node list and D3DFillTreeDataTraverse traverses the tree to fill it.
-   // D3DFillTreeDataTraverse is slightly faster for drawing a partial room.
-   // This function is added here so the data for walls, ceilings and floors
-   // can be added to their structs (i.e. the data from the Extract functions)
-   // so we don't have to calculate them repeatedly each time we draw something.
-   // Data is valid for the entire frame. D3DGeometryBuildNew also calls this
-   // to build the static light maps (with the third parameter set to TRUE to
-   // fill the entire tree).
-   D3DFillTreeDataTraverse(room->tree, params, FALSE);
-   //D3DFillTreeData(room, params, FALSE);
-
 	gDLightCache.numLights = 0;
 	gDLightCacheDynamic.numLights = 0;
 	D3DLMapsStaticGet(room);
@@ -803,6 +791,18 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 	D3DCacheSystemReset(&gWorldCacheSystem);
 	
 	UpdateRoom3D(room, params);
+
+   // These two functions do the same thing, D3DFillTreeData uses the room's
+   // node list and D3DFillTreeDataTraverse traverses the tree to fill it.
+   // D3DFillTreeDataTraverse is slightly faster for drawing a partial room.
+   // This function is added here so the data for walls, ceilings and floors
+   // can be added to their structs (i.e. the data from the Extract functions)
+   // so we don't have to calculate them repeatedly each time we draw something.
+   // Data is valid for the entire frame. D3DGeometryBuildNew also calls this
+   // to build the static light maps (with the third parameter set to TRUE to
+   // fill the entire tree).
+   D3DFillTreeDataTraverse(room->tree, params, FALSE);
+   //D3DFillTreeData(room, params, FALSE);
 
 	playerDeltaPos.x = params->viewer_x - playerOldPos.x;
 	playerDeltaPos.y = params->viewer_y - playerOldPos.y;
@@ -1373,8 +1373,8 @@ void D3DRenderBegin(room_type *room, Draw3DParams *params)
 		debug(("number of vertices = %d\nnumber of dp calls = %d\n", gNumVertices,
 		gNumDPCalls));
 
-   //debug(("all = %d lmaps = %d wrld = %d obj = %d  particles = %d sky = %d init = %d\n",
-		//timeOverall, timeLMaps, timeWorld, timeObjects, timeParticles, timeSkybox+timeSkybox2, timeInit));
+   debug(("all = %d lmaps = %d wrld = %d obj = %d  particles = %d sky = %d init = %d\n",
+		timeOverall, timeLMaps, timeWorld, timeObjects, timeParticles, timeSkybox+timeSkybox2, timeInit));
 }
 
 void D3DRenderWorldDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DParams *params)

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -1468,6 +1468,9 @@ void D3DRenderWorldDraw(d3d_render_pool_new *pPool, room_type *room, Draw3DParam
 					pWall->separator.b = pNode->u.internal.separator.b;
 					pWall->separator.c = pNode->u.internal.separator.c;
 
+               // TODO: this feature doesn't currently work properly, due to walls not being tagged
+               // as drawable correctly in drawbsp.c. Code left commented out, as it is a work in progress.
+
                // D3DRenderWorldDraw now relies on checks done while constructing the list
                // of viewable objects, walls etc. in DrawBSP() in drawbsp.c. Walls that can be seen
                // have the respective boolean value set to TRUE, so all we need to do here is check
@@ -1778,9 +1781,9 @@ void D3DRenderLMapsPostDraw(BSPnode *tree, Draw3DParams *params, d_light *light)
 		case BSPleaftype:
 			if (tree->u.leaf.sector->flags & SF_HAS_ANIMATED)
 			{
-            if (tree->drawfloor)
+            //if (tree->drawfloor)
                D3DRenderLMapPostFloorAdd(tree, &gLMapPool, light, TRUE);
-            if (tree->drawceiling)
+            //if (tree->drawceiling)
 				   D3DRenderLMapPostCeilingAdd(tree, &gLMapPool, light, TRUE);
 			}
 			return;
@@ -1801,7 +1804,7 @@ void D3DRenderLMapsPostDraw(BSPnode *tree, Draw3DParams *params, d_light *light)
 			{
 				//WallList list;
 				WallData	*pWall;
-				//int			flags;
+				int			flags;
 
 				for (pWall = tree->u.internal.walls_in_plane; pWall != NULL; pWall = pWall->next)
 				{
@@ -1834,7 +1837,7 @@ void D3DRenderLMapsPostDraw(BSPnode *tree, Draw3DParams *params, d_light *light)
 					if (FALSE == bDynamic)
 						continue;
 
-               /*flags = 0;
+               flags = 0;
 					if (pWall->pos_sidedef)
 					{
 						if (pWall->pos_sidedef->normal_bmap)
@@ -1857,7 +1860,7 @@ void D3DRenderLMapsPostDraw(BSPnode *tree, Draw3DParams *params, d_light *light)
 
 						if (pWall->neg_sidedef->above_bmap)
 							flags |= D3DRENDER_WALL_ABOVE;
-					}*/
+					}
 
 					pWall->separator.a = tree->u.internal.separator.a;
 					pWall->separator.b = tree->u.internal.separator.b;
@@ -1869,20 +1872,23 @@ void D3DRenderLMapsPostDraw(BSPnode *tree, Draw3DParams *params, d_light *light)
                // that value to decide whether to render light on the wall. Significantly speeds up
                // rendering large amounts of lights. Old code left commented out as opposed to deleting
                // in case any modification to drawbsp.c is performed which invalidates this method.
-					if (pWall->drawnormal) //((flags & D3DRENDER_WALL_NORMAL) && (((short)pWall->z2 != (short)pWall->z1)
-						//|| (pWall->zz2 != pWall->zz1)))
+					//if (pWall->drawnormal) 
+               if ((flags & D3DRENDER_WALL_NORMAL) && (((short)pWall->z2 != (short)pWall->z1)
+						|| (pWall->zz2 != pWall->zz1)))
 					{
 						D3DRenderLMapPostWallAdd(pWall, &gLMapPool, D3DRENDER_WALL_NORMAL, side, light, TRUE);
 					}
 
-					if (pWall->drawbelow) //((flags & D3DRENDER_WALL_BELOW) && (((short)pWall->z1 != (short)pWall->z0)
-						//|| ((short)pWall->zz1 != (short)pWall->zz0)))
+					//if (pWall->drawbelow)
+               if ((flags & D3DRENDER_WALL_BELOW) && (((short)pWall->z1 != (short)pWall->z0)
+						|| ((short)pWall->zz1 != (short)pWall->zz0)))
 					{
 						D3DRenderLMapPostWallAdd(pWall, &gLMapPool, D3DRENDER_WALL_BELOW, side, light, TRUE);
 					}
 
-					if (pWall->drawabove) //((flags & D3DRENDER_WALL_ABOVE) && (((short)pWall->z3 != (short)pWall->z2)
-						//|| ((short)pWall->zz3 != (short)pWall->zz2)))
+					//if (pWall->drawabove)
+               if ((flags & D3DRENDER_WALL_ABOVE) && (((short)pWall->z3 != (short)pWall->z2)
+						|| ((short)pWall->zz3 != (short)pWall->zz2)))
 					{
 						D3DRenderLMapPostWallAdd(pWall, &gLMapPool, D3DRENDER_WALL_ABOVE, side, light, TRUE);
 					}
@@ -1924,9 +1930,9 @@ void D3DRenderLMapsDynamicPostDraw(BSPnode *tree, Draw3DParams *params, d_light 
 	switch(tree->type)
 	{
       case BSPleaftype:
-         if (tree->drawfloor)
+         //if (tree->drawfloor)
 			   D3DRenderLMapPostFloorAdd(tree, &gLMapPool, light, TRUE);
-         if (tree->drawceiling)
+         //if (tree->drawceiling)
 			   D3DRenderLMapPostCeilingAdd(tree, &gLMapPool, light, TRUE);
 
 			return;
@@ -1947,13 +1953,13 @@ void D3DRenderLMapsDynamicPostDraw(BSPnode *tree, Draw3DParams *params, d_light 
 			{
 				//WallList list;
 				WallData	*pWall;
-				//int			flags;
+				int			flags;
 
 				for (pWall = tree->u.internal.walls_in_plane; pWall != NULL; pWall = pWall->next)
 				{
-					//flags = 0;
+					flags = 0;
 
-					/*if (pWall->pos_sidedef)
+					if (pWall->pos_sidedef)
 					{
 
 						if (pWall->pos_sidedef->normal_bmap)
@@ -1976,7 +1982,7 @@ void D3DRenderLMapsDynamicPostDraw(BSPnode *tree, Draw3DParams *params, d_light 
 
 						if (pWall->neg_sidedef->above_bmap)
 							flags |= D3DRENDER_WALL_ABOVE;
-					}*/
+					}
 
 					pWall->separator.a = tree->u.internal.separator.a;
 					pWall->separator.b = tree->u.internal.separator.b;
@@ -1988,20 +1994,23 @@ void D3DRenderLMapsDynamicPostDraw(BSPnode *tree, Draw3DParams *params, d_light 
                // that value to decide whether to render light on the wall. Significantly speeds up
                // rendering large amounts of lights. Old code left commented out as opposed to deleting
                // in case any modification to drawbsp.c is performed which invalidates this method.
-					if (pWall->drawnormal) //((flags & D3DRENDER_WALL_NORMAL) && (((short)pWall->z2 != (short)pWall->z1)
-						//|| ((short)pWall->zz2 != (short)pWall->zz1)))
+					//if (pWall->drawnormal)
+               if ((flags & D3DRENDER_WALL_NORMAL) && (((short)pWall->z2 != (short)pWall->z1)
+						|| ((short)pWall->zz2 != (short)pWall->zz1)))
 					{
 						D3DRenderLMapPostWallAdd(pWall, &gLMapPool, D3DRENDER_WALL_NORMAL, side, light, TRUE);
 					}
 
-               if (pWall->drawbelow) //((flags & D3DRENDER_WALL_BELOW) && (((short)pWall->z1 != (short)pWall->z0)
-						//|| ((short)pWall->zz1 != (short)pWall->zz0)))
+               //if (pWall->drawbelow) 
+               if ((flags & D3DRENDER_WALL_BELOW) && (((short)pWall->z1 != (short)pWall->z0)
+						|| ((short)pWall->zz1 != (short)pWall->zz0)))
 					{
 						D3DRenderLMapPostWallAdd(pWall, &gLMapPool, D3DRENDER_WALL_BELOW, side, light, TRUE);
 					}
 
-               if (pWall->drawabove) //((flags & D3DRENDER_WALL_ABOVE) && (((short)pWall->z3 != (short)pWall->z2)
-						//|| ((short)pWall->zz3 != (short)pWall->zz2)))
+               //if (pWall->drawabove)
+               if ((flags & D3DRENDER_WALL_ABOVE) && (((short)pWall->z3 != (short)pWall->z2)
+						|| ((short)pWall->zz3 != (short)pWall->zz2)))
 					{
 						D3DRenderLMapPostWallAdd(pWall, &gLMapPool, D3DRENDER_WALL_ABOVE, side, light, TRUE);
 					}

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -38,51 +38,34 @@ inline DWORD F2DW( FLOAT f ) { return *((DWORD*)&f); }
 #define D3DRENDER_REDRAW_ALL	0x00000002
 
 #define D3DRENDER_SET_ALPHATEST_STATE(_pDevice, _enable, _refValue, _compareFunc)	\
-do	\
-{	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHATESTENABLE, _enable);	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAREF, _refValue);	\
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAFUNC, _compareFunc);	\
-} while (0)
+	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHAFUNC, _compareFunc);
 
 #define D3DRENDER_SET_ALPHABLEND_STATE(_pDevice, _enable, _srcBlend, _dstBlend)	\
-do	\
-{	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_ALPHABLENDENABLE, _enable);	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_SRCBLEND, _srcBlend);	\
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_DESTBLEND, _dstBlend);	\
-} while (0)
+	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_DESTBLEND, _dstBlend);
 
 #define D3DRENDER_SET_STENCIL_STATE(_pDevice, _enable, _stencilFunc, _refValue, _pass, _fail, _zfail)	\
-do	\
-{	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_STENCILENABLE, _enable);	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_STENCILFUNC, _stencilFunc);	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_STENCILREF, _refValue);	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_STENCILPASS, _pass);	\
 	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_STENCILFAIL, _fail);	\
-	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_STENCILZFAIL, _zfail);	\
-} while (0)
+	IDirect3DDevice9_SetRenderState(gpD3DDevice, D3DRS_STENCILZFAIL, _zfail);
 
 #define D3DRENDER_SET_COLOR_STAGE(_pDevice, _stage, _opValue, _arg0Value, _arg1Value)	\
-do	\
-{	\
 	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_COLOROP,	_opValue);	\
 	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_COLORARG1, _arg0Value);	\
-	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_COLORARG2, _arg1Value);	\
-} while (0)
+	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_COLORARG2, _arg1Value);
 
 #define D3DRENDER_SET_ALPHA_STAGE(_pDevice, _stage, _opValue, _arg0Value, _arg1Value)	\
-do	\
-{	\
 	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_ALPHAOP,	_opValue);	\
 	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_ALPHAARG1, _arg0Value);	\
-	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_ALPHAARG2, _arg1Value);	\
-} while (0)
+	IDirect3DDevice9_SetTextureStageState(_pDevice, _stage, D3DTSS_ALPHAARG2, _arg1Value);
 
 #define D3DRENDER_SET_STREAMS(_pDevice, _pCache, _numStages)	\
-do	\
-{	\
 	int	_i = 0;	\
 	int	_j;	\
 	IDirect3DDevice9_SetStreamSource(_pDevice, _i++,	\
@@ -92,20 +75,16 @@ do	\
 	for (_j = 0; _j < _numStages; _j++)	\
 		IDirect3DDevice9_SetStreamSource(_pDevice, _i++,	\
 			(_pCache)->stBuffer[_j].pVBuffer, 0, sizeof(custom_st));	\
-	IDirect3DDevice9_SetIndices(_pDevice, (_pCache)->indexBuffer.pIBuffer);	\
-} while (0)
+	IDirect3DDevice9_SetIndices(_pDevice, (_pCache)->indexBuffer.pIBuffer);
 
 #define D3DRENDER_CLEAR_STREAMS(_pDevice, _numStages)	\
-do	\
-{	\
 	int	_i = 0;	\
 	int	_j;	\
 	IDirect3DDevice9_SetStreamSource(_pDevice, _i++, NULL, 0, 0);	\
 	IDirect3DDevice9_SetStreamSource(_pDevice, _i++, NULL, 0, 0);	\
 	for (_j = 0; _j < _numStages; _j++)	\
 		IDirect3DDevice9_SetStreamSource(_pDevice, _i++, NULL, 0, 0);	\
-	IDirect3DDevice9_SetIndices(_pDevice, NULL);	\
-} while (0)
+	IDirect3DDevice9_SetIndices(_pDevice, NULL);
 
 typedef struct d_light
 {

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -166,6 +166,7 @@ Bool D3DMaterialLMapDynamicPool(d3d_render_pool_new *pPool);
 Bool D3DMaterialLMapDynamicPacket(d3d_render_packet_new *pPacket, d3d_render_cache_system *pCacheSystem);
 Bool D3DMaterialLMapDynamicChunk(d3d_render_chunk_new *pChunk);
 Bool D3DMaterialLMapStaticChunk(d3d_render_chunk_new *pChunk);
+Bool IsHidden(Draw3DParams *params, long x0, long y0, long x1, long y1);
 
 // objects
 Bool D3DMaterialObjectPool(d3d_render_pool_new *pPool);

--- a/clientd3d/d3drender.h
+++ b/clientd3d/d3drender.h
@@ -89,6 +89,9 @@ inline DWORD F2DW( FLOAT f ) { return *((DWORD*)&f); }
 typedef struct d_light
 {
 	custom_xyz	xyz;
+   // Max and min x,y values for how far
+   // the light reaches.
+   float maxX, maxY, minX, minY;
 	custom_xyz	xyzScale;
 	custom_xyz	invXYZScale;
 	custom_xyz	invXYZScaleHalf;
@@ -166,7 +169,6 @@ Bool D3DMaterialLMapDynamicPool(d3d_render_pool_new *pPool);
 Bool D3DMaterialLMapDynamicPacket(d3d_render_packet_new *pPacket, d3d_render_cache_system *pCacheSystem);
 Bool D3DMaterialLMapDynamicChunk(d3d_render_chunk_new *pChunk);
 Bool D3DMaterialLMapStaticChunk(d3d_render_chunk_new *pChunk);
-Bool IsHidden(Draw3DParams *params, long x0, long y0, long x1, long y1);
 
 // objects
 Bool D3DMaterialObjectPool(d3d_render_pool_new *pPool);
@@ -196,5 +198,9 @@ Bool D3DMaterialParticleChunk(d3d_render_chunk_new *pChunk);
 void SandstormInit(void);
 void RainInit(void);
 void SnowInit(void);
+
+// Use this function to determine if the bounding box is out of the player's
+//view. Useful for not adding stuff to draw that the player can't see.
+Bool IsHidden(Draw3DParams *params, long x0, long y0, long x1, long y1);
 
 #endif	// __D3DRENDER_H__

--- a/clientd3d/d3dtypes.h
+++ b/clientd3d/d3dtypes.h
@@ -66,25 +66,12 @@
 #define D3DRENDER_SCREEN_TO_CLIP_X(_x, _scale)	(((_x) - (_scale) / 2.0f) / ((_scale) / 2.0f))
 #define D3DRENDER_SCREEN_TO_CLIP_Y(_y, _scale)	(((_y) - (_scale) / 2.0f) / (-(_scale) / 2.0f))
 
-typedef struct custom_xyz
-{
-	float	x, y, z;
-} custom_xyz;
 
 typedef struct custom_xyzw
 {
 	float	x, y, z, w;
 } custom_xyzw;
 
-typedef struct custom_st
-{
-	float	s, t;
-} custom_st;
-
-typedef struct custom_bgra
-{
-	unsigned char	b, g, r, a;
-} custom_bgra;
 
 typedef short custom_index;
 

--- a/clientd3d/draw3d.h
+++ b/clientd3d/draw3d.h
@@ -22,9 +22,10 @@
 #define DIVUP(a,b) ((a)+(b)-1)/(b)
 
 /* Given a distance x, return palette index to use.  Must have x > 0 */
-/* "v" is strength of light source at viewer; "a" strength of ambient light */
+/* "v" is strength of light source at viewer; "a" strength of ambient light. */
+/* 4194304 is 4*FINENESS*FINENESS */
 #define LIGHT_INDEX(x, v, a) (min(MAX_LIGHT - 1, \
-				  (4*FINENESS*FINENESS) / (x) * (v) / KOD_LIGHT_LEVELS + (a)))
+				  (4194304) / (x) * (v) / KOD_LIGHT_LEVELS + (a)))
 
 #define LIGHT_NEUTRAL 192       // Light level of sector drawn at ambient light level
 

--- a/clientd3d/drawbsp.c
+++ b/clientd3d/drawbsp.c
@@ -4375,12 +4375,6 @@ void DrawBSP(room_type *room, Draw3DParams *params, long width, Bool draw)
    center_a = COS(viewer_angle) >> 6;
    center_b = SIN(viewer_angle) >> 6;
 
-   left_a = -center_b + ((center_a * screen_width2) >> LOG_VIEWER_DISTANCE);
-   left_b =  center_a + ((center_b * screen_width2) >> LOG_VIEWER_DISTANCE);
-
-   right_a =  center_b + ((center_a * screen_width2) >> LOG_VIEWER_DISTANCE);
-   right_b = -center_a + ((center_b * screen_width2) >> LOG_VIEWER_DISTANCE);
-
    // If the D3D render is in use, we need to increase the frustum
    if (D3DRenderIsEnabled())
    {
@@ -4390,6 +4384,15 @@ void DrawBSP(room_type *room, Draw3DParams *params, long width, Bool draw)
       right_a = center_b + ((center_a * screen_width) >> LOG_VIEWER_DISTANCE);
       right_b = -center_a + ((center_b * screen_width) >> LOG_VIEWER_DISTANCE);
    }
+   else
+   {
+      left_a = -center_b + ((center_a * screen_width2) >> LOG_VIEWER_DISTANCE);
+      left_b = center_a + ((center_b * screen_width2) >> LOG_VIEWER_DISTANCE);
+
+      right_a = center_b + ((center_a * screen_width2) >> LOG_VIEWER_DISTANCE);
+      right_b = -center_a + ((center_b * screen_width2) >> LOG_VIEWER_DISTANCE);
+   }
+
 
    /* add moving objects to BSP tree */
    AddObjects(room);

--- a/clientd3d/drawbsp.c
+++ b/clientd3d/drawbsp.c
@@ -685,14 +685,6 @@ static void AddObjects(room_type *room)
  * contains cones with larger columns.  The tree is also threaded with
  * a doubly-linked list which connects the cones in order.
  */
-typedef struct ConeTreeNode
-{
-  ViewCone cone;
-  int height;           /* height of subtree rooted at node */
-  struct ConeTreeNode *parent;        /* up the cone tree   */
-  struct ConeTreeNode *left, *right;  /* down the cone tree */
-  struct ConeTreeNode *prev, *next;   /* pre-order walk     */
-} ConeTreeNode;
 
 /* pointer to root node of cone tree */
 static ConeTreeNode *cone_tree_root;
@@ -763,7 +755,7 @@ static void print_cone_tree(void)
 
 /* finds lowest-columned cone with some pixels >= column <col> */
 /* O(h) time */
-static ConeTreeNode *search_for_first(long col)
+ConeTreeNode *search_for_first(long col)
 {
   ConeTreeNode *root = cone_tree_root;
   ConeTreeNode *sofar = &end_anchor;  /* lowest-columned cone found so far */

--- a/clientd3d/drawbsp.c
+++ b/clientd3d/drawbsp.c
@@ -1488,13 +1488,13 @@ static Bool add_dn(DrawItem *item_template, long a, long b, long d, long col0, l
  * lie. These values are use to interpolate the height(s) at each endpoint
  * of a wall that bounds a sloped sector.
  */
-int world_to_screen(double x0, double y0, double x1, double y1,
+int world_to_screen(float x0, float y0, float x1, float y1,
 		    long *t0, long *t1, /* special parameters for sloped walls */
-		    long *col0, double *d0, long *col1, double *d1)
+          long *col0, float *d0, long *col1, float *d1)
 {
-  double left0,right0,left1,right1;
-  double x,y;
-  long t,tleft,tright;
+   float left0, right0, left1, right1;
+   float x, y;
+    long t,tleft,tright;
   
   /* go to viewer-relative coords */
   x0 -= viewer_x;
@@ -1512,9 +1512,9 @@ int world_to_screen(double x0, double y0, double x1, double y1,
   /* make sure left and right are not both zero.  If they are,   */
   /* move them to a point that maps to the center of the screen. */
   if (right0 <= 0.001 && right0 >= -0.001)
-     right0 = 1.0;
+     right0 = 1.0f;
   if (right1 <= 0.001 && right1 >= -0.001)
-     right1 = 1.0;
+     right1 = 1.0f;
   
   if (left0 < 0)
   {
@@ -2017,7 +2017,7 @@ Bool Bbox_shadowed(long x0, long y0, long x1, long y1)
 static void WalkWall(WallData *wall, long side)
 {
    long col0,col1;
-   double d0,d1;
+   float d0,d1;
    ConeTreeNode *c, *next;
    long toprow0,toprow1,botrow0,botrow1;
    long a,b,d;
@@ -2387,11 +2387,11 @@ static void WalkLeaf(BSPleaf *leaf)
 {
    long i;
    long col0,col1;
-   double d0, d1;
+   float d0, d1;
    long row0,row1;
    DrawItem item_template;
    long a,b,d;
-   long x0,y0,x1,y1;
+   float x0,y0,x1,y1;
    long t0,t1,height,height0,height1;
    SlopeData *sloped_floor = leaf->sector->sloped_floor;  // only a tiny bit faster but much easier to read
    SlopeData *sloped_ceiling = leaf->sector->sloped_ceiling;
@@ -2842,17 +2842,17 @@ void doDrawWall(DrawWallStruct *wall, ViewCone *c)
    long clipstart,clipend;
    long textpos;
    long a,b;
-   double d0,d1;
+   float d0,d1;
    long xoffset, yoffset;
    WallData *BSPwall = wall->wall;
    PDIB bmap;
    BYTE *bits, light;
    int backwards, transparent, bitmap_height, bitmap_width;
-   double x0, y0, x1, y1;
+   float x0, y0, x1, y1;
    long  num_steps, total_steps;
-   double d,f;
-   double z0, z1;
-   double oldf = 0.0;
+   float d, f;
+   float z0, z1;
+   float oldf = 0.0;
    BOOL hasMipMaps = FALSE;
    grid_bitmap_type grid = NULL;
    Animate *pAnim = NULL;
@@ -3090,9 +3090,9 @@ void doDrawWall(DrawWallStruct *wall, ViewCone *c)
       z1 = (a * x1 + b * y1) / FINENESS;
       
       if (z0 > 0)
-	 z0 = 0;
+	 z0 = 0.0f;
       if (z1 <= 0)
-	 z1 = 1;
+	 z1 = 1.0f;
 
       f = ((-z0) * (FINENESS * 4)) / (z1 - z0);
       if (f < oldf)
@@ -3102,7 +3102,7 @@ void doDrawWall(DrawWallStruct *wall, ViewCone *c)
       // Compute extent of wall on screen
       d = d0 + (((d1-d0)*f) / (FINENESS * 4));
       if (d <= 1.0)
-	d = 1.0;
+	d = 1.0f;
 
       rowstart = horizon + ((viewer_height - top) << LOG_VIEWER_DISTANCE) / d;
       rowend = horizon + ((viewer_height - bottom) << LOG_VIEWER_DISTANCE) / d;

--- a/clientd3d/drawbsp.h
+++ b/clientd3d/drawbsp.h
@@ -99,4 +99,13 @@ void DrawMiniMap(room_type *room, Draw3DParams *params); /* in Draw3d.h */
 void EnterNewRoom3D(room_type *room);
 Bool GetRoomHeightRad(BSPnode *tree, long *ceiling, long *floor, int *flags, int x, int y, long r);
 
+typedef struct ConeTreeNode
+{
+   ViewCone cone;
+   int height;           /* height of subtree rooted at node */
+   struct ConeTreeNode *parent;        /* up the cone tree   */
+   struct ConeTreeNode *left, *right;  /* down the cone tree */
+   struct ConeTreeNode *prev, *next;   /* pre-order walk     */
+} ConeTreeNode;
+ConeTreeNode *search_for_first(long col);
 #endif /* #ifndef _DRAWBSP_H */

--- a/clientd3d/effect.c
+++ b/clientd3d/effect.c
@@ -15,6 +15,8 @@
 
 Effects effects;
 
+extern Bool gD3DRedrawAll;
+
 static void EffectFlash(int duration);
 /****************************************************************************/
 /*
@@ -88,6 +90,7 @@ Bool PerformEffect(WORD effect, char *ptr, int len)
 
    case EFFECT_SEE:
       effects.blind = False;
+      gD3DRedrawAll |= D3DRENDER_REDRAW_ALL;
       RedrawAll();
       break;
 

--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -33,7 +33,7 @@ static Bool capture = False;  // True when graphics area has mouse capture
 static ID   drag_object;      // When capture = True, holds id of object being dragged
 static int fps;
 static int msDrawFrame;
-static long fpsDrawTime = 0;
+DWORD fpsDrawTime = 0;
 static int fpsCount = 0;
 static int msDrawFrameCount = 0;
 
@@ -352,8 +352,7 @@ void RedrawForce(void)
    if (1 > totalFrameTime)
 	   totalFrameTime = 1;
    fps = 1000 / (int)totalFrameTime;
-
-   if (timeGetTime() >= fpsDrawTime + 200)
+   if (timeGetTime() >= fpsDrawTime + 250)
    {
       fpsCount = fps;
       msDrawFrameCount = msDrawFrame;

--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -362,7 +362,7 @@ void RedrawForce(void)
    timeEndPeriod(1);
 
    // Try to redraw new graphics
-   gD3DRedrawAll |= D3DRENDER_REDRAW_ALL;
+   //gD3DRedrawAll |= D3DRENDER_REDRAW_ALL;
 
    if (config.showFPS)
    {

--- a/clientd3d/graphics.c
+++ b/clientd3d/graphics.c
@@ -33,6 +33,9 @@ static Bool capture = False;  // True when graphics area has mouse capture
 static ID   drag_object;      // When capture = True, holds id of object being dragged
 static int fps;
 static int msDrawFrame;
+static long fpsDrawTime = 0;
+static int fpsCount = 0;
+static int msDrawFrameCount = 0;
 
 // XXX This isn't currently used at all
 // # of pieces to divide graphics area horizontally & vertically for determining what
@@ -348,8 +351,15 @@ void RedrawForce(void)
    // if totalFrameTime is less than one, clamp to 1 so we don't divide by 0 or get negative fps
    if (1 > totalFrameTime)
 	   totalFrameTime = 1;
-
    fps = 1000 / (int)totalFrameTime;
+
+   if (timeGetTime() >= fpsDrawTime + 200)
+   {
+      fpsCount = fps;
+      msDrawFrameCount = msDrawFrame;
+      fpsDrawTime = timeGetTime();
+   }
+
    if (config.maxFPS)
    {
       if (fps > config.maxFPS)
@@ -367,14 +377,14 @@ void RedrawForce(void)
    if (config.showFPS)
    {
       RECT rc,lagBox;
-      wsprintf(buffer, "FPS=%d (%dms)        ", fps, msDrawFrame);
+      wsprintf(buffer, "FPS = %d (%dms)        ", fpsCount, msDrawFrameCount);
       ZeroMemory(&rc,sizeof(rc));
-      rc.bottom = DrawText(hdc,buffer,-1,&rc,DT_SINGLELINE|DT_CALCRECT);
+      rc.bottom = DrawText(hdc, buffer, -1, &rc, DT_SINGLELINE | DT_CALCRECT | DT_NOCLIP);
       Lagbox_GetRect(&lagBox);
       OffsetRect(&rc,lagBox.right + TOOLBAR_SEPARATOR_WIDTH,lagBox.top);
       DrawWindowBackground(hdc, &rc, rc.left, rc.top);
       oldMode = SetBkMode(hdc,TRANSPARENT);
-      DrawText(hdc,buffer,-1,&rc,DT_SINGLELINE);
+      DrawText(hdc, buffer, -1, &rc, DT_SINGLELINE | DT_NOCLIP);
       SetBkMode(hdc,oldMode);
       GdiFlush();
    }

--- a/clientd3d/maindlg.c
+++ b/clientd3d/maindlg.c
@@ -181,6 +181,7 @@ BOOL CALLBACK PreferencesDialogProc(HWND hDlg, UINT message, UINT wParam, LONG l
       CheckDlgButton(hDlg, IDC_SAFETY, config.aggressive);
       CheckDlgButton(hDlg, IDC_TEMPSAFE, config.tempsafe);
       CheckDlgButton(hDlg, IDC_GROUPING, config.grouping);
+      CheckDlgButton(hDlg, IDC_SHOWFPS, config.showFPS);
       CheckDlgButton(hDlg, IDC_BOUNCE, config.bounce);
       CheckDlgButton(hDlg, IDC_WEATHER, config.weather);
       CheckDlgButton(hDlg, IDC_TOOLBAR, config.toolbar);
@@ -266,6 +267,7 @@ BOOL CALLBACK PreferencesDialogProc(HWND hDlg, UINT message, UINT wParam, LONG l
          config.aggressive    = IsDlgButtonChecked(hDlg, IDC_SAFETY);
          config.tempsafe      = IsDlgButtonChecked(hDlg, IDC_TEMPSAFE);
          config.grouping      = IsDlgButtonChecked(hDlg, IDC_GROUPING);
+         config.showFPS       = IsDlgButtonChecked(hDlg, IDC_SHOWFPS);
          config.bounce        = IsDlgButtonChecked(hDlg, IDC_BOUNCE);
          config.weather       = IsDlgButtonChecked(hDlg, IDC_WEATHER);
          config.antiprofane   = IsDlgButtonChecked(hDlg, IDC_PROFANE);

--- a/clientd3d/move.c
+++ b/clientd3d/move.c
@@ -167,28 +167,28 @@ void UserMovePlayer(int action)
    if (player.viewID)
    {
       if (player.viewFlags & REMOTE_VIEW_CONTROL)
-	 return;
+         return;
       if (!(player.viewFlags & REMOTE_VIEW_MOVE))
-	 return;
+         return;
    }
    // Find out how far to move based on time elapsed:  always move at a rate of 
    // constant rate per MOVE_DELAY milliseconds.
    switch (action)
    {
-	case A_FORWARDFAST:
-	case A_BACKWARDFAST:
-	case A_SLIDELEFTFAST:
-	case A_SLIDERIGHTFAST:
-	case A_SLIDELEFTFORWARDFAST:
-	case A_SLIDERIGHTFORWARDFAST:
-	case A_SLIDELEFTBACKWARDFAST:
-	case A_SLIDERIGHTBACKWARDFAST:
-		move_distance = 2 * MOVEUNITS;
-	break;
+   case A_FORWARDFAST:
+   case A_BACKWARDFAST:
+   case A_SLIDELEFTFAST:
+   case A_SLIDERIGHTFAST:
+   case A_SLIDELEFTFORWARDFAST:
+   case A_SLIDERIGHTFORWARDFAST:
+   case A_SLIDELEFTBACKWARDFAST:
+   case A_SLIDERIGHTBACKWARDFAST:
+      move_distance = 2 * MOVEUNITS;
+   break;
 
-	default:
-		move_distance = MOVEUNITS;
-	break;
+   default:
+      move_distance = MOVEUNITS;
+   break;
    }
 
    now = timeGetTime();
@@ -238,25 +238,25 @@ void UserMovePlayer(int action)
       angle = (player.angle + 3 * NUMDEGREES / 4) % NUMDEGREES;  /* angle + 3pi/2 */
       break;
    case A_SLIDERIGHT:
-	case A_SLIDERIGHTFAST:
+   case A_SLIDERIGHTFAST:
       angle = (player.angle + NUMDEGREES / 4) % NUMDEGREES;  /* angle + pi/2 */
       break;
-	case A_SLIDELEFTFORWARD:
-	case A_SLIDELEFTFORWARDFAST:
-		angle = (player.angle + 7 * NUMDEGREES / 8) % NUMDEGREES;
-		break;
-	case A_SLIDELEFTBACKWARD:
-	case A_SLIDELEFTBACKWARDFAST:
-		angle = (player.angle + 5 * NUMDEGREES / 8) % NUMDEGREES;
-		break;
-	case A_SLIDERIGHTFORWARD:
-	case A_SLIDERIGHTFORWARDFAST:
-		angle = (player.angle + 1 * NUMDEGREES / 8) % NUMDEGREES;
-		break;
-	case A_SLIDERIGHTBACKWARD:
-	case A_SLIDERIGHTBACKWARDFAST:
-		angle = (player.angle + 3 * NUMDEGREES / 8) % NUMDEGREES;
-		break;
+   case A_SLIDELEFTFORWARD:
+   case A_SLIDELEFTFORWARDFAST:
+      angle = (player.angle + 7 * NUMDEGREES / 8) % NUMDEGREES;
+      break;
+   case A_SLIDELEFTBACKWARD:
+   case A_SLIDELEFTBACKWARDFAST:
+      angle = (player.angle + 5 * NUMDEGREES / 8) % NUMDEGREES;
+      break;
+   case A_SLIDERIGHTFORWARD:
+   case A_SLIDERIGHTFORWARDFAST:
+      angle = (player.angle + 1 * NUMDEGREES / 8) % NUMDEGREES;
+      break;
+   case A_SLIDERIGHTBACKWARD:
+   case A_SLIDERIGHTBACKWARDFAST:
+      angle = (player.angle + 3 * NUMDEGREES / 8) % NUMDEGREES;
+      break;
    default:
       debug(("Bad action type in UserMovePlayer\n"));
       return;
@@ -294,66 +294,68 @@ void UserMovePlayer(int action)
       leaf = BSPFindLeafByPoint(current_room.tree, x, y);
       if (leaf == NULL || leaf->sector == NULL)
       {
-	 x = last_x;
-	 y = last_y;
-	 z = last_z;
-	 break;
+         x = last_x;
+         y = last_y;
+         z = last_z;
+         break;
       }
 
       if (lastBlockingNode)
       {
-	 lastBlockingWall = IntersectNode(lastBlockingNode,last_x,last_y,x,y,z);
-	 if (lastBlockingWall)
-	 {
-	    SlideAlongWall(lastBlockingWall,last_x,last_y,&x,&y);
-	 }
-	 else
-	    lastBlockingNode = NULL;
+         lastBlockingWall = IntersectNode(lastBlockingNode,last_x,last_y,x,y,z);
+         if (lastBlockingWall)
+         {
+            SlideAlongWall(lastBlockingWall,last_x,last_y,&x,&y);
+         }
+         else
+            lastBlockingNode = NULL;
       }
       else
       {
-	 lastBlockingNode = FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall);
-	 if (lastBlockingNode)
-	 {
-	    SlideAlongWall(lastBlockingWall,last_x,last_y,&x,&y);
-	 }
+         lastBlockingNode = FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall);
+         if (lastBlockingNode)
+         {
+            SlideAlongWall(lastBlockingWall,last_x,last_y,&x,&y);
+         }
       }
       if (FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall))
       {
-	 SlideAlongWall(lastBlockingWall,last_x,last_y,&x,&y);
-	 if (FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall))
-	 {
-	    FindOffsets(MIN_SIDE_MOVE, (angle + 3 * NUMDEGREES / 4) % NUMDEGREES, &dx, &dy);
-	    x = last_x + dx;
-	    y = last_y + dy;
-	    if (FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall))
-	    {
-	       FindOffsets(MIN_SIDE_MOVE, (angle + NUMDEGREES / 4) % NUMDEGREES, &dx, &dy);
-	       x = last_x + dx;
-	       y = last_y + dy;
-	       if (FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall))
-	       {
-		  x = last_x;
-		  y = last_y;
-		  z = last_z;
-		  break;
-	       }
-	    }
-	 }
+         SlideAlongWall(lastBlockingWall,last_x,last_y,&x,&y);
+         if (FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall))
+         {
+            FindOffsets(MIN_SIDE_MOVE, (angle + 3 * NUMDEGREES / 4) % NUMDEGREES, &dx, &dy);
+            x = last_x + dx;
+            y = last_y + dy;
+            if (FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall))
+            {
+               FindOffsets(MIN_SIDE_MOVE, (angle + NUMDEGREES / 4) % NUMDEGREES, &dx, &dy);
+               x = last_x + dx;
+               y = last_y + dy;
+               if (FindIntersection(current_room.tree,last_x,last_y,x,y,z,&lastBlockingWall))
+               {
+                  x = last_x;
+                  y = last_y;
+                  z = last_z;
+                  break;
+               }
+            }
+         }
       }
-      
+
       // Don't try to slide to current location
       if (x == last_x && y == last_y)
-		  x = x;
+         x = x;
 //	 break;
       
       // Get around integer divide yuckiness
       if (y < 0)
-	 row = -1;
-      else row = y / FINENESS;
+         row = -1;
+      else
+         row = y / FINENESS;
       if (x < 0)
-	 col = -1;
-      else col = x / FINENESS;
+         col = -1;
+      else
+         col = x / FINENESS;
 
       // See if trying to move off room.
       if (!IsInRoom(row, col, current_room))
@@ -385,17 +387,17 @@ void UserMovePlayer(int action)
 
       if (retval == MOVE_BLOCKED)
       {
-	 //	 debug(("Move blocked by object\n"));
-	 x = last_x;
-	 y = last_y;
-	 z = last_z;
-	 bounce = False;
-	 break;
+         // debug(("Move blocked by object\n"));
+         x = last_x;
+         y = last_y;
+         z = last_z;
+         bounce = False;
+         break;
       }
       else if (retval == MOVE_CHANGED)
       {
-	 // Stop at this modified move
-	 break;
+         // Stop at this modified move
+         break;
       }
 
       last_x = x;
@@ -428,11 +430,11 @@ void UserMovePlayer(int action)
       // Only set motion if not already moving that direction
       if (z > player_obj->motion.z && player_obj->motion.v_z <= 0)
       {
-	 player_obj->motion.v_z = CLIMB_VELOCITY_0;
+         player_obj->motion.v_z = CLIMB_VELOCITY_0;
       }
       else if (z < player_obj->motion.z && player_obj->motion.v_z >= 0)
       {
-	 player_obj->motion.v_z = FALL_VELOCITY_0;
+         player_obj->motion.v_z = FALL_VELOCITY_0;
       }
    }
    else player_obj->motion.z = z;
@@ -494,10 +496,10 @@ BSPnode *FindIntersection(BSPnode *node, int xOld, int yOld, int xNew, int yNew,
       BSPinternal *inode = &node->u.internal;
       BSPnode *nodeIntersect = FindIntersection(inode->pos_side, xOld, yOld, xNew, yNew, z, wallIntersect);
       if (nodeIntersect)
-	 return nodeIntersect;
+         return nodeIntersect;
       nodeIntersect = FindIntersection(inode->neg_side, xOld, yOld, xNew, yNew, z, wallIntersect);
       if (nodeIntersect)
-	 return nodeIntersect;
+         return nodeIntersect;
       return NULL;
    }
 }
@@ -506,8 +508,7 @@ WallData *IntersectNode(BSPnode *node, int old_x, int old_y, int new_x, int new_
 {
    BSPinternal *inode;
    WallData *wall;
-   int a, b, c, plane_distance, old_distance;
-   int newDistance;
+   float a, b, c, plane_distance, old_distance, newDistance;
 
    if (node == NULL || node->type == BSPleaftype)
       return NULL;
@@ -527,7 +528,7 @@ WallData *IntersectNode(BSPnode *node, int old_x, int old_y, int new_x, int new_
    c = inode->separator.c;
    plane_distance = (a * new_x + b * new_y + c);
    old_distance = (a * old_x + b * old_y + c);
-   newDistance = ABS(plane_distance) >> LOG_FINENESS;
+   newDistance = ABS(plane_distance) / FINENESS;
    if ((newDistance > min_distance) || (ABS(plane_distance) > ABS(old_distance)))
       return NULL;
 
@@ -536,85 +537,86 @@ WallData *IntersectNode(BSPnode *node, int old_x, int old_y, int new_x, int new_
    {
       Sidedef *sidedef;
       Sector *other_sector;
-      int below_height, d0, d1, dx, dy, lenWall2;
-      int minx = min(wall->x0, wall->x1) - min_distance;
-      int maxx = max(wall->x0, wall->x1) + min_distance;
-      int miny = min(wall->y0, wall->y1) - min_distance;
-      int maxy = max(wall->y0, wall->y1) + min_distance;
-	 
+      int below_height;
+      float d0, d1, dx, dy, lenWall2;
+      float minx = min(wall->x0, wall->x1) - min_distance;
+      float maxx = max(wall->x0, wall->x1) + min_distance;
+      float miny = min(wall->y0, wall->y1) - min_distance;
+      float maxy = max(wall->y0, wall->y1) + min_distance;
+
       // See if we are near the wall itself, and not just the wall's plane
       if ((new_x >= minx) && (new_x <= maxx) && (new_y >= miny) && (new_y <= maxy))
       {
-	 // Skip floor->ceiling wall if player can walk through it
-	 if (SGN(old_distance) > 0)
-	 {
-	    sidedef = wall->pos_sidedef;
-	    other_sector = wall->neg_sector;
-	 }
-	 else
-	 {
-	    sidedef = wall->neg_sidedef;
-	    other_sector = wall->pos_sector;
-	 }
-	 if (sidedef == NULL)
-	    continue;
+         // Skip floor->ceiling wall if player can walk through it
+         if (SGNDOUBLE(old_distance) > 0)
+         {
+            sidedef = wall->pos_sidedef;
+            other_sector = wall->neg_sector;
+         }
+         else
+         {
+            sidedef = wall->neg_sidedef;
+            other_sector = wall->pos_sector;
+         }
+         if (sidedef == NULL)
+            continue;
 
-	 // Check for wading on far side of wall; reduce effective height of wall if found
-	 below_height = 0;
-	 if (other_sector != NULL)
-	    below_height = sector_depths[SectorDepth(other_sector->flags)];
+         // Check for wading on far side of wall; reduce effective height of wall if found
+         below_height = 0;
+         if (other_sector != NULL)
+            below_height = sector_depths[SectorDepth(other_sector->flags)];
 
-	 // Can't step up too far; watch bumping your head; see if passable
-	 if ((sidedef->below_bmap == NULL || 
-		 (sidedef->below_bmap != NULL && 
-	       (wall->z1 - below_height - z) <= MAX_STEP_HEIGHT))
-		&&
-		(sidedef->above_bmap == NULL || 
-		 (sidedef->above_bmap != NULL && wall->z2 - z >= player.height)) 
-		&&
-		(sidedef->flags & WF_PASSABLE))
-	    continue;
+         // Can't step up too far; watch bumping your head; see if passable
+         if ((sidedef->below_bmap == NULL || 
+            (sidedef->below_bmap != NULL && 
+            (wall->z1 - below_height - z) <= MAX_STEP_HEIGHT))
+            &&
+            (sidedef->above_bmap == NULL || 
+            (sidedef->above_bmap != NULL && wall->z2 - z >= player.height)) 
+            &&
+            (sidedef->flags & WF_PASSABLE))
+            continue;
 
-	 // If distance to either vertex is > wall length, then destination of move is
-	 // past end of wall; use distance to closer vertex as distance to line
-	 dx = new_x - wall->x0;
-	 dy = new_y - wall->y0;
-	 d0 = dx * dx + dy * dy;
+         // If distance to either vertex is > wall length, then destination of move is
+         // past end of wall; use distance to closer vertex as distance to line
+         dx = new_x - wall->x0;
+         dy = new_y - wall->y0;
+         d0 = dx * dx + dy * dy;
 
-	 dx = new_x - wall->x1;
-	 dy = new_y - wall->y1;
-	 d1 = dx * dx + dy * dy;
+         dx = new_x - wall->x1;
+         dy = new_y - wall->y1;
+         d1 = dx * dx + dy * dy;
 
-	 // Recheck distance to wall based on distance to closest vertex
-	 //len = FinenessKodToClient(wall->length);
-	 //lenWall2 = len * len;
-	 dx = wall->x1 - wall->x0;
-	 dy = wall->y1 - wall->y0;
-	 lenWall2 = dx * dx + dy * dy;
-	 if (d0 > lenWall2) // d1 is closest vertex
-	 {
-	    int dx = old_x - wall->x1;
-	    int dy = old_y - wall->y1;
-	    int oldEndDist = dx * dx + dy * dy;
-	    if ((d1 < min_distance2) && (d1 <= oldEndDist))
-	    {
-	       return wall;
-	    }
-	 }
-	 else if (d1 > lenWall2) // d0 is closest vertex
-	 {
-	    int dx = old_x - wall->x0;
-	    int dy = old_y - wall->y0;
-	    int oldEndDist = dx * dx + dy * dy;
-	    if ((d0 < min_distance2) && (d0 <= oldEndDist))
-	    {
-	       return wall;
-	    }
-	 }
-	 else // within wall range!
-	 {
-	    return wall;
-	 }
+         // Recheck distance to wall based on distance to closest vertex
+         //len = FinenessKodToClient(wall->length);
+         //lenWall2 = len * len;
+         dx = wall->x1 - wall->x0;
+         dy = wall->y1 - wall->y0;
+         lenWall2 = dx * dx + dy * dy;
+         if (d0 > lenWall2) // d1 is closest vertex
+         {
+            float dx = old_x - wall->x1;
+            float dy = old_y - wall->y1;
+            float oldEndDist = dx * dx + dy * dy;
+            if ((d1 < min_distance2) && (d1 <= oldEndDist))
+            {
+               return wall;
+            }
+         }
+         else if (d1 > lenWall2) // d0 is closest vertex
+         {
+            float dx = old_x - wall->x0;
+            float dy = old_y - wall->y0;
+            float oldEndDist = dx * dx + dy * dy;
+            if ((d0 < min_distance2) && (d0 <= oldEndDist))
+            {
+               return wall;
+            }
+         }
+         else // within wall range!
+         {
+            return wall;
+         }
       }
    }
    return NULL;
@@ -937,19 +939,19 @@ void UserTurnPlayer(int action)
    if (player.viewID)
    {
       if (!(player.viewFlags & REMOTE_VIEW_TURN))
-	 return;
+         return;
       if (player.viewFlags & REMOTE_VIEW_CONTROL)
       {
-	 room_contents_node *viewObject = GetRoomObjectById(player.viewID);
-	 if (viewObject)
-	 {
-	    viewObject->angle += delta;
-	    if (viewObject->angle < 0)
-	       viewObject->angle += NUMDEGREES;
-	    viewObject->angle = viewObject->angle % NUMDEGREES;
-	    RedrawAll();
-	    return;
-	 }
+         room_contents_node *viewObject = GetRoomObjectById(player.viewID);
+         if (viewObject)
+         {
+            viewObject->angle += delta;
+            if (viewObject->angle < 0)
+               viewObject->angle += NUMDEGREES;
+            viewObject->angle = viewObject->angle % NUMDEGREES;
+            RedrawAll();
+            return;
+         }
       }
    }
 
@@ -973,19 +975,19 @@ void UserTurnPlayerMouse(int delta)
    if (player.viewID)
    {
       if (!(player.viewFlags & REMOTE_VIEW_TURN))
-	 return;
+         return;
       if (player.viewFlags & REMOTE_VIEW_CONTROL)
       {
-	 room_contents_node *viewObject = GetRoomObjectById(player.viewID);
-	 if (viewObject)
-	 {
-	    viewObject->angle += delta;
-	    if (viewObject->angle < 0)
-	       viewObject->angle += NUMDEGREES;
-	    viewObject->angle = viewObject->angle % NUMDEGREES;
-	    RedrawAll();
-	    return;
-	 }
+         room_contents_node *viewObject = GetRoomObjectById(player.viewID);
+         if (viewObject)
+         {
+            viewObject->angle += delta;
+            if (viewObject->angle < 0)
+               viewObject->angle += NUMDEGREES;
+            viewObject->angle = viewObject->angle % NUMDEGREES;
+            RedrawAll();
+            return;
+         }
       }
    }
 
@@ -1008,17 +1010,17 @@ void UserFlipPlayer(void)
    if (player.viewID)
    {
       if (!(player.viewFlags & REMOTE_VIEW_TURN))
-	 return;
+         return;
       if (player.viewFlags & REMOTE_VIEW_CONTROL)
       {
-	 room_contents_node *viewObject = GetRoomObjectById(player.viewID);
-	 if (viewObject)
-	 {
-	    viewObject->angle += NUMDEGREES / 2;
-	    viewObject->angle = viewObject->angle % NUMDEGREES;
-	    RedrawAll();
-	    return;
-	 }
+         room_contents_node *viewObject = GetRoomObjectById(player.viewID);
+         if (viewObject)
+         {
+            viewObject->angle += NUMDEGREES / 2;
+            viewObject->angle = viewObject->angle % NUMDEGREES;
+            RedrawAll();
+            return;
+         }
       }
    }
 
@@ -1028,7 +1030,6 @@ void UserFlipPlayer(void)
    MoveUpdateServer();
    RedrawAll();
 }
-
 
 // Move at most HEIGHT_INCREMENT per HEIGHT_DELAY milliseconds
 #define HEIGHT_INCREMENT (MAXY / 4)    
@@ -1050,7 +1051,8 @@ void BounceUser(int dt)
      bounce_time += ((float) dt) / MOVE_DELAY;  /* In radians */
      bounce_height = (long) (BOUNCE_HEIGHT * sin(bounce_time));
    }
-   else bounce_height = 0;
+   else
+      bounce_height = 0;
 }
 /************************************************************************/
 /*

--- a/clientd3d/resource.h
+++ b/clientd3d/resource.h
@@ -402,6 +402,7 @@
 #define IDC_WEATHER                     1208
 #define IDC_TEMPSAFE                    1209
 #define IDC_GROUPING                    1210
+#define IDC_SHOWFPS                     1211
 #define ID_GAME_EXIT                    3002
 #define ID_FONT_MAIL                    3014
 #define ID_FONT_LIST                    3015
@@ -465,7 +466,7 @@
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        191
 #define _APS_NEXT_COMMAND_VALUE         3517
-#define _APS_NEXT_CONTROL_VALUE         1211
+#define _APS_NEXT_CONTROL_VALUE         1212
 #define _APS_NEXT_SYMED_VALUE           105
 #endif
 #endif


### PR DESCRIPTION
Load room data as floats instead of integers, use in calculations for higher accuracy. I don't think there's much benefit to having the extra precision in software mode, but I have converted it for now anyway.

Fixes slope errors (gaps) and 99% of polygon cracks (i.e. wireframes).

The D3D header edits are to clean up compiler warnings (I'm not sure why they wrote the defines that way, I can't see a purpose to it as opposed to just defining).

Wireframe is on for now, as there are still a few stray sky pixels being drawn between polygons (interestingly, not on sloped surfaces).

Added FPS counter option to client preferences menu (English and German). Shows a text FPS ticker next to the lagbox. Code for FPS counter was already present, but not available outside of debug mode. FPS counter updates every 250ms.

Added an IsHidden() function to d3drender.c based on Bbox_shadowed() from drawbsp.c. Returns TRUE if the player cannot see the box outlined by the given coordinates.

Particle system change - particles not added to rendering pipeline if the user cannot see them (uses IsHidden()). Increased the amount of snow emitters from 48 to 54.

Refactored the D3D systems for lighting and calculating wall/floor/ceiling data. Calculations are now done once at the start of each frame by D3DFillTreeData() or D3DFillTreeDataTraversal() and stored in each BSPnode or WallData, and this data is used in place of calling D3DRenderFloorExtract/WallExtract/CeilingExtract. These new functions can be passed a parameter which determines whether to process the entire tree or not (the initial calculation of static light maps requires the entire tree pre-calculated). 

When checking nodes for generating the static light maps, nodes that aren't lit up by the given light are not processed (cutting down the amount of polys added to that rendering system).

Dynamic light maps and static light map changes (i.e. animated sectors/walls) are now processed by traversing the tree for each light, but culling the nodes that aren't lit up by the light. In addition, nodes aren't processed at all if they are outside the view frustum. The limit for lights to draw was raised to 150.

Added draw booleans to the BSPNode and WallData structs to determine whether to draw something in the D3D code. Added the code to d3drender.c to use these, but have not implemented it yet as the old code in drawbsp.c isn't accurate enough to determine with certainty whether to draw something or not (it errs on the side of *not* drawing, so would leave gaps in the world). Using these will eventually reduce the amount of geometry sent down the rendering pipeline to eventually be discarded by the graphics card, which is the single biggest cause of FPS drop remaining.

Objects with transparency effects are now rendered in a separate pass done after all other objects are rendered. This fixes the issue where objects behind another transparent object (e.g. trees or players behind fog) were not being rendered correctly or at all. There are still issues remaining with drawing a transparent object behind another transparent object.

Increased the maximum amount of memory allocated by a factor of two, to deal with excessively large .bgf files (e.g. minotaur). These appear to use far more memory than they should, and the entire .bmp/pDib loading/cache process probably needs attention. I suspect this fix will also take care of some of the random crashes occurring for some people.