### PR TITLE
Rewrite missing m59bind.exe error message, fix inventory scrollbar drawing. Extend player viewing range.

### DIFF
--- a/blakcomp/actions.c
+++ b/blakcomp/actions.c
@@ -42,7 +42,7 @@ void initialize_parser(void)
       id->type = I_FUNCTION;
       id->idnum = i;  /* For functions, idnum is just index in table, not a real id # */
       if (table_insert(st.globalvars, (void *) id, id_hash, id_compare) != 0)
-	 simple_error("Duplicate built-in function name %s", id->name);
+         simple_error("Duplicate built-in function name %s", id->name);
    }
 
    /* Add builtin identifiers to appropriate symbol tables */
@@ -50,18 +50,18 @@ void initialize_parser(void)
       switch (BuiltinIds[i].type)
       {
       case I_MISSING:
-	 if (table_insert(st.missingvars, (void *) &BuiltinIds[i], id_hash, id_compare) != 0)
-	    simple_error("Duplicate builtin identifier name %s", BuiltinIds[i].name);
-	 break;
+         if (table_insert(st.missingvars, (void *) &BuiltinIds[i], id_hash, id_compare) != 0)
+            simple_error("Duplicate builtin identifier name %s", BuiltinIds[i].name);
+         break;
 
       case I_PROPERTY:
-	 if (table_insert(st.globalvars, (void *) &BuiltinIds[i], id_hash, id_compare) != 0)
-	    simple_error("Duplicate builtin identifier name %s", BuiltinIds[i].name);
-	 break;
+         if (table_insert(st.globalvars, (void *) &BuiltinIds[i], id_hash, id_compare) != 0)
+            simple_error("Duplicate builtin identifier name %s", BuiltinIds[i].name);
+         break;
 
       default:
-	 simple_error("Bad type on builtin identifier %s", BuiltinIds[i].name);
-	 break;
+         simple_error("Bad type on builtin identifier %s", BuiltinIds[i].name);
+         break;
       }
 
    st.maxid = IDBASE; /* Base for user-defined ids; builtins have lower #s */
@@ -76,6 +76,7 @@ void initialize_parser(void)
    st.recompile_list = NULL;
    st.constants = NULL;
    st.num_strings = 0;
+   st.strings = NULL;
    st.override_classvars = NULL;
 }
 /************************************************************************/

--- a/blakcomp/blakcomp.l
+++ b/blakcomp/blakcomp.l
@@ -525,13 +525,16 @@ int main(int argc, char **argv)
       
 
    for (current_file_ptr = file_list; current_file_ptr != NULL; 
-	current_file_ptr = current_file_ptr->next)
+      current_file_ptr = current_file_ptr->next)
    {
+      // Reset per-file counts
       include_depth = 0;
+      st.num_strings = 0;
+      st.strings = NULL;
 
       include_stack[0].file_ptr = open_file( (char *) current_file_ptr->data);
       include_stack[0].buffer = yy_create_buffer(include_stack[0].file_ptr, 
-						 YY_BUF_SIZE);
+                                                   YY_BUF_SIZE);
       include_stack[0].filename = current_fname;
       yy_switch_to_buffer(include_stack[0].buffer);
 /*
@@ -545,7 +548,7 @@ int main(int argc, char **argv)
 /*      yy_delete_buffer(include_stack[0].buffer); */
 
       if (generate_code) 
-	 codegen(current_fname, bof_fname); 
+         codegen(current_fname, bof_fname); 
       generate_code = True;
    }
 

--- a/blakcomp/codegen.c
+++ b/blakcomp/codegen.c
@@ -901,12 +901,12 @@ void codegen(char *kod_fname, char *bof_fname)
       endpos = FileCurPos(outfile);
       FileGoto(outfile, debugpos); 
       if (debug_bof)
-	 OutputInt(outfile, endpos);
+         OutputInt(outfile, endpos);
       else OutputInt(outfile, 0);
 
       FileGotoEnd(outfile);
       if (debug_bof)
-	 codegen_debug_info();
+         codegen_debug_info();
 
       /* Backpatch location of kod filename */
       endpos = FileCurPos(outfile);

--- a/blakserv/kodbase.c
+++ b/blakserv/kodbase.c
@@ -161,7 +161,8 @@ void LoadKodbaseProperty(char *prop_name,int property_id)
 {
    if (current_class == NULL)
    {
-      eprintf("LoadKodbaseProperty has no current class\n");
+      eprintf("LoadKodbaseProperty has no current class (%s:%d)\n",
+         prop_name, property_id);
       return;
    }
 
@@ -180,7 +181,8 @@ void LoadKodbaseClassVariable(char *classvar_name,int classvar_id)
 
    if (current_class == NULL)
    {
-      eprintf("LoadKodbaseClassVariable has no current class\n");
+      eprintf("LoadKodbaseClassVariable has no current class (%s:%d)\n",
+         classvar_name, classvar_id);
       return;
    }
 

--- a/clientd3d/client.rc
+++ b/clientd3d/client.rc
@@ -1589,7 +1589,7 @@ BEGIN
     IDS_CONFIGMENUEXE       "m59bind.exe"
     IDS_CANTDELETEFILE      "Can't delete the file %s.\n\nTry again?"
     IDS_CANTWRITEFILE       "Can't write to file %s."
-    IDS_NOCONFIGMENUEXE     "Configuration menu not found!  Please uninstall and reinstall Meridian 59"
+    IDS_NOCONFIGMENUEXE     "Configuration menu not found!  Try restarting the client, patching to verify m59bind.exe is present or contact an administrator."
     IDS_CONNECTERROR        "Couldn't connect to server!"
     IDS_BADLOGIN            "Incorrect username or password."
     IDS_NOTIMERS            "All Windows timers are currently in use.\nClose some applications and try again."

--- a/clientd3d/d3drender.c
+++ b/clientd3d/d3drender.c
@@ -15,7 +15,7 @@
 #define	TEX_CACHE_MAX_PARTICLE	1000000
 #define FOV_H					((gD3DRect.right - gD3DRect.left) / (float)(MAXX * stretchfactor) * (-PI / 3.6f))
 #define FOV_V					((gD3DRect.bottom - gD3DRect.top) / (float)(MAXY * stretchfactor) * (PI / 6.0f))
-#define Z_RANGE					(200000.0f)
+#define Z_RANGE					(400000.0f)
 
 d3d_render_packet_new	*gpPacket;
 

--- a/module/merintr/inventry.c
+++ b/module/merintr/inventry.c
@@ -196,6 +196,7 @@ void InventoryBoxCreate(HWND hParent)
 
    InventoryResetFont();
    InventoryChangeColor();
+   InventoryDisplayScrollbar();
 }
 /************************************************************************/
 /*


### PR DESCRIPTION
This is telling users to reinstall the whole client, when the error is just m59bind.exe missing or unable to be opened. Seems a little overkill (especially now that we have the patcher).

Fixed the inventory scrollbar not always drawing correctly.

Fixed view range issues on very large (future) screens. Currently the view limit is ~190 row/col units, this change raises it to ~380 (i.e. further than we'll likely ever need).

Added some small fixes from the original repo.