### PR TITLE
Add maximum HP for player suicides.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -276,6 +276,11 @@ resources:
       "You can't kill yourself now, not when you're the sacred guardian of a "
       "Meridian token!"
 
+   user_cant_suicide_hp = \
+      "You've accomplished much so far in your time here, and you can't quite "
+      "stomach the thought of ending your journey now.  If you have a good "
+      "reason for suiciding, perhaps one of the Gods will assist you."
+
    user_cant_suicide_OOG = \
       "Somehow, even though you deserve it, you are unable to bear the "
       "thought of killing yourself now."
@@ -1662,21 +1667,28 @@ messages:
          {
             Send(self,@MsgSendUser,#message_rsc=user_cant_suicide_OOG);
             
-            return;            
+            return;
          }
          
-         if getTime() < piLast_restart_time + SUICIDE_REPEAT_TIME
+         if GetTime() < piLast_restart_time + SUICIDE_REPEAT_TIME
          {
             Send(self,@MsgSendUser,#message_rsc=user_cant_suicide_yet);
             
-            return;            
+            return;
          }
 
          if Send(self,@FindHolding,#class=&Token)
          {
             Send(self,@MsgSendUser,#message_rsc=user_cant_suicide_token);
             
-            return;                 
+            return;
+         }
+
+         if Send(Send(SYS,@GetSettings),@GetMaxSuicideHP) <= piBase_Max_health
+         {
+            Send(self,@MsgSendUser,#message_rsc=user_cant_suicide_hp);
+
+            return;
          }
 
          % Successful SUICIDE.

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -89,6 +89,11 @@ properties:
    % The default time for building group membership.
    piDefaultGroupTime = 60000
 
+   % The maximum HP a player can suicide their character at, without admin
+   % help. Prevents people making mistakes in a fit of rage, or suiciding
+   % hacked accounts.
+   piMaxSuicideHP =  60
+
    %
    % Spell settings
    %
@@ -383,6 +388,11 @@ messages:
    GetDefaultGroupTime()
    {
       return piDefaultGroupTime;
+   }
+
+   GetMaxSuicideHP()
+   {
+      return piMaxSuicideHP;
    }
 
    %


### PR DESCRIPTION
This one might be a little controversial.

There have been several cases where users have suicided multiple built characters, and this is usually in a fit of rage that they later regret. Meridian characters can take hundreds of hours to build for less
experienced players, and I don't think we should allow it to be negated due to momentary anger. One of the high profile suiciders recently contacted me asking if we can restore his accounts, and I had to tell him that we could not.

In addition, this will prevent hacked/shared accounts from being suicided maliciously (this also happened recently).

Players who really need to suicide their characters can contact an admin, and we can do it for them. I've set the limit to 60HP - with the stat reset system, legit suicides over that amount should be very rare.