### PR TITLE
Set spectral mummy karma to 0. Add system setting for initial homeroom (default RID_NEWB1).

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/specmum.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/specmum.kod
@@ -51,7 +51,7 @@ classvars:
    viLevel = 40
    viDifficulty = 5
    viVisionDistance = 8
-   viKarma = -35
+   viKarma = 0
    vbIsUndead = TRUE
    viDefault_behavior = AI_FIGHT_AGGRESSIVE | AI_MOVE_FLEE_FRIGHTENERS
    viCashmin = 120

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -8478,11 +8478,12 @@ messages:
 
    SetInitialHomeroom()
    {
-      piHomeroom = RID_NEWB1;
-      
+      % Get initial Homeroom from system settings.
+      piHomeroom = Send(Send(SYS,@GetSettings),@GetInitialRoomID);
+
       return;
    }
-   
+
    SetRandomHomeroom()
    "This sets one of the many hometowns to be the initial hometown."
    {
@@ -8704,9 +8705,10 @@ messages:
    TeleportToInitialLocation()
    "Assertion:  you are NOT logged on"
    {
-      local oRoom;
+      local iInitialRoomID, oRoom;
 
-      oRoom = Send(SYS,@FindRoomByNum,#num=Send(self,@GetInitialRoomID));
+      iInitialRoomID = Send(Send(SYS,@GetSettings),@GetInitialRoomID);
+      oRoom = Send(SYS,@FindRoomByNum,#num=iInitialRoomID);
 
       if oRoom = $
       {
@@ -8729,11 +8731,6 @@ messages:
       }
 
       return;
-   }
-
-   GetInitialRoomID()
-   {
-      return RID_NEWB1;
    }
 
    TeleportTo(RID = RID_TOS,foyer=TRUE,bAdminPort=TRUE)

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -142,6 +142,9 @@ properties:
    % Miscellaneous
    %
 
+   % Set map where players start in.
+   piInitialRoomID = RID_NEWB1
+
    % Enables or disables some safe-spots, see blakston.khd comments.
    piLOSSkip = LOS_SKIP_1
 
@@ -432,6 +435,11 @@ messages:
    %
    % Miscellaneous
    %
+
+   GetInitialRoomID()
+   {
+      return piInitialRoomID;
+   }
 
    GetLOSSkip()
    {


### PR DESCRIPTION
Player requested. Change spectral mummy karma to 0, so players don't change karma when killing them. This is live already on 103, but this pull request will change the value in kod.

Forum thread: http://openmeridian.org/forums/index.php/topic,518.0.html

Added Taran's initial homeroom system setting from #721