### PR TITLE
Fix parameter handling for resource-based admin commands.

### DIFF
--- a/blakserv/adminfn.c
+++ b/blakserv/adminfn.c
@@ -571,7 +571,7 @@ void AdminBufferSend(char *buf,int len_buf)
 void AdminSendBufferList(void)
 {
 	session_node *s;
-	buffer_node *bn;
+	buffer_node *bn = NULL;
 	unsigned short len;
 	
 	s = GetSessionByID(admin_session_id);
@@ -831,7 +831,12 @@ void AdminTable(int len_command_table,admin_table_type command_table[],int sessi
 			break;
 		case R :
 			/* remember how strtok works to see why this works */
-			admin_parm[i] = (admin_parm_type) (prev_tok + strlen(prev_tok) + 1);
+			admin_parm[i] = (admin_parm_type)strtok(NULL, " \t\n");
+			if (!admin_parm[i])
+			{
+				aprintf("Missing text parameter.\n");
+				return;
+			}
 			/* now make sure no more params */
 			prev_tok = NULL;
 			break;
@@ -1227,16 +1232,16 @@ void AdminWhoEachSession(session_node *s)
 void AdminLock(int session_id,admin_parm_type parms[],
                int num_blak_parm,parm_node blak_parm[])               
 {
-	char *ptr;
+	char *ptr = NULL;
 	char *lockstr;
 	
-	char *text;
+	char *text = NULL;
 	text = (char *)parms[0];
 	
 	lockstr = ConfigStr(LOCK_DEFAULT);
 	
 	ptr = text;
-	while (*ptr != 0)
+	while (ptr && *ptr != 0)
 	{
 		if (*ptr != ' ' && *ptr != '\n' && *ptr != '\t')
 		{
@@ -1746,6 +1751,11 @@ void AdminShowAccount(int session_id,admin_parm_type parms[],
 	is_account_number = True;
 	
 	ptr = account_str;
+	if (!ptr)
+	{
+		aprintf("Missing account string.\n");
+		return;
+	}
 	while (*ptr != 0)
 	{
 		if (*ptr < '0' || *ptr > '9')
@@ -3925,6 +3935,8 @@ void AdminSendUsers(int session_id,admin_parm_type parms[],
 	char *text;
 	text = (char *)parms[0];
 	
+	if (!text)
+		return;
 	SetTempString(text,strlen(text));
 	str_val.v.tag = TAG_TEMP_STRING;
 	str_val.v.data = 0;		/* doesn't matter for TAG_TEMP_STRING */

--- a/blakserv/adminfn.c
+++ b/blakserv/adminfn.c
@@ -1319,9 +1319,9 @@ void AdminShowStatus(int session_id,admin_parm_type parms[],
                      int num_blak_parm,parm_node blak_parm[])
 {
 	kod_statistics *kstat;
-	object_node *o;
-	class_node *c;
-	char *m;
+	object_node *o = NULL;
+	class_node *c = NULL;
+	char *m = NULL;
 	int now = GetTime();
 	
 	aprintf("System Status -----------------------------\n");
@@ -1347,11 +1347,11 @@ void AdminShowStatus(int session_id,admin_parm_type parms[],
 	aprintf("Most instructions on one top level message is %i instructions\n",kstat->num_interpreted_highest);
 	aprintf("Number of top level messages over 1000 milliseconds is %i\n",kstat->interpreting_time_over_second);
 	aprintf("Longest time on one top level message is %i milliseconds\n",kstat->interpreting_time_highest);
-	
 	if (kstat->interpreting_time_object_id != INVALID_ID)
 	{
 		o = GetObjectByID(kstat->interpreting_time_object_id);
-		c = o? GetClassByID(o->class_id) : NULL;
+		c = o ? GetClassByID(o->class_id) : NULL;
+	}
 		m = GetNameByID(kstat->interpreting_time_message_id);
 		aprintf("Most recent slow top level message is OBJECT %i CLASS %s MESSAGE %s\n",
 			kstat->interpreting_time_object_id,
@@ -1359,7 +1359,6 @@ void AdminShowStatus(int session_id,admin_parm_type parms[],
 			(char*)(m? m : "(unknown)"));
 		aprintf("Most recent slow top level message includes %i posted followups\n",
 			kstat->interpreting_time_posts);
-	}
 	
 	aprintf("----\n");
 	aprintf("Active accounts: %i\n",GetActiveAccountCount());
@@ -2179,6 +2178,7 @@ void AdminShowMessage(int session_id,admin_parm_type parms[],
 	if (c != found_class)
 		aprintf(" (handled by CLASS %s)",found_class->class_name);
 	aprintf("\n");
+	aprintf("Called count: %i\n", m->called_count);
 	aprintf("--------------------------------------------------------------\n");
 	aprintf("  Parameters:\n");
 	/* we need to read the first few bytes from the bkod to get the parms */

--- a/blakserv/class.c
+++ b/blakserv/class.c
@@ -444,7 +444,7 @@ void ForEachClass(void (*callback_func)(class_node *c))
 
 const char * GetClassDebugStr(class_node *c,int dstr_id)
 {
-	if (dstr_id > c->dstrs->num_strings)
+	if (dstr_id > c->dstrs->num_strings || dstr_id < 0)
 	{
 		eprintf("GetClassDebugStr got invalid dstr id, %i %i\n",c->class_id,dstr_id);
 		return "Invalid DStr";

--- a/blakserv/interface.c
+++ b/blakserv/interface.c
@@ -1150,7 +1150,7 @@ BOOL CALLBACK InterfaceDialogTabPage(HWND hwnd,UINT message,UINT wParam,LONG lPa
 
 void InterfaceTabPageCommand(HWND hwnd,int id, HWND hwndCtl, UINT codeNotify)
 {
-	char s[400];
+	char s[4096];
 	
 	switch (codeNotify)
 	{


### PR DESCRIPTION
When reading resource parameters, the code was assuming that the
parameters were present without actually checking for them. This was
most noticeable with the "lock" command, which displayed garbage if no
lock text was given as it reads past the end of the "lock" string to
find the requested lock text.

Changed the 'R' parameter-based admin commands to use strtok correctly,
so the commands will now fail if the parameter is not present. This does
mean that lock will no longer work on its own, the alternative is to let
NULL through here but handle it correctly for every single
resource-based admin command (most of them cause blakserv to crash when
passed NULL).

Added a few safety checks, and increased the length of a buffer that
was causing blakserv to crash when viewing large debug messages
in the server dialog box.

Added some more information to two admin commands:
* AdminShowStatus will now show the most recent slow message even after
the object ID has become invalid.
* AdminShowMessage will show the called count (# of times called) for the
message.

Example: http://i.imgur.com/DKWCdNO.png