### PR TITLE
Modify monster gen times and some max mob values.

### DIFF
--- a/kod/object/active/holder/room/monsroom.kod
+++ b/kod/object/active/holder/room/monsroom.kod
@@ -104,7 +104,7 @@ messages:
       % GetSpawnRate =  1
       % iWaitTime = (20000 * (300 / 100));
       % iWaitTime = 200
-      iWaitTime = (piGen_Time * Send(Send(SYS,@GetSettings),@GetSpawnRate)) / 200;
+      iWaitTime = (piGen_Time * Send(Send(SYS,@GetSettings),@GetSpawnRate)) / 100;
 
       % Reduce spawn time for up to 5 people.
       iNumberOfPlayers = Send(self,@CountHoldingHowMany,#class=&Player);

--- a/kod/object/active/holder/room/monsroom/a5.kod
+++ b/kod/object/active/holder/room/monsroom/a5.kod
@@ -48,7 +48,7 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 40000
+   piGen_time = 25000
    piGen_percent = 80
 
    piInit_count_min = 5

--- a/kod/object/active/holder/room/monsroom/a6.kod
+++ b/kod/object/active/holder/room/monsroom/a6.kod
@@ -45,7 +45,7 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 40000
+   piGen_time = 25000
    piGen_percent = 80
 
    piInit_count_min = 4

--- a/kod/object/active/holder/room/monsroom/barlsew.kod
+++ b/kod/object/active/holder/room/monsroom/barlsew.kod
@@ -44,7 +44,7 @@ properties:
 
    prMusic = barlsew_music
 
-   piGen_time = 60000
+   piGen_time = 30000
    piGen_percent = 80
 
    piInit_count_min = 4

--- a/kod/object/active/holder/room/monsroom/barlsew2.kod
+++ b/kod/object/active/holder/room/monsroom/barlsew2.kod
@@ -45,7 +45,7 @@ properties:
 
    prMusic = barsew2_music
 
-   piGen_time = 70000
+   piGen_time = 30000
    piGen_percent = 80
 
    piInit_count_min = 4

--- a/kod/object/active/holder/room/monsroom/barlsew3.kod
+++ b/kod/object/active/holder/room/monsroom/barlsew3.kod
@@ -45,7 +45,7 @@ properties:
 
    prMusic = barsew3_music
 
-   piGen_time = 50000
+   piGen_time = 30000
    piGen_percent = 80
 
    piInit_count_min = 7

--- a/kod/object/active/holder/room/monsroom/bossroom/orcpit1.kod
+++ b/kod/object/active/holder/room/monsroom/bossroom/orcpit1.kod
@@ -70,7 +70,7 @@ properties:
 
    prMusic = Orcpit1_music
 
-   piGen_time = 50000
+   piGen_time = 25000
    piGen_percent = 80
 
    piInit_count_min = 7

--- a/kod/object/active/holder/room/monsroom/c4.kod
+++ b/kod/object/active/holder/room/monsroom/c4.kod
@@ -45,7 +45,6 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 80000
    piGen_percent = 80
 
 messages:

--- a/kod/object/active/holder/room/monsroom/c6.kod
+++ b/kod/object/active/holder/room/monsroom/c6.kod
@@ -45,7 +45,6 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 110000
    piGen_percent = 70
 
    piInit_count_min = 3

--- a/kod/object/active/holder/room/monsroom/d4.kod
+++ b/kod/object/active/holder/room/monsroom/d4.kod
@@ -44,7 +44,6 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 70000
    piGen_percent = 80
 
    % Give users a healthy mix of creatures when entering room.

--- a/kod/object/active/holder/room/monsroom/d5.kod
+++ b/kod/object/active/holder/room/monsroom/d5.kod
@@ -46,7 +46,6 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 90000
    piGen_percent = 70
 
    piInit_count_min = 5

--- a/kod/object/active/holder/room/monsroom/d6.kod
+++ b/kod/object/active/holder/room/monsroom/d6.kod
@@ -45,7 +45,6 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 100000
    piGen_percent = 80
 
    piInit_count_min = 4

--- a/kod/object/active/holder/room/monsroom/d7.kod
+++ b/kod/object/active/holder/room/monsroom/d7.kod
@@ -45,7 +45,6 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 100000
    piGen_percent = 80
 
    piMonster_count_max = 15

--- a/kod/object/active/holder/room/monsroom/e2.kod
+++ b/kod/object/active/holder/room/monsroom/e2.kod
@@ -50,7 +50,7 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 45000
+   piGen_time = 20000
    piGen_percent = 70
 
    piInit_count_min = 2

--- a/kod/object/active/holder/room/monsroom/e4.kod
+++ b/kod/object/active/holder/room/monsroom/e4.kod
@@ -45,7 +45,6 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 100000
    piGen_percent = 70
 
    piInit_count_min = 5

--- a/kod/object/active/holder/room/monsroom/e7.kod
+++ b/kod/object/active/holder/room/monsroom/e7.kod
@@ -40,7 +40,7 @@ properties:
 
    piBaseLight = LIGHT_NICE
    piOutside_factor = 8
-   piGen_time = 100000
+
    piGen_percent = 80
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS

--- a/kod/object/active/holder/room/monsroom/f2.kod
+++ b/kod/object/active/holder/room/monsroom/f2.kod
@@ -59,12 +59,12 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 55000 % temporarily increased from 45000
+   piGen_time = 20000
    piGen_percent = 80
 
    piInit_count_min = 4
    piInit_count_max = 6
-   piMonster_count_max = 6 % temporarily reduced from 10 (default)
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/f3.kod
+++ b/kod/object/active/holder/room/monsroom/f3.kod
@@ -45,13 +45,12 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 120000
    piGen_percent = 60
 
    piInit_count_min = 2
    piInit_count_max = 5
 
-   piMonster_count_max = 7
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/f4.kod
+++ b/kod/object/active/holder/room/monsroom/f4.kod
@@ -45,13 +45,10 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 120000
    piGen_percent = 60
 
    piInit_count_min = 1
    piInit_count_max = 3
-
-   piMonster_count_max = 6
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/f6.kod
+++ b/kod/object/active/holder/room/monsroom/f6.kod
@@ -45,13 +45,12 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 70000
    piGen_percent = 60
 
    piInit_count_min = 3
    piInit_count_max = 6
 
-   piMonster_count_max = 10
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/f7.kod
+++ b/kod/object/active/holder/room/monsroom/f7.kod
@@ -45,13 +45,12 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 70000
    piGen_percent = 60
 
    piInit_count_min = 2
    piInit_count_max = 5
 
-   piMonster_count_max = 9
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/f8.kod
+++ b/kod/object/active/holder/room/monsroom/f8.kod
@@ -61,13 +61,11 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 60000
+   piGen_time = 20000
    piGen_percent = 60
 
    piInit_count_min = 1
    piInit_count_max = 3
-
-   piMonster_count_max = 5
 
    pbDoor_open = FALSE
    ptDoor = $

--- a/kod/object/active/holder/room/monsroom/feyforst.kod
+++ b/kod/object/active/holder/room/monsroom/feyforst.kod
@@ -40,7 +40,7 @@ properties:
    
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
-   piGen_time = 150000
+   piGen_time = 20000
    piGen_percent = 80
    
    piRoom_Karma = 50                %%% Room Karma is the karma of the Faerie Forest

--- a/kod/object/active/holder/room/monsroom/feyforst/a1.kod
+++ b/kod/object/active/holder/room/monsroom/feyforst/a1.kod
@@ -33,7 +33,7 @@ properties:
    prMusic = OutdoorsA1_music
    piRoom_num = RID_A1
    
-   piGen_time = 150000   
+   piGen_time = 25000
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/feyforst/b1.kod
+++ b/kod/object/active/holder/room/monsroom/feyforst/b1.kod
@@ -35,7 +35,7 @@ properties:
    prMusic = OutdoorsB1_music
    piRoom_num = RID_B1
    
-   piGen_time = 180000
+   piGen_time = 25000
    
 messages:
    

--- a/kod/object/active/holder/room/monsroom/feyforst/b2.kod
+++ b/kod/object/active/holder/room/monsroom/feyforst/b2.kod
@@ -35,7 +35,7 @@ properties:
    prMusic = OutdoorsB2_music
    piRoom_num = RID_B2
    
-   piGen_time = 240000
+   piGen_time = 25000
 
 messages:
    

--- a/kod/object/active/holder/room/monsroom/feyforst/c1.kod
+++ b/kod/object/active/holder/room/monsroom/feyforst/c1.kod
@@ -33,7 +33,7 @@ properties:
    prMusic = OutdoorsC1_music
    piRoom_num = RID_C1
 
-   piGen_time = 100000
+   piGen_time = 25000
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/feyforst/c2.kod
+++ b/kod/object/active/holder/room/monsroom/feyforst/c2.kod
@@ -45,7 +45,7 @@ properties:
    prMusic = OutdoorsC2_music
    piRoom_num = RID_C2
    
-   piGen_time = 50000
+   piGen_time = 25000
    
    plFey_Forest = $
 

--- a/kod/object/active/holder/room/monsroom/feyforst/c3.kod
+++ b/kod/object/active/holder/room/monsroom/feyforst/c3.kod
@@ -36,7 +36,7 @@ properties:
    prMusic = OutdoorsC3_music
    piRoom_num = RID_C3
   
-   piGen_time = 150000  
+   piGen_time = 25000
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/feyforst/d1.kod
+++ b/kod/object/active/holder/room/monsroom/feyforst/d1.kod
@@ -36,7 +36,7 @@ properties:
    prMusic = OutdoorsD1_music
    piRoom_num = RID_D1
    
-   piGen_time = 180000
+   piGen_time = 25000
    
 messages:
 

--- a/kod/object/active/holder/room/monsroom/feyforst/d2.kod
+++ b/kod/object/active/holder/room/monsroom/feyforst/d2.kod
@@ -36,7 +36,7 @@ properties:
    prMusic = OutdoorsD2_music
    piRoom_num = RID_D2
 
-   piGen_time = 210000
+   piGen_time = 25000
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/g4.kod
+++ b/kod/object/active/holder/room/monsroom/g4.kod
@@ -47,13 +47,10 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 150000
-   piGen_percent = 40
+   piGen_percent = 90
 
-   piInit_count_min = 1
-   piInit_count_max = 4
-
-   piMonster_count_max = 7
+   piInit_count_min = 2
+   piInit_count_max = 5
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/g5.kod
+++ b/kod/object/active/holder/room/monsroom/g5.kod
@@ -40,8 +40,8 @@ properties:
 
    piBaseLight = LIGHT_NICE
    piOutside_factor = 8
-   piGen_time = 50000
-   piGen_percent = 40
+   piGen_time = 20000
+   piGen_percent = 70
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
@@ -50,7 +50,7 @@ properties:
    piInit_count_min = 1
    piInit_count_max = 3
 
-   piMonster_count_max = 7
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/g6.kod
+++ b/kod/object/active/holder/room/monsroom/g6.kod
@@ -44,7 +44,7 @@ properties:
 
    piBaseLight = LIGHT_NICE
    piOutside_factor = 8
-   piGen_time = 100000
+   piGen_time = 20000
    piGen_percent = 80
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
@@ -54,7 +54,7 @@ properties:
    piInit_count_min = 4
    piInit_count_max = 8
 
-   piMonster_count_max = 9
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/g8.kod
+++ b/kod/object/active/holder/room/monsroom/g8.kod
@@ -37,7 +37,7 @@ properties:
 
    piBaseLight = LIGHT_NICE
    piOutside_factor = 8
-   piGen_time = 100000
+   piGen_time = 20000
    piGen_percent = 80
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS

--- a/kod/object/active/holder/room/monsroom/h3.kod
+++ b/kod/object/active/holder/room/monsroom/h3.kod
@@ -45,13 +45,12 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 100000
-   piGen_percent = 60
+   piGen_percent = 90
 
    piInit_count_min = 2
    piInit_count_max = 4
 
-   piMonster_count_max = 6
+   piMonster_count_max = 12
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/h5.kod
+++ b/kod/object/active/holder/room/monsroom/h5.kod
@@ -45,7 +45,7 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 160000
+   piGen_time = 20000
    piGen_percent = 80
 
    piInit_count_min = 1

--- a/kod/object/active/holder/room/monsroom/h6.kod
+++ b/kod/object/active/holder/room/monsroom/h6.kod
@@ -48,7 +48,7 @@ properties:
    pbSnowGroundTexture = TRUE
 
 %   piGen_time = 45000
-   piGen_time = 25000 % temporarily increased from 25000
+   piGen_time = 20000 % temporarily increased from 25000
    piGen_percent = 80
 
 %% modified for press day
@@ -58,7 +58,7 @@ properties:
    piInit_count_min = 5  % minimum # of monsters loaded by first_user_enters
    piInit_count_max = 7  % maximum # of monsters loaded by initial load
 
-   piMonster_count_max = 7 % temporarily reduced from 13
+   piMonster_count_max = 12 % temporarily reduced from 13
 
 
 messages:

--- a/kod/object/active/holder/room/monsroom/h7.kod
+++ b/kod/object/active/holder/room/monsroom/h7.kod
@@ -45,13 +45,13 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 60000
+   piGen_time = 20000
    piGen_percent = 80
 
    piInit_count_min = 6
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/i3.kod
+++ b/kod/object/active/holder/room/monsroom/i3.kod
@@ -46,13 +46,13 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 45000
-   piGen_percent = 40
+   piGen_time = 20000
+   piGen_percent = 80
 
-   piInit_count_min = 0
-   piInit_count_max = 2
+   piInit_count_min = 1
+   piInit_count_max = 4
 
-   piMonster_count_max = 7
+   piMonster_count_max = 12
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/i6.kod
+++ b/kod/object/active/holder/room/monsroom/i6.kod
@@ -40,8 +40,8 @@ properties:
 
    piBaseLight = LIGHT_NICE
    piOutside_factor = 8
-   piGen_time = 80000
-   piGen_percent = 75
+   piGen_time = 20000
+   piGen_percent = 90
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
@@ -50,7 +50,7 @@ properties:
    piInit_count_min = 1
    piInit_count_max = 4
 
-   piMonster_count_max = 6
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/i7.kod
+++ b/kod/object/active/holder/room/monsroom/i7.kod
@@ -12,7 +12,7 @@ OutdoorsI7 is MonsterRoom
 
 constants:
 
-   include blakston.khd                                
+   include blakston.khd
 
 resources:
 
@@ -45,7 +45,7 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 45000
+   piGen_time = 25000
    piGen_percent = 80
 
    piInit_count_min = 8

--- a/kod/object/active/holder/room/monsroom/i8.kod
+++ b/kod/object/active/holder/room/monsroom/i8.kod
@@ -44,7 +44,7 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 80000
+   piGen_time = 20000
    piGen_percent = 80
 
    piInit_count_min = 8

--- a/kod/object/active/holder/room/monsroom/i9.kod
+++ b/kod/object/active/holder/room/monsroom/i9.kod
@@ -60,7 +60,7 @@ properties:
 
    ptDoorway = $
 
-   piGen_time = 70000
+   piGen_time = 25000
    piGen_percent = 85
 
    piInit_count_min = 9

--- a/kod/object/active/holder/room/monsroom/j3.kod
+++ b/kod/object/active/holder/room/monsroom/j3.kod
@@ -48,13 +48,13 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 180000
-   piGen_percent = 60
+   piGen_time = 20000
+   piGen_percent = 90
 
    piInit_count_min = 1
    piInit_count_max = 3
 
-   piMonster_count_max = 5
+   piMonster_count_max = 8
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/jassew1.kod
+++ b/kod/object/active/holder/room/monsroom/jassew1.kod
@@ -83,7 +83,7 @@ properties:
 
    prMusic = jassew1_music
 
-   piGen_time = 80000
+   piGen_time = 30000
    piGen_percent = 80
 
    piInit_count_min = 6

--- a/kod/object/active/holder/room/monsroom/jassew2.kod
+++ b/kod/object/active/holder/room/monsroom/jassew2.kod
@@ -43,7 +43,7 @@ properties:
 
    prMusic = jassew2_music
 
-   piGen_time = 55000
+   piGen_time = 30000
    piGen_percent = 80
 
    piInit_count_min = 5

--- a/kod/object/active/holder/room/monsroom/jassew3.kod
+++ b/kod/object/active/holder/room/monsroom/jassew3.kod
@@ -44,7 +44,7 @@ properties:
 
    prMusic = jassew3_music
 
-   piGen_time = 35000
+   piGen_time = 30000
    piGen_percent = 80
 
    piInit_count_min = 5

--- a/kod/object/active/holder/room/monsroom/kcforest/ka1.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/ka1.kod
@@ -44,13 +44,13 @@ properties:
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
-   piGen_time = 90000
+   piGen_time = 35000
    piGen_percent = 70
 
    piInit_count_min = 5
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/kcforest/ka2.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/ka2.kod
@@ -43,13 +43,13 @@ properties:
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
-   piGen_time = 90000
+   piGen_time = 20000
    piGen_percent = 70
 
    piInit_count_min = 5
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
 messages:
      

--- a/kod/object/active/holder/room/monsroom/kcforest/ka3.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/ka3.kod
@@ -43,13 +43,13 @@ properties:
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
-   piGen_time = 90000
+   piGen_time = 20000
    piGen_percent = 70
 
    piInit_count_min = 5
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/kcforest/ka4.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/ka4.kod
@@ -43,13 +43,13 @@ properties:
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
-   piGen_time = 90000
+   piGen_time = 25000
    piGen_percent = 70
 
    piInit_count_min = 5
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/kcforest/ka5.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/ka5.kod
@@ -41,13 +41,13 @@ properties:
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
-   piGen_time = 90000
+   piGen_time = 20000
    piGen_percent = 70
 
    piInit_count_min = 5
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/kcforest/kb1.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/kb1.kod
@@ -42,13 +42,13 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 90000
+   piGen_time = 25000
    piGen_percent = 70
 
    piInit_count_min = 5
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/kcforest/kb2.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/kb2.kod
@@ -43,13 +43,13 @@ properties:
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
-   piGen_time = 90000
+   piGen_time = 25000
    piGen_percent = 70
 
    piInit_count_min = 5
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/kcforest/kb3.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/kb3.kod
@@ -42,13 +42,13 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 90000
+   piGen_time = 25000
    piGen_percent = 70
 
    piInit_count_min = 5
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/kcforest/kb4.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/kb4.kod
@@ -41,7 +41,7 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 90000
+   piGen_time = 30000
    piGen_percent = 70
 
    piInit_count_min = 5

--- a/kod/object/active/holder/room/monsroom/kcforest/kb5.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/kb5.kod
@@ -39,13 +39,13 @@ properties:
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
-   piGen_time = 90000
+   piGen_time = 25000
    piGen_percent = 70
 
    piInit_count_min = 5
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
    pbSnowGroundTexture = TRUE
 

--- a/kod/object/active/holder/room/monsroom/kcforest/kc1.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/kc1.kod
@@ -41,13 +41,13 @@ properties:
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
-   piGen_time = 90000
+   piGen_time = 25000
    piGen_percent = 70
 
    piInit_count_min = 5
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
    pbSnowGroundTexture = TRUE
 

--- a/kod/object/active/holder/room/monsroom/kcforest/kc2.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/kc2.kod
@@ -41,13 +41,13 @@ properties:
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
-   piGen_time = 90000
+   piGen_time = 25000
    piGen_percent = 70
 
    piInit_count_min = 5
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
    pbSnowGroundTexture = TRUE
 

--- a/kod/object/active/holder/room/monsroom/kcforest/kc4.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/kc4.kod
@@ -45,7 +45,7 @@ properties:
    piInit_count_min = 7
    piInit_count_max = 13
 
-   piMonster_count_max = 13
+   piMonster_count_max = 15
 
    pbSnowGroundTexture = TRUE
 

--- a/kod/object/active/holder/room/monsroom/kcforest/kd1.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/kd1.kod
@@ -41,13 +41,13 @@ properties:
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
-   piGen_time = 90000
+   piGen_time = 25000
    piGen_percent = 70
 
    piInit_count_min = 5
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
    pbSnowGroundTexture = TRUE
 

--- a/kod/object/active/holder/room/monsroom/kcforest/kd2.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/kd2.kod
@@ -39,13 +39,13 @@ properties:
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
-   piGen_time = 90000
+   piGen_time = 25000
    piGen_percent = 70
 
    piInit_count_min = 5
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
    pbSnowGroundTexture = TRUE
 

--- a/kod/object/active/holder/room/monsroom/kcforest/kd3.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/kd3.kod
@@ -39,13 +39,13 @@ properties:
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
-   piGen_time = 90000
+   piGen_time = 25000
    piGen_percent = 70
 
    piInit_count_min = 5
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
    pbSnowGroundTexture = TRUE
 

--- a/kod/object/active/holder/room/monsroom/kcforest/ke2.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/ke2.kod
@@ -41,13 +41,13 @@ properties:
 
    piDirectional_percent = DIRECTIONAL_PERCENT_OUTDOORS
 
-   piGen_time = 90000
+   piGen_time = 25000
    piGen_percent = 70
 
    piInit_count_min = 5
    piInit_count_max = 9
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/kcforest/ke4.kod
+++ b/kod/object/active/holder/room/monsroom/kcforest/ke4.kod
@@ -93,13 +93,13 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 60000
+   piGen_time = 30000
    piGen_percent = 80
 
    piInit_count_min = 7
    piInit_count_max = 10
 
-   piMonster_count_max = 12
+   piMonster_count_max = 15
 
    % Used to give cute message for people trying to drown themselves.
    piCount = 0

--- a/kod/object/active/holder/room/monsroom/kocsew1.kod
+++ b/kod/object/active/holder/room/monsroom/kocsew1.kod
@@ -46,7 +46,7 @@ properties:
 
    prMusic = kocsew1_music
 
-   piGen_time = 80000
+   piGen_time = 40000
    piGen_percent = 20
 
    piInit_count_min = 0

--- a/kod/object/active/holder/room/monsroom/necare3a.kod
+++ b/kod/object/active/holder/room/monsroom/necare3a.kod
@@ -39,7 +39,7 @@ properties:
    piBaseLight = LIGHT_MIN
    piOutside_factor = 0
 
-   piGen_time = 40000
+   piGen_time = 25000
    piGen_percent = 80
 
    piInit_count_min = 7

--- a/kod/object/active/holder/room/monsroom/necare3b.kod
+++ b/kod/object/active/holder/room/monsroom/necare3b.kod
@@ -39,7 +39,7 @@ properties:
    piBaseLight = LIGHT_MIN
    piOutside_factor = 0
 
-   piGen_time = 40000
+   piGen_time = 25000
    piGen_percent = 80
 
    piInit_count_min = 7

--- a/kod/object/active/holder/room/monsroom/necarea1.kod
+++ b/kod/object/active/holder/room/monsroom/necarea1.kod
@@ -41,7 +41,7 @@ properties:
    piBaseLight = LIGHT_DARK
    piOutside_factor = 0
 
-   piGen_time = 40000
+   piGen_time = 25000
    piGen_percent = 80
 
    piInit_count_min = 7

--- a/kod/object/active/holder/room/monsroom/necarea2.kod
+++ b/kod/object/active/holder/room/monsroom/necarea2.kod
@@ -39,7 +39,7 @@ properties:
    piBaseLight = LIGHT_VERY_DARK
    piOutside_factor = 0
 
-   piGen_time = 40000
+   piGen_time = 25000
    piGen_percent = 80
 
    piInit_count_min = 7

--- a/kod/object/active/holder/room/monsroom/necarea3.kod
+++ b/kod/object/active/holder/room/monsroom/necarea3.kod
@@ -49,7 +49,7 @@ properties:
    piBaseLight = LIGHT_MIN
    piOutside_factor = 0
 
-   piGen_time = 40000
+   piGen_time = 25000
    piGen_percent = 80
 
    piInit_count_min = 7

--- a/kod/object/active/holder/room/monsroom/necarea4.kod
+++ b/kod/object/active/holder/room/monsroom/necarea4.kod
@@ -39,7 +39,7 @@ properties:
    piBaseLight = LIGHT_MIN
    piOutside_factor = 0
 
-   piGen_time = 40000
+   piGen_time = 25000
    piGen_percent = 80
 
    piInit_count_min = 7

--- a/kod/object/active/holder/room/monsroom/necarea5.kod
+++ b/kod/object/active/holder/room/monsroom/necarea5.kod
@@ -45,7 +45,7 @@ properties:
    piBaseLight = LIGHT_MIN
    piOutside_factor = 0
 
-   piGen_time = 40000
+   piGen_time = 25000
    piGen_percent = 80
 
    piInit_count_min = 7

--- a/kod/object/active/holder/room/monsroom/objroom/b6.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/b6.kod
@@ -45,13 +45,12 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 45000
    piGen_percent = 80
 
    piInit_count_min = 4
    piInit_count_max = 8
 
-   piMonster_count_max = 13
+   piMonster_count_max = 15
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/objroom/c5.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/c5.kod
@@ -46,13 +46,13 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 70000
+   piGen_time = 20000
    piGen_percent = 70
 
    piInit_count_min = 1
    piInit_count_max = 4
 
-   piMonster_count_max = 6
+   piMonster_count_max = 10
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/objroom/c7.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/c7.kod
@@ -45,13 +45,13 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 45000
+   piGen_time = 25000
    piGen_percent = 80
 
    piInit_count_min = 6
    piInit_count_max = 12
 
-   piMonster_count_max = 8
+   piMonster_count_max = 10
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/objroom/cave2.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/cave2.kod
@@ -41,7 +41,7 @@ properties:
 
    piOutside_factor = OUTDOORS_2
 
-   piGen_time = 35000
+   piGen_time = 20000
    piGen_percent = 80
 
    piGen_Object_Time = 1200000

--- a/kod/object/active/holder/room/monsroom/objroom/e6.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/e6.kod
@@ -45,7 +45,7 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 45000
+   piGen_time = 20000
    piGen_percent = 80
 
    piInit_count_min = 5

--- a/kod/object/active/holder/room/monsroom/objroom/h4.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/h4.kod
@@ -48,13 +48,13 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 120000
+   piGen_time = 20000
    piGen_percent = 70
 
    piInit_count_min = 2
    piInit_count_max = 5
 
-   piMonster_count_max = 8
+   piMonster_count_max = 10
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/objroom/h9.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/h9.kod
@@ -44,7 +44,7 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 80000
+   piGen_time = 20000
    piGen_percent = 80
 
    piGen_object_time = 600000
@@ -52,7 +52,7 @@ properties:
    piInit_count_min = 8
    piInit_count_max = 12
 
-   piMonster_count_max = 15
+   piMonster_count_max = 20
 
 messages:
 

--- a/kod/object/active/holder/room/monsroom/objroom/icecave1.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/icecave1.kod
@@ -48,13 +48,13 @@ properties:
    piBaseLight = LIGHT_NICE
    piOutside_factor = 8
 
-   piGen_time = 25000
+   piGen_time = 20000
    piGen_percent = 100
 
    piInit_count_min = 6
    piInit_count_max = 8
 
-   piMonster_count_max = 13
+   piMonster_count_max = 20
 
    ptYeti_gen = $
    ptManaDoor_Timer = $

--- a/kod/object/active/holder/room/monsroom/objroom/k5.kod
+++ b/kod/object/active/holder/room/monsroom/objroom/k5.kod
@@ -44,7 +44,7 @@ properties:
 
    pbSnowGroundTexture = TRUE
 
-   piGen_time = 60000
+   piGen_time = 25000
    piGen_percent = 80
 
    piInit_count_min = 5


### PR DESCRIPTION
Lowered monster generation times across all mob spawning rooms. Increased the max monster count in some rooms. I still think some of these values could be better, but this should be a good point to move forward from.

Notably, a lot of rooms are bad for building in because the gen time is so low. A lot of rooms are now closer to the default, which is 15 sec gen time. Default number of mobs to spawn is 10, which is probably too low (I think we should set this to 25, and set rooms lower if we need them to be but I haven't done this yet).

Vale rooms are all set to around 25 sec (down from 2-4 minutes). Vale node will still work, and will probably be easier.