### PR TITLE
Run patcher locally when updating before attempting to download it again.

### DIFF
--- a/clientd3d/client.rc
+++ b/clientd3d/client.rc
@@ -1673,7 +1673,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_CANTUPDATE          "Unable to run %s, the program that updates your copy of Meridian 59.\nPlease report the problem to a system administrator."
+    IDS_CANTUPDATE          "Unable to run the patcher to update Meridian 59.\nPlease contact the admins at http://openmeridian.org/forums."
     IDS_NEEDNEWVERSION      "You need to get an updated version of Meridian 59.\nDo you want to retrieve it automatically now?"
     IDS_CANTMOVE            "Can't move the downloaded file %s to %s.\n\nTry again?"
     IDS_LONGCMDLINE         "The automatic update program will fail because its command line is too long.\nPlease report the following command line:\n\n%s"


### PR DESCRIPTION
The client will now attempt to run the patcher from the default location (..\Start Menu\Programs\OpenMeridian\) when updating and if that fails, it will attempt to download it from the homepage. If that fails, the user now gets a message to contact us at the forums.