### PR TITLE
Add magic flag to spellblade and bonded items.

### DIFF
--- a/kod/object/passive/itematt.kod
+++ b/kod/object/passive/itematt.kod
@@ -322,7 +322,8 @@ messages:
          lData = Cons(iValue,lData);
       }
 
-      iValue = Send(self,@SetCompound,#random_gen=random_gen,#oItem=oItem,#iPower=iPower);
+      iValue = Send(self,@SetCompound,#random_gen=random_gen,
+                     #oItem=oItem,#iPower=iPower);
       lData = Cons(iValue,lData);
 
       Send(self,@AddEffects,#oItem=oItem,#lData=lData,#state1=state1);
@@ -330,9 +331,10 @@ messages:
 
       %% Add magic item flag for item attributes that add an effect
       if Send(self,@IsMagicalEffect)
-         {
-            Send(oItem,@AddMagicFlag);
-         }
+      {
+         Send(oItem,@AddMagicFlag);
+      }
+
       return;
    }
 

--- a/kod/object/passive/itematt/iabonded.kod
+++ b/kod/object/passive/itematt/iabonded.kod
@@ -61,7 +61,7 @@ messages:
 %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-   AddToItem(oItem=$,oPlayer=$,identified=false)   
+   AddToItem(oItem=$,oPlayer=$,identified=FALSE)
    {
       local lData, iValue;
 
@@ -73,6 +73,10 @@ messages:
       lData = Cons(iValue,lData);
 
       Send(oItem,@AddAttributeSpecifics,#lItemAtt=lData);
+
+      % Add the magic flag to the item (colored name in lists).
+      Send(oItem,@AddMagicFlag);
+
       return;
    }
 

--- a/kod/object/passive/itematt/weapatt/waspell.kod
+++ b/kod/object/passive/itematt/weapatt/waspell.kod
@@ -207,6 +207,9 @@ messages:
 
       Send(oItem,@AddAttributeSpecifics,#lItemAtt=lData);
 
+      % Add the magic flag to the item (colored name in lists).
+      Send(oItem,@AddMagicFlag);
+
       return;
    }
 
@@ -214,6 +217,15 @@ messages:
    AppendDesc(oItem=$,lData=$)
    {
       AppendTempString(vrDesc);
+
+      % Check if we have a valid lData list. If we don't, don't try to
+      % append the spell name to the description. This happens with
+      % artificed items.
+      if lData = $
+      {
+         return;
+      }
+
       AppendTempString(vrDesc2);
       AppendTempString(Send(Send(SYS,@FindSpellByNum,#num=Nth(lData,2)),@GetName));
 


### PR DESCRIPTION
Added magic flag (colored name in lists) to spellblade and bonded items.

Also check when creating spellblade description that we have valid data
list. Artificed weapons don't actually have the data necessary to add
the spell to the description, so they throw an error here.