### PR TITLE
Use item's true name with dm item command. Lower delay on Brax lever pulls. Add indefinite article "an" to a few items that were missing it.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -9666,9 +9666,9 @@ messages:
    "Processes a stat change request from the client"
    {
       local i,lSpellLevels,lSkillLevels,lSpellLevels_new,lSkillLevels_new,
-      totalLevels,totalSchools,totalLvlOnes,iPrimaryStat,
-      oSpell,iSpellAbility,iSpellNum,
-      oSkill,iSkillAbility,iSkillNum;
+            totalLevels,totalSchools,totalLvlOnes,iPrimaryStat,
+            oSpell,iSpellAbility,iSpellNum,
+            oSkill,iSkillAbility,iSkillNum;
 
       % if stats reset is turned off, ignore the request
       if NOT Send(Send(SYS,@GetSettings),@GetStatsResetEnabled)
@@ -9676,7 +9676,7 @@ messages:
          return;
       }
       
-      if Send(self,@FindHolding,#what=&StatsResetToken) = $
+      if Send(self,@FindHolding,#class=&StatsResetToken) = $
          AND (piBase_Max_Health > Send(Send(SYS,@GetSettings),@GetFreeStatsResetCap))
       {
          return;

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
@@ -1870,7 +1870,7 @@ messages:
 
             for i in lTemplate
             {
-               if StringContain(string,Send(i,@GetName))
+               if StringContain(string,Send(i,@GetTrueName))
                   AND NOT Send(i,@IsItemType,#type=ITEMTYPE_SPECIAL)
                {
                   iGiven = Send(SYS,@RoomGive,#who=self,#classtype=GetClass(i),
@@ -1897,7 +1897,7 @@ messages:
 
             for i in lTemplate
             {
-               if StringContain(string,Send(i,@GetName))
+               if StringContain(string,Send(i,@GetTrueName))
                   AND NOT Send(i,@IsItemType,#type=ITEMTYPE_SPECIAL)
                {
                   Send(self,@NewHold,#what=create(GetClass(i)));
@@ -1906,7 +1906,7 @@ messages:
                      Send(poOwner,@SomeoneSaid,#what=self,#type=SAY_MESSAGE,
                            #string=dm_void,#parm1=vrName,
                            #parm2=Send(i,@GetIndef),
-                           #parm3=Send(i,@GetName));
+                           #parm3=Send(i,@GetTrueName));
                   }
 
                   bFound = TRUE;

--- a/kod/object/active/holder/room/monsroom/g9.kod
+++ b/kod/object/active/holder/room/monsroom/g9.kod
@@ -58,7 +58,7 @@ constants:
    LIGHTNING_TOUCHEDTIMELIMIT = 1000 * 60 * 5
 
    % 2 seconds
-   LEVER_REACTIVATE_DELAY = 1000 * 2      
+   LEVER_REACTIVATE_DELAY = 1000 * 1      
 
 resources:
 

--- a/kod/object/item/passitem/numbitem/reagent/elderbry.kod
+++ b/kod/object/item/passitem/numbitem/reagent/elderbry.kod
@@ -32,6 +32,8 @@ classvars:
 
    vrName_plural = Elderberry_name_plural_rsc
 
+   viIndefinite = ARTICLE_AN
+
    viValue_average = 20
    viWeight = 3
    viBulk = 3

--- a/kod/object/item/passitem/numbitem/reagent/emerald.kod
+++ b/kod/object/item/passitem/numbitem/reagent/emerald.kod
@@ -33,6 +33,8 @@ classvars:
    vrIcon = emerald_icon_rsc
    vrDesc = emerald_desc_rsc
 
+   viIndefinite = ARTICLE_AN
+
    viBulk = 1
    viWeight = 1
 

--- a/kod/object/item/passitem/numbitem/reagent/orctooth.kod
+++ b/kod/object/item/passitem/numbitem/reagent/orctooth.kod
@@ -31,6 +31,8 @@ classvars:
 
    vrName_plural = orctooth_name_plural_rsc
 
+   viIndefinite = ARTICLE_AN
+
    viValue_average = 40
    viWeight = 3
    viBulk = 3

--- a/kod/object/item/passitem/numbitem/reagent/uncserpm.kod
+++ b/kod/object/item/passitem/numbitem/reagent/uncserpm.kod
@@ -19,9 +19,9 @@ resources:
    uncutseraphym_name_rsc = "uncut seraphym"
    uncutseraphym_icon_rsc = serapunc.bgf
    uncutseraphym_desc_rsc = \
-   "There must be something remarkable about this ugly lump of "
-   "stone, for the wizards of the orc clans certainly seem fond of "
-   "them. A vein in the rock pulses occasionally, like a heartbeat." 
+      "There must be something remarkable about this ugly lump of "
+      "stone, for the wizards of the orc clans certainly seem fond of "
+      "them.  A vein in the rock pulses occasionally, like a heartbeat." 
    uncutseraphym_name_plural_rsc = "uncut seraphym"
 
 classvars:
@@ -31,6 +31,8 @@ classvars:
    vrDesc = uncutseraphym_desc_rsc
 
    vrName_plural = uncutseraphym_name_plural_rsc
+
+   viIndefinite = ARTICLE_AN
 
    viValue_average = 30
    viWeight = 6
@@ -43,25 +45,26 @@ properties:
 
 messages:
 
-SendAnimation()
-{
-AddPacket(1,ANIMATE_CYCLE,4,180,2,1,2,6);  % Frames 1 to 6, and back to 1
-return;
-}
+   SendAnimation()
+   {
+      AddPacket(1,ANIMATE_CYCLE,4,180,2,1,2,6);  % Frames 1 to 6, and back to 1
 
-SendLookAnimation()
-{
-AddPacket(1,ANIMATE_CYCLE,4,180,2,1,2,6);  % Frames 1 to 6, and back to 1
-return;
-}
+      return;
+   }
 
-SendInventoryAnimation()
-{
-AddPacket(1,ANIMATE_CYCLE,4,180,2,1,2,6);  % Frames 1 to 6, and back to 1
-return;
-}
+   SendLookAnimation()
+   {
+      AddPacket(1,ANIMATE_CYCLE,4,180,2,1,2,6);  % Frames 1 to 6, and back to 1
 
+      return;
+   }
 
+   SendInventoryAnimation()
+   {
+      AddPacket(1,ANIMATE_CYCLE,4,180,2,1,2,6);  % Frames 1 to 6, and back to 1
+
+      return;
+   }
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Allows DMs to get rings, wands etc.

Most issues players are having with the Brax levers is due to the wait time needed before pulling the next lever. Lowered the time from 2 sec to 1 sec to reduce that issue.

A few reagents didn't have the proper indefinite article set, added it.

Fixed a FindHolding call in User that was sending the wrong parameter name.