### PR TITLE
Starting toon stat suggestion changes.

### DIFF
--- a/module/char/char.rc
+++ b/module/char/char.rc
@@ -47,12 +47,14 @@ BEGIN
     LTEXT           "Genauigkeit",-1,20,123,39,8
     CONTROL         "",1026,"BlakGraph",WS_TABSTOP | 0xb,65,120,102,14
     GROUPBOX        "Hilfe für Einsteiger",-1,24,139,269,68
-    PUSHBUTTON      "&Magier",1010,43,154,34,12
-    LTEXT           "Konzentriere dich auf Zauberschulen.",-1,87,156,119,8
-    PUSHBUTTON      "&Krieger",1011,43,171,34,12
-    LTEXT           "Konzentriere dich auf Waffenfertigkeiten und Kraanan.",-1,87,173,172,8
-    PUSHBUTTON      "&Hybrid",1012,43,188,34,12
-    LTEXT           "Wende Magie und Waffenfertigkeiten an.",-1,87,190,161,8
+    PUSHBUTTON      "&Magier",1010,43,150,50,11
+    LTEXT           "Konzentriere dich auf Zauberschulen.",-1,98,150,190,8
+    PUSHBUTTON      "&Krieger",1011,43,164,50,11
+    LTEXT           "Konzentriere dich auf Waffenfertigkeiten und Kraanan.",-1,98,164,190,8
+    PUSHBUTTON      "&Hybrid",1012,43,178,50,11
+    LTEXT           "Lerne Magie und Waffenfertigkeiten.",-1,98,178,190,8
+    PUSHBUTTON      "Hybrid &2",1027,43,192,50,11
+    LTEXT           "Lerne Waffenfertigkeiten, Riija und eine andere Zauberschule.",-1,98,192,190,8
     LTEXT           "Eigenschaftspunkte übrig:",-1,8,215,83,8
     CONTROL         "",1028,"BlakGraph",0x8,95,214,98,11
     PUSHBUTTON      "&<< Zurück",1008,219,214,41,12
@@ -360,12 +362,14 @@ BEGIN
     LTEXT           "Aim",IDC_STATIC,26,122,12,8
     CONTROL         "",IDC_CHAR_GRAPH6,"BlakGraph",WS_TABSTOP | 0xb,42,120,102,14
     GROUPBOX        "Suggestions for newcomers",IDC_STATIC,24,139,269,68
-    PUSHBUTTON      "&Mage",IDC_MAGE,43,154,34,12
-    LTEXT           "Learn spells from many schools -- with sufficent study",IDC_STATIC,87,156,168,8
-    PUSHBUTTON      "&Warrior",IDC_WARRIOR,43,171,34,12
-    LTEXT           "Master weaponcraft and ranged combat",IDC_STATIC,87,173,167,8
-    PUSHBUTTON      "&Hybrid",IDC_HYBRID,43,188,34,12
-    LTEXT           "A flexible generalist",IDC_STATIC,87,190,161,8
+    PUSHBUTTON      "&Mage",IDC_MAGE,43,150,50,11
+    LTEXT           "Learn spells from many schools -- with sufficent study",IDC_STATIC,98,150,168,8
+    PUSHBUTTON      "&Warrior",IDC_WARRIOR,43,164,50,11
+    LTEXT           "Master weaponcraft and ranged combat",IDC_STATIC,98,164,167,8
+    PUSHBUTTON      "Hybrid &1",IDC_HYBRID,43,178,50,11
+    LTEXT           "Learn weaponcraft and two schools of magic",IDC_STATIC,98,178,161,8
+    PUSHBUTTON      "Hybrid &2",IDC_RIIJA,43,192,50,11
+    LTEXT           "Learn weaponcraft, Riija and another magic school",IDC_STATIC,98,192,161,8
     LTEXT           "Stat points left",IDC_STATIC,24,215,46,8
     CONTROL         "",IDC_POINTSLEFT,"BlakGraph",0x8,87,214,98,11
     PUSHBUTTON      "&<< Prev",IDC_PREVIOUS_PAGE,231,214,34,12

--- a/module/char/charrc.h
+++ b/module/char/charrc.h
@@ -65,6 +65,7 @@
 #define IDC_CHAR_GRAPH5                 1025
 #define IDC_MOUTH2                      1026
 #define IDC_CHAR_GRAPH6                 1026
+#define IDC_RIIJA                       1027
 #define IDC_POINTSLEFT                  1028
 #define IDC_SPELLIST1                   1029
 #define IDC_SPELLIST2                   1030

--- a/module/char/charstat.c
+++ b/module/char/charstat.c
@@ -32,9 +32,10 @@ static Stat stats[] = {
 #define NUM_STATS (sizeof stats / sizeof stats[0])
 
 static int suggested_stats[][NUM_STATS] = {
-   { 50, 10, 50, 30, 10, 50 },  // Warrior
-   { 35, 40, 50, 15, 45, 15 },  // Mage
-   { 40, 25, 35, 25, 35, 40 },  // Hybrid
+   { 40, 10, 50, 40, 10, 50 },  // Pure Fighter (Weaponcraft/Kraanan)
+   { 40, 25, 50, 15, 35, 35 },  // Shal'ille/Qor Warrior
+   { 40, 35, 50, 25, 15, 35 },  // Riija Warrior
+   { 40, 50, 45, 15, 45, 5  },  // Pure mage
 };
 
 static int  stat_points = STAT_POINTS_INITIAL;   // # of stat points remaining
@@ -222,12 +223,16 @@ void CharStatsCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify)
       SetStatSliders(hwnd, suggested_stats[0]);
       break;
 
-   case IDC_MAGE:
+   case IDC_HYBRID:
       SetStatSliders(hwnd, suggested_stats[1]);
       break;
       
-   case IDC_HYBRID:
+   case IDC_RIIJA:
       SetStatSliders(hwnd, suggested_stats[2]);
+      break; 
+	  
+   case IDC_MAGE:
+      SetStatSliders(hwnd, suggested_stats[3]);
       break;
 
    default:


### PR DESCRIPTION
Changed suggested stats to the following:
 { 40, 10, 50, 40, 10, 50 },  // Pure Fighter (Weaponcraft/Kraanan)
 { 40, 25, 50, 15, 35, 35},  // Shal'ille/Qor Warrior
 { 40, 35, 50, 25, 15, 35},  // Riija Warrior
{ 40, 50, 45, 15, 45, 5  },  // Pure mage

Did this a while ago, perhaps these are no longer valid. Opening this pull request so we can discuss it.

Edit: I don't really mind what we put here, anything would be an improvement on the current defaults.

Edit2: Added Gar's suggestions, and moved some PF might into agil. I've left the mights at 40 mainly because I think new players would be less frustrated with a higher weight limit, rather than trying to min/max their aim/agil.