### PR TITLE
Client crash fixes, lupogg king stuck-in-one-place fix.

### DIFF
--- a/clientd3d/client.h
+++ b/clientd3d/client.h
@@ -48,7 +48,7 @@ typedef unsigned char Bool;
 enum {False = 0, True = 1};
 
 #define MAJOR_REV 50   /* Major version of client program */
-#define MINOR_REV 27  /* Minor version of client program; must be in [0, 99] */
+#define MINOR_REV 28  /* Minor version of client program; must be in [0, 99] */
 
 #define MAXAMOUNT 9     /* Max # of digits in a server integer */
 #define MAXSTRINGLEN 512 /* Max length of a string loaded from string table */

--- a/clientd3d/drawbsp.c
+++ b/clientd3d/drawbsp.c
@@ -159,7 +159,7 @@ static Bool AddObject(BSPnode *tree, ObjectData *object)
    {
       if (tree == NULL)
       {
-	 debug(("add_object got NULL tree for object %d!\n", object->draw.id));
+	 //debug(("add_object got NULL tree for object %d!\n", object->draw.id));
 	 object->parent = NULL;
 	 return False;
       }
@@ -1068,6 +1068,8 @@ static Bool add_up(DrawItem *item_template, long a, long b, long d, long col0, l
   Bool additem = item_template->type != DrawBackgroundType || incremental_background;
   
   blakassert(col1 < MAXX);
+  if (col1 >= MAXX)
+     col1 = MAXX - 1;
   for(c = search_for_first(col0); c->cone.leftedge <= col1; c = next)
     {
       next = c->next;  /* get next pointer now, before we munge c */
@@ -1279,6 +1281,9 @@ static Bool add_dn(DrawItem *item_template, long a, long b, long d, long col0, l
   Bool additem = item_template->type != DrawBackgroundType || incremental_background;
   
   blakassert(col1 < MAXX);
+
+  if (col1 >= MAXX)
+     col1 = MAXX-1;
   for(c = search_for_first(col0); c->cone.leftedge <= col1; c = next)
     {
       next = c->next;  /* get next pointer now, before we munge c */
@@ -1503,9 +1508,9 @@ int world_to_screen(float x0, float y0, float x1, float y1,
   
   /* make sure left and right are not both zero.  If they are,   */
   /* move them to a point that maps to the center of the screen. */
-  if (right0 <= 0.001 && right0 >= -0.001)
+  if (right0 < 1.0f && right0 >= -1.0f)
      right0 = 1.0f;
-  if (right1 <= 0.001 && right1 >= -0.001)
+  if (right1 < 1.0f && right1 >= -1.0f)
      right1 = 1.0f;
   
   if (left0 < 0)
@@ -2216,6 +2221,8 @@ static void WalkWall(WallData *wall, long side)
       // flag it for drawing.
       wall->drawnormal = TRUE;
      blakassert(col1 < MAXX);
+     if (col1 >= MAXX)
+        col1 = MAXX - 1;
      for(c = search_for_first(col0); c->cone.leftedge <= col1; c = next)
      {
 	    next = c->next;
@@ -3993,7 +4000,7 @@ static void doDrawBackground(ViewCone *c)
    long mincol,maxcol;
    long row,col;
    long width,height;
-   BYTE *bkgnd_bmap, *bkgnd_ptr;
+   BYTE *bkgnd_bmap = NULL, *bkgnd_ptr;
    long length;
    long xoffset;
    list_type l;

--- a/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
@@ -399,7 +399,8 @@ messages:
          if NOT Send(self,@CanReach,#what=poTarget) 
          {
             Send(self,@MonsterCastAttackSpell);
-            Send(poBrain,@PostAttackTimer,#mob=self,#state=piState);
+            Send(self,@EnterStateChase,#Target=poTarget);
+            %Send(poBrain,@PostAttackTimer,#mob=self,#state=piState);
 
             return;
          }


### PR DESCRIPTION
Some players are experiencing rare crashes with the upgraded client due to some calculations no longer being rounded to zero. This will fix those issues by replicating the rounding as before, and some checks have been added to prevent crashes if for some reason this still fails at some point (this is some of the older code in the client software renderer). Commented out a debug line that causes a lot of spam in the debug window (looking into it) and added a fix from the VS branch (variable initialisation).

Also added a fix for the lupogg king not-moving issue, where he gets stuck in a loop trying to cast hold on players he can't see.