### PR TITLE
Partial Vault Withdrawal

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -3981,13 +3981,13 @@ messages:
          return;
       }         
 
-      if Send(what, @GetBulkMax) <> $ AND
-         (iBulk + Send(what,@GetBulkHold)) > Send(what,@GetBulkMax)
-      {
-         Send(self,@SayToOne,#target=what,#message_rsc=vaultman_no_room);
-
-         return;
-      }   
+      %if Send(what, @GetBulkMax) <> $ AND
+      %   (iBulk + Send(what,@GetBulkHold)) > Send(what,@GetBulkMax)
+      %{
+      %   Send(self,@SayToOne,#target=what,#message_rsc=vaultman_no_room);
+      %
+      %   return;
+      %}   
       
       % The next line added to handle player specified amounts
       lNumbers = number_list;
@@ -4002,13 +4002,20 @@ messages:
          {
             if IsClass(i,&NumberItem)
             {               
-               Send(oVault,@WithdrawFromStorage,#what=i,#who=what,
-                    #count=First(lNumbers));
+               if NOT Send(oVault,@WithdrawFromStorage,#what=i,#who=what,
+                    #count=First(lNumbers))
+               {
+                  break;
+               }
+
                lNumbers = Rest(lNumbers);
             }
             else
             {
-               Send(oVault,@WithdrawFromStorage,#what=i,#who=what,#count=1); 
+               if NOT Send(oVault,@WithdrawFromStorage,#what=i,#who=what,#count=1)
+               {
+                  break;
+               }
             }
             
          }

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -176,6 +176,9 @@ resources:
    vaultman_deposit_thanks = \
       "Thank you for trusting me to quartermaster your gear."
    vaultman_thanks = "Here is your gear.  Thank you for your patronage."
+   vaultman_withdraw_failed = \
+      "I was unable to complete our transaction.  Please sort your inventory "
+      "and try again."
    vaultman_nowithdraw_cash = \
       "You currently cannot pay the exit fee to get your stuff out."
    vaultman_nodeposit_cash = \
@@ -3889,7 +3892,7 @@ messages:
    VaultWithdraw(what=$,lItems=$,number_list = $)
    {
       local i, j, iFee, iCash, lStored, oVault, iBulk, oMoney, bFound,
-            oSafeBox, lNumbers, iCount;
+            oSafeBox, lNumbers, iCount, bFailed;
 
       if what=$ OR lItems = $
       {
@@ -3991,6 +3994,7 @@ messages:
       
       % The next line added to handle player specified amounts
       lNumbers = number_list;
+      bFailed = FALSE;
 
       % At this point, we're pretty sure it's all legal.      
       for i in lItems
@@ -4005,6 +4009,7 @@ messages:
                if NOT Send(oVault,@WithdrawFromStorage,#what=i,#who=what,
                     #count=First(lNumbers))
                {
+                  bFailed = TRUE;
                   break;
                }
 
@@ -4014,6 +4019,7 @@ messages:
             {
                if NOT Send(oVault,@WithdrawFromStorage,#what=i,#who=what,#count=1)
                {
+                  bFailed = TRUE;
                   break;
                }
             }
@@ -4023,13 +4029,27 @@ messages:
 
       if iFee <> 0
       {
-         Send(oMoney,@SubtractNumber,#number=iFee);  
-         Send(self,@SayToOne,#message_rsc=vaultman_Thanks_amount,#target=what,
+         Send(oMoney,@SubtractNumber,#number=iFee);
+         if bFailed
+         {
+            Send(self,@SayToOne,#target=what,#message_rsc=vaultman_withdraw_failed);
+         }
+         else
+         {
+            Send(self,@SayToOne,#message_rsc=vaultman_Thanks_amount,#target=what,
               #parm1=iFee);
+         }
       }
       else
       {
-         Send(self,@SayToOne,#target=what,#message_rsc=vaultman_thanks);
+         if bFailed
+         {
+            Send(self,@SayToOne,#target=what,#message_rsc=vaultman_withdraw_failed);
+         }
+         else
+         {
+            Send(self,@SayToOne,#target=what,#message_rsc=vaultman_thanks);
+         }
       }
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcvaultm.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcvaultm.kod
@@ -108,7 +108,7 @@ messages:
    GetVaultRetrievalFee(what=$)
    "Default cost no cost.  However, expensive places can charge more."
    {
-      return 1;
+      return 0;
    }
 
 end

--- a/kod/object/passive/storage.kod
+++ b/kod/object/passive/storage.kod
@@ -193,7 +193,7 @@ messages:
 
    WithdrawFromStorage(who=$,what=$,count=$)
    {
-      local i, j, oBox, oItem, cClass, currentAmount;
+      local i, j, oBox, oItem, cClass, currentAmount, iCanHold;
       
       if who=$ or what=$ 
       { DEBUG("Called with invalid data!"); return; }
@@ -217,6 +217,12 @@ messages:
 
       if isClass(what,&NumberItem) 
       {
+         iCanHold = Send(who,@GetNumberCanHold,#what=what);
+         if iCanHold < count
+         {
+            count = iCanHold;
+         }
+         
 	 currentAmount = send(what,@GetNumber);
 	 if (count > 0) AND (count <= currentAmount)
 	 {

--- a/kod/object/passive/storage.kod
+++ b/kod/object/passive/storage.kod
@@ -20,6 +20,9 @@ resources:
    msg_not_enough_items_on_deposit = "%s%s does not have that many on deposit."
    msg_does_not_have_item = "%s%s does not have that item on deposit for you."
    msg_has_no_deposit = "%s%s does not have any items on deposit for you."
+   
+   msg_reduced_tally = "You couldn't carry everything you requested."
+   msg_cannot_carry = "You were unable to withdraw %s%s."
 
 classvars:
 
@@ -221,34 +224,52 @@ messages:
          if iCanHold < count
          {
             count = iCanHold;
+            if count > 0
+            {
+               Send(who,@MsgSendUser,#message_rsc=msg_reduced_tally);
+            }
+            if count = 0
+            {
+               return FALSE;
+            }
          }
-         
-	 currentAmount = send(what,@GetNumber);
-	 if (count > 0) AND (count <= currentAmount)
-	 {
-	    cClass = GetClass(what);
-	    oItem = Create(cClass,#number=count);
-	    send(what,@SubtractNumber,#number=count);
-	    send(who,@NewHold,#what=oItem);
-	 }
-	 else
-	 { % Send message to user that they don't have that many items on deposit
-	    DEBUG("Failed test for count >0 and count <= currentAmount");
-	    send(self,@MsgSendUser,#message_rsc=msg_not_enough_items_on_deposit,
-	         #parm1=Send(what,@GetCapDef),#parm2=Send(what,@GetName));
-	    return False;
-	 }
+
+         currentAmount = send(what,@GetNumber);
+         if (count > 0) AND (count <= currentAmount)
+         {
+            cClass = GetClass(what);
+            oItem = Create(cClass,#number=count);
+            send(what,@SubtractNumber,#number=count);
+            send(who,@NewHold,#what=oItem);
+         }
+         else
+         { % Send message to user that they don't have that many items on deposit
+            DEBUG("Failed test for count >0 and count <= currentAmount");
+            send(self,@MsgSendUser,#message_rsc=msg_not_enough_items_on_deposit,
+             #parm1=Send(what,@GetCapDef),#parm2=Send(what,@GetName));
+            return False;
+         }
       }
       else
       {
-         send(who,@newhold,#what=what);
+         if Send(who,@ReqNewHold,#what=what)
+         {
+            Send(who,@NewHold,#what=what);
+         }
+         else
+         {
+            Send(who,@MsgSendUser,#message_rsc=msg_cannot_carry,
+                                  #parm1=Send(what,@GetDef),
+                                  #parm2=Send(what,@GetName));
+            return FALSE;
+         }
       }
-      
+
       if send(oBox,@GetHolderPassive) = $  
       { 
-	 send(self,@DestroyPlayersVault,#who=who); 
+         send(self,@DestroyPlayersVault,#who=who); 
       }
-      return FALSE;
+      return TRUE;
    }
 
    DestroyPlayersVault(who=$)


### PR DESCRIPTION
This smooths the withdrawal process for vaults. You can attempt to take out any number of things, but the vaultman will stop once you cannot carry anymore.

For example, if you take out a huge list of things, hit a plate armor, and can't carry it, no more will be withdrawn.

If you take out a huge stack of reagents, your tally will be reduced to exactly what you can carry.

I have also removed the 1 shilling fee per item withdrawn at the Ko'catan vaults. I am not entirely convinced it was even intentional. If it was... why? All it ever did was sometimes screw over people who had no shillings on them.