### PR TITLE
Increase loyalty time from 24hr to 48hr.

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2458,12 +2458,12 @@
    INTRIGUE_ENABLE_HP = 50
    INTRIGUE_ENABLE_SPELL = 40 
 
-   % Four hours, in seconds.
-   FACTION_MIN_REVISIT_TIME   = 14400
-   % 24 hours, in seconds.
-   FACTION_RESIGN_TIME        = 86400
-   % 20 hours, in seconds.
-   FACTION_WARN_TIME          = 72000
+   % One hour, in seconds.
+   FACTION_MIN_REVISIT_TIME   = 3600
+   % 48 hours, in seconds.
+   FACTION_RESIGN_TIME        = 172800
+   % 44 hours, in seconds.
+   FACTION_WARN_TIME          = 158400
    % 20 min, in milleseconds.
    FACTION_UPDATE_TIME        = 1200000
 


### PR DESCRIPTION
Currently players get kicked out of a faction after 24 hours of online
time, increased that to 48 hours. Lowered the minimum revisit time to 1
hour (from 4) and increased 'warn' time to 44 hours.