### PR TITLE
Check for valid Brain in Lupogg King PostAttackTimer, fix CanSee row/col checks.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/lupking.kod
@@ -409,14 +409,17 @@ messages:
       if NOT Send(poTarget,@IsEnchanted,#what=oSpell)
          AND iRandom = 1
       {
-         Send(self,@MonsterCastAttackSpell); 
+         Send(self,@MonsterCastAttackSpell);
       }
       else
       {
-         Send(self,@TryAttack,#what=poTarget); 
+         Send(self,@TryAttack,#what=poTarget);
       }
 
-      Send(poBrain,@PostAttackTimer,#mob=self,#state=piState);
+      if poBrain <> $
+      {
+         Send(poBrain,@PostAttackTimer,#mob=self,#state=piState);
+      }
 
       return;
    }
@@ -446,7 +449,7 @@ messages:
          iRow = Send(what,@GetRow);
          iCol = Send(what,@GetCol);
 
-         if iRow > 18 and iCol > 43
+         if iRow > 18 OR iCol > 43 OR iCol < 24
          {
             return FALSE;
          }


### PR DESCRIPTION
Check for valid Brain before sending PostAttackTimer, sometimes Lupogg King dies while he's going through all the cast spell/attack code.

Also fix up the bad logic in the CanSee override, and add the Jasper Sewers part of Lair that he can't see.