### PR TITLE
Fix players with < 10 vigor not being able to change rooms.

### DIFF
--- a/clientd3d/move.c
+++ b/clientd3d/move.c
@@ -361,7 +361,9 @@ void UserMovePlayer(int action)
          // Delay between consecutive attempts to move off room
          if (now - move_off_room_time >= MOVE_OFF_ROOM_INTERVAL) // current time 
          {
-            RequestMove(y, x, USER_RUNNING_SPEED, player.room_id);
+            // Need to send walking speed for room change, otherwise room
+            // changes by players with vigor < 10 will be blocked.
+            RequestMove(y, x, USER_WALKING_SPEED, player.room_id);
             move_off_room_time = now;
          }
          // Don't actually move player off room


### PR DESCRIPTION
Previous change to fix possible vigor exploits left players with under 10 vigor sometimes unable to change rooms, as it was being caught by the 'run with no vigor' code on the server.

Still not entirely happy with how this is all calculated on the server - it really should be calculating speed itself based on how the user is moving. Currently it forces the client to send a sane value if they wish to keep moving, but I think we could improve this.

@cyberjunk you'll probably need to change this in Ogre client too.