### PR TITLE
Fix WA_SPELLCASTER weapon attribute only spawning MoD on weapons. 

### DIFF
--- a/kod/object/item/passitem/weapon.kod
+++ b/kod/object/item/passitem/weapon.kod
@@ -1178,5 +1178,42 @@ messages:
       return TRUE;
    }
 
+   FixSpellItemAtts()
+   "Swaps spell objects in WA_SPELLCASTER weapons for the SID. "
+   "Essentially it just removes and readds the enchantment."
+   {
+      local i, oAttribute, oSpell;
+
+      if Send(self,@HasAttribute,#itematt=WA_SPELLCASTER)
+      {
+         oAttribute = Send(SYS,@FindItemAttByNum,#num=WA_SPELLCASTER);
+         oSpell = $;
+
+         for i in plItem_Attributes
+         {
+            if Send(self,@GetNumFromCompound,#compound=First(i)) = WA_SPELLCASTER
+            {
+               oSpell = Nth(i,2);
+               break;
+            }
+         }
+
+         if oSpell = $
+         {
+            Debug("$ spell found when fixing WA_SPELLCASTER itematts!",
+                  " object is ",self);
+
+            return;
+         }
+
+         Send(oAttribute,@RemoveFromItem,#oItem=self);
+         Send(oAttribute,@AddToItem,#oItem=self,
+               #spellNum=Send(oSpell,@GetSpellNum),#random_gen=TRUE);
+         Debug("readded enchantment to ",self);
+      }
+
+      return;
+   }
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/itematt/weapatt/waspell.kod
+++ b/kod/object/passive/itematt/weapatt/waspell.kod
@@ -48,6 +48,7 @@ properties:
 
    piValue_modifier = 150   %% modify the object's price by 100%
    piValue_power_modifier = 10
+   piEffect_percent = 15
 
    plSpells = $
 
@@ -82,7 +83,7 @@ messages:
          return damage;
       }
 
-      if (Random(1,100) <= ((100-Nth(lData,3))/10))
+      if Random(1,100) <= piEffect_percent
          AND Send(wielder,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
       {
          oSpell = Send(SYS,@FindSpellByNum,#num=Nth(lData,2));

--- a/kod/object/passive/itematt/weapatt/waspell.kod
+++ b/kod/object/passive/itematt/weapatt/waspell.kod
@@ -27,12 +27,15 @@ constants:
 resources:
 
    WeapAttSpellCaster_desc = " Mystical energy flits about this weapon."
+   WeapAttSpellCaster_desc2 = " This weapon will cast the "
+   WeapAttSpellCaster_desc3 = " spell on your target."
    WeapAttSpellCaster_dm = "spellcaster"
 
 classvars:
 
    vrDesc = WeapAttSpellCaster_desc
-   vrDesc2 = $
+   vrDesc2 = WeapAttSpellCaster_desc2
+   vrDesc3 = WeapAttSpellCaster_desc3
 
    viItem_Att_Num = WA_SPELLCASTER
 
@@ -48,17 +51,16 @@ properties:
 
 messages:
 
-Constructor()
-{
-   plSpells = [ [SID_DEMENT, 12], [SID_ENFEEBLE, 13],
-                [SID_VERTIGO, 13], [SID_SWAP, 12],
-                [SID_INVISIBILITY, 12], [SID_FORGET, 13],
-                [SID_EVIL_TWIN, 12], [SID_MARK_OF_DISHONOR, 13]
-              ];
-              
-   propagate;
-}
+   Constructor()
+   {
+      % Used to have swap and invisibility here.
+      plSpells = [ [SID_DEMENT, 17], [SID_ENFEEBLE, 16],
+                   [SID_VERTIGO, 16], [SID_FORGET, 16],
+                   [SID_EVIL_TWIN, 16], [SID_MARK_OF_DISHONOR, 17]
+                 ];
 
+      propagate;
+   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
@@ -80,7 +82,7 @@ Constructor()
       if (Random(1,100) <= ((100-Nth(lData,3))/10))
          AND Send(wielder,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
       {
-         oSpell = Nth(lData,2);
+         oSpell = Send(SYS,@FindSpellByNum,#num=Nth(lData,2));
          if Send(oSpell,@CanPayCosts,#who=self,#ltargets=[target],
                #ispellpower=Nth(lData,3))
          {
@@ -118,9 +120,9 @@ Constructor()
       iSpell = 0;
       for i in plSpells
       {
-         if StringContain(string,Send(Send(SYS,@FindSpellByNum,#num=first(i)),@GetName))
+         if StringContain(string,Send(Send(SYS,@FindSpellByNum,#num=First(i)),@GetName))
          {
-            iSpell = first(i);
+            iSpell = First(i);
          }
       }
 
@@ -133,8 +135,7 @@ Constructor()
       {
          Debug("Adding to item");
 
-         Send(self,@AddToItem,#oItem=oWeapon, #spellNum = iSpell,
-              #random_gen=TRUE);
+         Send(self,@AddToItem,#oItem=oWeapon,#spellNum=iSpell,#random_gen=TRUE);
 
          return TRUE;
       }
@@ -144,26 +145,28 @@ Constructor()
       return FALSE;
    }
 
-   AddToItem(oItem=$,spellNum=$,oPlayer=$,identified=false)
+   AddToItem(oItem=$,spellNum=$,oPlayer=$,identified=FALSE)
    {
       local lData, iValue, i;
 
       lData = $;
 
-      %spellpower
+      % Spellpower.
       lData = Cons(Random(30,60),lData);
 
-      %spell
+      % Spell.
       if spellNum = $
       {
          iValue = Random(1,100);
-         spellNum = first(first(plSpells));
+         spellNum = First(First(plSpells));
 
          for i in plSpells
          {
             if iValue <= Nth(i,2)
             {
                spellNum = Nth(i,1);
+
+               break;
             }
             else
             {
@@ -172,7 +175,9 @@ Constructor()
          }
       }
 
-      lData = Cons(Send(SYS,@FindSpellByNum,#num=spellNum),lData);
+      % Use SID for this, spell object might change. Specifically, RecreateAll
+      % makes new spell objects (this itematt keeps the old ones hanging around).
+      lData = Cons(spellNum,lData);
 
       iValue = Send(self,@SetCompound,#oItem=oItem,#iPower=0);
       lData = Cons(iValue,lData);
@@ -183,6 +188,18 @@ Constructor()
       }
 
       Send(oItem,@AddAttributeSpecifics,#lItemAtt=lData);
+
+      return;
+   }
+
+   % Add the spell name to the description.
+   AppendDesc(oItem=$,lData=$)
+   {
+      AppendTempString(vrDesc);
+      AppendTempString(vrDesc2);
+      AppendTempString(Send(Send(SYS,@FindSpellByNum,#num=Nth(lData,2)),@GetName));
+      AppendTempString(vrDesc3);
+
       return;
    }
 

--- a/kod/object/passive/itematt/weapatt/waspell.kod
+++ b/kod/object/passive/itematt/weapatt/waspell.kod
@@ -29,6 +29,7 @@ resources:
    WeapAttSpellCaster_desc = " Mystical energy flits about this weapon."
    WeapAttSpellCaster_desc2 = " This weapon will cast the "
    WeapAttSpellCaster_desc3 = " spell on your target."
+   WeapAttSpellCaster_desc_invis = " spell on the wielder."
    WeapAttSpellCaster_dm = "spellcaster"
 
 classvars:
@@ -36,6 +37,7 @@ classvars:
    vrDesc = WeapAttSpellCaster_desc
    vrDesc2 = WeapAttSpellCaster_desc2
    vrDesc3 = WeapAttSpellCaster_desc3
+   vrDesc4 = WeapAttSpellCaster_desc_invis
 
    viItem_Att_Num = WA_SPELLCASTER
 
@@ -53,10 +55,11 @@ messages:
 
    Constructor()
    {
-      % Used to have swap and invisibility here.
-      plSpells = [ [SID_DEMENT, 17], [SID_ENFEEBLE, 16],
-                   [SID_VERTIGO, 16], [SID_FORGET, 16],
-                   [SID_EVIL_TWIN, 16], [SID_MARK_OF_DISHONOR, 17]
+      % Used to have swap here.
+      plSpells = [ [SID_DEMENT, 14], [SID_ENFEEBLE, 14],
+                   [SID_VERTIGO, 14], [SID_FORGET, 15],
+                   [SID_EVIL_TWIN, 14], [SID_MARK_OF_DISHONOR, 15],
+                   [SID_INVISIBILITY, 14]
                  ];
 
       propagate;
@@ -83,11 +86,25 @@ messages:
          AND Send(wielder,@CheckPlayerFlag,#flag=PFLAG_PKILL_ENABLE)
       {
          oSpell = Send(SYS,@FindSpellByNum,#num=Nth(lData,2));
-         if Send(oSpell,@CanPayCosts,#who=self,#ltargets=[target],
-               #ispellpower=Nth(lData,3))
+
+         % Handle self-target spells separately.
+         if Nth(lData,2) = SID_INVISIBILITY
          {
-            Send(oSpell,@CastSpell,#who=wielder,#ltargets=[target],
-                  #ispellpower=Nth(lData,3),#bItemCast=TRUE);
+            if Send(oSpell,@CanPayCosts,#who=self,#lTargets=[wielder],
+                  #ispellpower=Nth(lData,3))
+            {
+               Send(oSpell,@CastSpell,#who=wielder,#lTargets=$,
+                     #ispellpower=Nth(lData,3),#bItemCast=TRUE);
+            }
+         }
+         else
+         {
+            if Send(oSpell,@CanPayCosts,#who=self,#lTargets=[target],
+                  #ispellpower=Nth(lData,3))
+            {
+               Send(oSpell,@CastSpell,#who=wielder,#lTargets=[target],
+                     #ispellpower=Nth(lData,3),#bItemCast=TRUE);
+            }
          }
       }
 
@@ -198,7 +215,16 @@ messages:
       AppendTempString(vrDesc);
       AppendTempString(vrDesc2);
       AppendTempString(Send(Send(SYS,@FindSpellByNum,#num=Nth(lData,2)),@GetName));
-      AppendTempString(vrDesc3);
+
+      % Special case for spell cast on self.
+      if Nth(lData,2) = SID_INVISIBILITY
+      {
+         AppendTempString(vrDesc4);
+      }
+      else
+      {
+         AppendTempString(vrDesc3);
+      }
 
       return;
    }

--- a/kod/object/passive/spell/SUMMTWIN.KOD
+++ b/kod/object/passive/spell/SUMMTWIN.KOD
@@ -71,7 +71,7 @@ messages:
 
    CanPayCosts(who=$,lTargets=$)
    {
-      local oTarget, oRoom;
+      local oTarget;
 
       oTarget = First(lTargets);
 
@@ -90,10 +90,12 @@ messages:
       {
          % Lich, lupogg king, evil twins, reflections and revenants 
          % all not valid targets
-
-         Send(who,@MsgSendUser,#message_rsc=summonEvilTwin_bad_target,
-               #parm1=Send(oTarget,@GetDef),
-               #parm2=Send(oTarget,@GetName));
+         if IsClass(who,&Player)
+         {
+            Send(who,@MsgSendUser,#message_rsc=summonEvilTwin_bad_target,
+                  #parm1=Send(oTarget,@GetDef),
+                  #parm2=Send(oTarget,@GetName));
+         }
 
          return FALSE;
       }
@@ -101,8 +103,11 @@ messages:
       % Check for evil twin already following target.
       if Send(oTarget,@HasEvilTwin)
       {
-         Send(who,@MsgSendUser,#message_rsc=summonEvilTwin_only_one,
-              #parm1=Send(oTarget,@GetName));
+         if IsClass(who,&Player)
+         {
+            Send(who,@MsgSendUser,#message_rsc=summonEvilTwin_only_one,
+                  #parm1=Send(oTarget,@GetName));
+         }
 
          return FALSE;
       }
@@ -112,8 +117,11 @@ messages:
          if Send(oTarget,@CheckPlayerFlag,#flag=PFLAG_MORPHED)
          {
             % Morph protects against evil twin
-            Send(who,@MsgSendUser,#message_rsc=summonEvilTwin_bad_target,
-                 #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
+            if IsClass(who,&Player)
+            {
+               Send(who,@MsgSendUser,#message_rsc=summonEvilTwin_bad_target,
+                     #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
+            }
 
             return FALSE;
          }
@@ -124,15 +132,6 @@ messages:
          {
             return FALSE;
          }
-      }
-
-      oRoom = Send(SYS,@UtilGetRoom,#what=who);
-
-      if Send(oRoom,@CountHoldingHowMany,#class=&Monster) > 25
-      {
-         Send(who,@MsgSendUser,#message_rsc=summonEvilTwin_failed_rsc);
-
-         return FALSE;
       }
 
       propagate;


### PR DESCRIPTION
Due to an 18 year old bug, the WA_SPELLCASTER weapon attribute was only ever making Mark of Dishonor weapons. When cycling through the choices, it never broke out of the loop when it picked a spell so it always ended up picking the last one on the list (MoD). It can now choose MoD, Vertigo, Enfeeble, Dement, Evil Twin or Forget.

Also changed the weapon attribute to use the SID rather than the spell object, as the object can be deleted/recreated (so the weapon ends up referring to the old spell object and keeping it active).

Added a message to weapon.kod to replace the spell object in all existing spellblades with the appropriate SID (FixSpellItemAtts). To fix all weapons, run the command "send c weapon FixSpellItemAtts".

Removed the swap spell from the spellblade spawn list (no current weapons actually have it).
Modified the spellblade code so it casts invisibility on the wielder of the weapon, not the target. Reflected in weapon description.

Added the spell cast by the weapon to the weapon's description.