### PR TITLE
Add name change system to Caramo.

### DIFF
--- a/blakserv/ccode.c
+++ b/blakserv/ccode.c
@@ -1134,6 +1134,17 @@ int C_SetResource(int object_id,local_var_type *local_vars,
 			new_str = r->resource_val;
 			break;
 		}
+	case TAG_STRING :
+		snod = GetStringByID(str_val.v.data);
+		if (snod == NULL)
+		{
+			bprintf( "C_SetResource can't set from bad string %i\n",
+				str_val.v.data);
+			return NIL;
+		}
+		new_len = snod->len_data;
+		new_str = snod->data;
+		break;
 	default :
 		bprintf("C_SetResource can't set from non temp string %i,%i\n",
 			str_val.v.tag,str_val.v.data);

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -184,8 +184,8 @@ resources:
    vaultman_nodeposit_cash = \
       "Storing these items would cost %i shillings - which I see you do not "
       "have."
-   vaultman_cant_part = "\
-      Wow... I couldn't feel responsible if your %s were to disappear - I "
+   vaultman_cant_part = \
+      "Wow... I couldn't feel responsible if your %s were to disappear - I "
       "cannot store it."
    vaultman_noaccount = "I do not seem to be storing any of your gear."
    vaultman_not_enough = "You don't have that many %s stored in your name!"

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.kod
@@ -101,6 +101,36 @@ resources:
       "According to the Royal Paperwork Reduction Act, ballots are no "
       "longer used in this office."
 
+   % Name changing.
+   barloque_clerk_trigger_change = "change"
+   barloque_clerk_trigger_name = "name"
+   barloque_clerk_change_name = \
+      "Yes, I can change your legal name by deed poll.  Simply fill out your "
+      "new name on this scroll and return it. If it is available and not "
+      "obscene, it shall be yours.  I must warn you, there is a fee of %i "
+      "shillings for providing this service, which will be deducted from "
+      "your bank account."
+   barloque_clerk_cant_hold = \
+      "I can change your legal name by deed poll, but you have no room in "
+      "your inventory to hold the scroll you would need to fill out."
+   barloque_clerk_warning_cost = \
+      "I must warn you again before I complete this process, that you will be "
+      "charged %i shillings for this service.  If you are positive you wish "
+      "to pay the fee, I will accept your scroll."
+   barloque_clerk_not_enough = \
+      "You do not have enough money in your bank account for this service."
+   barloque_clerk_bad_name = \
+      "Sorry, that username is not valid."
+   barloque_clerk_name_changed = \
+      "Your name has been changed."
+
+   barloque_clerk_name_post_1 = "'s name has been changed"
+   barloque_clerk_name_post_2 = "Let it be known that "
+   barloque_clerk_name_post_3 = \
+      "'s name has been changed by deed poll to "
+   barloque_clerk_name_post_4 = \
+      ". So it has been spoken, so shall it be done. \n\n-- Caramo"
+
 classvars:
 
    vrName = barloque_clerk_name_rsc
@@ -120,21 +150,37 @@ properties:
 
    piCommand = COMMAND_NONE
 
+   % A list containing players who have received the name change cost
+   % warning, to avoid players obtaining a ballot and giving it to
+   % Caramo "accidentally".
+   plNameChangeWarn = $
+
 messages:
 
    Constructor()
    {
-      plWantedItems = [ &BallotItem, &Money ];
+      plWantedItems = [ &NameChangeScroll, &BallotItem, &Money ];
       Send(SYS,@SetCaramo,#oCaramo=self);
 
       piJusticar_State = STATE_NO_ELECTIONS;
+
+      plNameChangeWarn = $;
 
       propagate;
    }
 
    GotWantedItem(obj=$,who=$)
    {
-      if IsClass(obj, &BallotItem)
+      if IsClass(obj,&NameChangeScroll)
+      {
+         % Deed poll can be used to change a player's name.
+         % Returns TRUE if successful, otherwise give the scroll back.
+         Send(self,@TryChangePlayerName,#who=who,#oItem=obj);
+
+         return;
+      }
+
+      if IsClass(obj,&BallotItem)
       {
          Post(poOwner,@SomeoneSaid,#what=self,#string=no_more_ballots,
                #type=SAY_RESOURCE);
@@ -148,6 +194,87 @@ messages:
       }
 
       propagate;
+   }
+
+   TryChangePlayerName(who=$,oItem=$)
+   "Attempts to change a player's name. If they've been warned, and they can "
+   "pay the fee, will check with System to see if the name is valid. If it "
+   "is, name will be changed."
+   {
+      local i, iAmount, oBank;
+
+      if who = $
+         OR oItem = $
+      {
+         return;
+      }
+
+      iAmount = Send(Send(SYS,@GetSettings),@GetNameChangeCost);
+
+      % No existing list, add player and warn, give ballot back.
+      if plNameChangeWarn = $
+      {
+         plNameChangeWarn = [who];
+         Send(self,@SayToOne,#message_rsc=barloque_clerk_warning_cost,
+               #target=who,#parm1=iAmount);
+         Send(who,@NewHold,#what=oItem);
+
+         return;
+      }
+
+      for i in plNameChangeWarn
+      {
+         if i = who
+         {
+            % Check if name is valid.
+            if NOT Send(SYS,@ValidateUserName,#oUser=who,
+                        #sName=Send(oItem,@GetInscription))
+            {
+               Send(self,@SayToOne,#target=who,
+                     #message_rsc=barloque_clerk_bad_name);
+
+               return;
+            }
+
+            % Get player's bank account.
+            oBank = Send(SYS,@FindBankByNum,#num=BID_TOS);
+            if Send(oBank,@GetAccount,#what=who) >= iAmount
+            {
+               % Player has enough money, change their name and take the
+               % money.
+               Send(oBank,@WithdrawAccount,#what=who,#amount=iAmount);
+               Send(self,@SayToOne,#target=who,
+                     #message_rsc=barloque_clerk_name_changed);
+               % Record the name change in the Book of Jala.
+               Send(self,@RecordNameChangeBook,#parm1=Send(who,@GetTrueName),
+                     #parm2=Send(oItem,@GetInscription));
+               % System will handle changing the name.
+               Send(SYS,@ChangeUserName,#oUser=who,
+                     #sName=Send(oItem,@GetInscription));
+               Send(oItem,@Delete);
+               plNameChangeWarn = DelListElem(plNameChangeWarn,i);
+
+               return;
+            }
+            else
+            {
+               % Not enough money, return scroll.
+               Send(self,@SayToOne,#target=who,
+                     #message_rsc=barloque_clerk_not_enough);
+               Send(who,@NewHold,#what=oItem);
+
+               return;
+            }
+         }
+      }
+
+      % Player wasn't in list, add them and give ballot back.
+      plNameChangeWarn = Cons(who,plNameChangeWarn);
+      Send(self,@SayToOne,#message_rsc=barloque_clerk_warning_cost,
+            #target=who,#parm1=iAmount);
+      Send(who,@NewHold,#what=oItem);
+
+      return;
    }
 
    CheckForIndulgence(who=$,obj=0)
@@ -236,11 +363,35 @@ messages:
       return;
    }
 
+   RecordNameChangeBook(parm1=$, parm2=$)
+   "parm1=oldname,parm2=newname"
+   {
+      local sString, sString2, oBook;
+
+      ClearTempString();
+      AppendTempString(parm1);
+      AppendTempString(barloque_clerk_name_post_1);
+      sString = SetString($,GetTempString());
+
+      ClearTempString();
+      AppendTempString(barloque_clerk_name_post_2);
+      AppendTempString(parm1);
+      AppendTempString(barloque_clerk_name_post_3);
+      AppendTempString(parm2);
+      AppendTempString(barloque_clerk_name_post_4);
+      sString2 = SetString($,GetTempString());
+
+      oBook = Send(poOwner,@GetBook);
+      Send(oBook,@PostNews,#what=self,#title=sString,#body=sString2);
+
+      return;
+   }
+
    %%% Handling citizen commands.
 
    SomeoneSaid(what=$,type=$,string=$)
    {
-      local iRow, iCol, oTarget;
+      local iRow, iCol, oTarget, iAmount, oScroll;
 
       if what = $ OR NOT IsClass(what,&Player)
       {
@@ -257,6 +408,27 @@ messages:
 
             return;
          }
+      }
+
+      if StringContain(string,barloque_clerk_trigger_change)
+         AND StringContain(string,barloque_clerk_trigger_change)
+      {
+         iAmount = Send(Send(SYS,@GetSettings),@GetNameChangeCost);
+         oScroll = Create(&NameChangeScroll);
+
+         if Send(what,@ReqNewHold,#what=oScroll)
+         {
+            Send(self,@SayToOne,#target=what,
+                  #message_rsc=barloque_clerk_change_name,#parm1=iAmount);
+            Send(what,@NewHold,#what=oScroll);
+         }
+         else
+         {
+            Send(self,@SayToOne,#target=what,
+                  #message_rsc=barloque_clerk_cant_hold);
+         }
+
+         return;
       }
 
       propagate;
@@ -314,6 +486,8 @@ messages:
 
    Delete()
    {
+      plNameChangeWarn = $;
+
       Send(SYS,@DeleteCaramo);
 
       propagate;

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/barlqtwn/bqclerk.kod
@@ -114,7 +114,7 @@ resources:
       "I can change your legal name by deed poll, but you have no room in "
       "your inventory to hold the scroll you would need to fill out."
    barloque_clerk_warning_cost = \
-      "I must warn you again before I complete this process, that you will be "
+      "~BI must warn you again before I complete this process, that you will be "
       "charged %i shillings for this service.  If you are positive you wish "
       "to pay the fee, I will accept your scroll."
    barloque_clerk_not_enough = \
@@ -157,9 +157,21 @@ properties:
 
 messages:
 
+   Recreate()
+   "Delete outstanding scrolls, verify wanted items and clear warn list."
+   {
+      Send(self,@SetWantedItems);
+
+      % Clear the name change warning list and delete outstanding scrolls.
+      Send(&NameChangeScroll,@Delete);
+      plNameChangeWarn = $;
+
+      return;
+   }
+
    Constructor()
    {
-      plWantedItems = [ &NameChangeScroll, &BallotItem, &Money ];
+      Send(self,@SetWantedItems);
       Send(SYS,@SetCaramo,#oCaramo=self);
 
       piJusticar_State = STATE_NO_ELECTIONS;
@@ -167,6 +179,13 @@ messages:
       plNameChangeWarn = $;
 
       propagate;
+   }
+
+   SetWantedItems()
+   {
+      plWantedItems = [ &NameChangeScroll, &BallotItem, &Money ];
+
+      return;
    }
 
    GotWantedItem(obj=$,who=$)
@@ -211,13 +230,12 @@ messages:
 
       iAmount = Send(Send(SYS,@GetSettings),@GetNameChangeCost);
 
-      % No existing list, add player and warn, give ballot back.
+      % No existing list, add player and warn.
       if plNameChangeWarn = $
       {
          plNameChangeWarn = [who];
          Send(self,@SayToOne,#message_rsc=barloque_clerk_warning_cost,
                #target=who,#parm1=iAmount);
-         Send(who,@NewHold,#what=oItem);
 
          return;
       }
@@ -251,28 +269,47 @@ messages:
                % System will handle changing the name.
                Send(SYS,@ChangeUserName,#oUser=who,
                      #sName=Send(oItem,@GetInscription));
+               % Scroll handles removing player from plNameChangeWarn list.
                Send(oItem,@Delete);
-               plNameChangeWarn = DelListElem(plNameChangeWarn,i);
 
                return;
             }
             else
             {
-               % Not enough money, return scroll.
+               % Not enough money.
                Send(self,@SayToOne,#target=who,
                      #message_rsc=barloque_clerk_not_enough);
-               Send(who,@NewHold,#what=oItem);
 
                return;
             }
          }
       }
 
-      % Player wasn't in list, add them and give ballot back.
+      % Player wasn't in list, add them.
       plNameChangeWarn = Cons(who,plNameChangeWarn);
       Send(self,@SayToOne,#message_rsc=barloque_clerk_warning_cost,
             #target=who,#parm1=iAmount);
-      Send(who,@NewHold,#what=oItem);
+
+      return;
+   }
+
+   RemoveFromWarnList(who=$)
+   {
+      local i;
+
+      if who = $
+         OR plNameChangeWarn = $
+      {
+         return;
+      }
+
+      for i in plNameChangeWarn
+      {
+         if i = who
+         {
+            plNameChangeWarn = DelListElem(plNameChangeWarn,who);
+         }
+      }
 
       return;
    }
@@ -406,12 +443,18 @@ messages:
          {
             Send(self,@CitizenRequestsPlayerRecord,#citizen=what,#who=oTarget);
 
-            return;
+            % Unlikely, but check if the player's name would interfere with
+            % the name change system.
+            if NOT (StringContain(string,barloque_clerk_trigger_change)
+               AND StringContain(string,barloque_clerk_trigger_name))
+            {
+               return;
+            }
          }
       }
 
       if StringContain(string,barloque_clerk_trigger_change)
-         AND StringContain(string,barloque_clerk_trigger_change)
+            AND StringContain(string,barloque_clerk_trigger_name)
       {
          iAmount = Send(Send(SYS,@GetSettings),@GetNameChangeCost);
          oScroll = Create(&NameChangeScroll);
@@ -420,12 +463,22 @@ messages:
          {
             Send(self,@SayToOne,#target=what,
                   #message_rsc=barloque_clerk_change_name,#parm1=iAmount);
-            Send(what,@NewHold,#what=oScroll);
+
+            % Don't give out multiple scrolls.
+            if Send(what,@FindHolding,#class=&NameChangeScroll) = $
+            {
+               Send(what,@NewHold,#what=oScroll);
+            }
+            else
+            {
+               Send(oScroll,@Delete);
+            }
          }
          else
          {
             Send(self,@SayToOne,#target=what,
                   #message_rsc=barloque_clerk_cant_hold);
+            Send(oScroll,@Delete);
          }
 
          return;

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -1598,6 +1598,8 @@ messages:
    "appropriate. This function will force a suicide and clean up anything, "
    "ignoring game rules."
    {
+      local sName;
+
       Send(self,@CancelIfOffer);
 
       if poGuild <> $
@@ -1616,11 +1618,18 @@ messages:
 
       if pbLogged_on
       {
-         addPacket(1,BP_USERCOMMAND,1,UC_SEND_QUIT);
+         AddPacket(1,BP_USERCOMMAND,1,UC_SEND_QUIT);
          SendPacket(poSession);
       }
 
+      % Change the name to a unique placeholder one.
+      ClearTempString();
+      AppendTempString("Suicide");
+      AppendTempString(GetTime());
+      AppendTempString(GetTickCount() MOD 1000);
+      sName = SetString($,GetTempString());
       Debug("Character",Send(self,@GetTrueName),self,"was suicided.");
+      Send(SYS,@ChangeUserName,#oUser=self,#sName=sName);
 
       Send(self,@ResetCharacter);
 

--- a/kod/object/active/holder/room/barlqrm/barcourt.kod
+++ b/kod/object/active/holder/room/barlqrm/barcourt.kod
@@ -18,7 +18,7 @@ resources:
 
    room_name_barloque_court = "Office of the Justicar"
    room_barloque_court = barcourt.roo
-   
+
    news_justicar = "Book of Jala"
    news_justicar_desc = \
       "Chronicling the history of the office of the Justicar."
@@ -72,7 +72,7 @@ messages:
 
    % The gallery is separated from the official courtroom by a wall.
    % Only those who are in the courtroom area are subject to Justicar
-   %  commands.  This allows others to watch a trial and not be abused.
+   % commands.  This allows others to watch a trial and not be abused.
 
    ReqInSpecialArea(row = $, col = $, obj = $)
    {
@@ -101,15 +101,19 @@ messages:
    {
       local oSign;
 
-      % The clerk     
+      % The clerk
       poCaramo = Send(SYS,@GetCaramo);
       if poCaramo = $
       {
          poCaramo = Create(&BarloqueClerk);
       }
-      
+      else
+      {
+         Send(poCaramo,@Recreate);
+      }
+
       Send(self,@NewHold,#what=poCaramo,
-           #new_row=12,#new_col=12,#fine_row=28,#fine_col=28,
+           #new_row=12,#new_col=12,#fine_row=32,#fine_col=36,
            #new_angle=ANGLE_WEST);
 
       % A guard
@@ -124,7 +128,7 @@ messages:
          poBookOfJala = Create(&NewsJusticar,#nid=NID_JUSTICAR,
                                #name=news_justicar,#desc=news_justicar_desc);
       }
-      
+
       Send(self,@NewHold,#what=poBookOfJala,
            #new_row=2,#new_col=11,#fine_row=44,#fine_col=44,
            #new_angle=ANGLE_SOUTH_WEST);
@@ -147,8 +151,8 @@ messages:
            #fine_row=28,#fine_col=28);
 
       % Candelabra
-      Send(self,@NewHold,#what=Create(&Candelabra),#new_row=12,#new_col=11,
-           #fine_row=60,#fine_col=52);
+      Send(self,@NewHold,#what=Create(&Candelabra),#new_row=13,#new_col=12,
+           #fine_row=00,#fine_col=00);
 
       propagate;
    }
@@ -177,7 +181,7 @@ messages:
    {
       return poBookOfJala;
    }
-   
+
    Delete()
    {
       if poCaramo <> $
@@ -185,12 +189,11 @@ messages:
          Send(poCaramo,@NewOwner,#what=$);
          poCaramo = $;
       }
-      
+
       poBookofJala = $;
 
       propagate;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/room/barlqrm/barcourt.kod
+++ b/kod/object/active/holder/room/barlqrm/barcourt.kod
@@ -28,12 +28,12 @@ resources:
 
    BarloqueCourt_sign_desc = \
       "Etched into the sign is the following text:\n\n"
-      "By decree of the Council and Princess Kateriina, the position of "
-      "the Justicar has been eliminated due to a long history of excessive corruption. "
+      "By decree of the Council and Princess Kateriina, the position of the "
+      "Justicar has been eliminated due to a long history of excessive corruption. "
       "\n\n"
       "However, the office of the Justicar will continue to adjudicate legal "
-      "matters throughout the land, serving the citizens of Meridian in a variety "
-      "of capacities."
+      "matters throughout the land, serving the citizens of Meridian in a "
+      "variety of capacities."
       "\n\n"
       "Any citizen may now request another citizen's legal record by "
       "stating the person's name aloud."
@@ -41,7 +41,11 @@ resources:
       "Also, given the curious and temporary nature of death in our world, "
       "pardons will now be issued as reward for generous indulgences to the "
       "state. Any murderer seeking reduction to outlaw status need only make "
-      "a generous donation, and immediate reprieve shall be theirs."
+      "a generous donation directly to Caramo and immediate reprieve shall "
+      "be theirs."
+      "\n\n"
+      "Citizens can also ask for a legal \"name change\" by deed poll, for "
+      "a high cost.  Caramo will provide more information if asked.\n"
 
 classvars:
 

--- a/kod/object/item/passitem/inscript.kod
+++ b/kod/object/item/passitem/inscript.kod
@@ -24,7 +24,7 @@ resources:
 
    inscript_emote_write_third_rsc = "%s scribbles something on %s%s."
 
-   inscript_blank_rsc = " "
+   inscript_blank_rsc = ""
    inscript_q = "%q"
 
 classvars:
@@ -77,7 +77,9 @@ messages:
 
       oOwner=send(self,@GetOwner);
 
-      if IsClass(self,&BallotItem) or IsClass(self,&Book)
+      if IsClass(self,&BallotItem)
+         OR IsClass(self,&Book)
+         OR IsClass(self,&NameChangeScroll)
       {
          return FALSE;
       }

--- a/kod/object/item/passitem/inscript/makefile
+++ b/kod/object/item/passitem/inscript/makefile
@@ -5,6 +5,6 @@
 !include $(TOPDIR)\common.mak
 
 DEPEND = ..\inscript.bof
-BOFS = book.bof ballot.bof
+BOFS = book.bof ballot.bof namechscroll.bof
 
 !include $(KODDIR)\kod.mak

--- a/kod/object/item/passitem/inscript/namechscroll.kod
+++ b/kod/object/item/passitem/inscript/namechscroll.kod
@@ -1,0 +1,62 @@
+% Meridian 59, Copyright 1994-2012 Andrew Kirmse and Chris Kirmse.
+% All rights reserved.
+%
+% This software is distributed under a license that is described in
+% the LICENSE file that accompanies it.
+%
+% Meridian is a registered trademark.
+
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+NameChangeScroll is InscriptionItem
+
+constants:
+
+   include blakston.khd
+
+resources:
+
+   deedpoll_name_rsc = "deed poll"
+   deedpoll_icon_rsc = scr02.bgf
+   deedpoll_desc_rsc = \
+      "This is an official document of the Office of the Justicar.\n"
+      "The Royal Justicar's office is responsible for organizing legal "
+      "name changes.  Fill out your requested name and return this scroll "
+      "to Caramo in the Office of the Justicar in North Barloque, and if "
+      "your proposed name is valid, it shall be yours.\n"
+      "\n"
+      "    =[C]=   Caramo, Assistant to the Royal Justicar"
+
+classvars:
+
+   vrName = deedpoll_name_rsc
+   vrIcon = deedpoll_icon_rsc
+   vrDesc = deedpoll_desc_rsc
+
+   viWeight = 2
+
+properties:
+
+messages:
+
+   ShowDesc()
+   {
+      AddPacket(4, deedpoll_desc_rsc);
+
+      return;
+   }
+
+   CanSwap()
+   {
+      % No more using these for swap mules
+      return FALSE;
+   }
+
+   DropOnDeath()
+   {
+      % No drop so that people can't load up on these and avoid real penalties
+      return FALSE;
+   }
+
+end
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/inscript/namechscroll.kod
+++ b/kod/object/item/passitem/inscript/namechscroll.kod
@@ -14,6 +14,8 @@ constants:
 
    include blakston.khd
 
+   DEED_POLL_DESTROY_TIME = 3600000
+
 resources:
 
    deedpoll_name_rsc = "deed poll"
@@ -26,6 +28,10 @@ resources:
       "your proposed name is valid, it shall be yours.\n"
       "\n"
       "    =[C]=   Caramo, Assistant to the Royal Justicar"
+   deedpoll_cant_drop_rsc = \
+      "You find yourself unable to get rid of the deed poll."
+   deedpoll_destroyed_rsc = \
+      "Your deed poll suddenly crumbles into dust!"
 
 classvars:
 
@@ -37,13 +43,84 @@ classvars:
 
 properties:
 
+   ptDestroy = $
+
 messages:
+
+   NewOwner(what=$)
+   {
+      if ptDestroy <> $
+      {
+         DeleteTimer(ptDestroy);
+         ptDestroy = $;
+      }
+
+      if IsClass(what,&Player)
+      {
+         ptDestroy = CreateTimer(self,@Destroy,DEED_POLL_DESTROY_TIME);
+      }
+
+      propagate;
+   }
+
+   Destroy()
+   {
+      ptDestroy = $;
+
+      if poOwner <> $
+         AND IsClass(poOwner,&User)
+      {
+         Send(poOwner,@MsgSendUser,#message_rsc=deedpoll_destroyed_rsc);
+      }
+
+      Send(self,@Delete);
+
+      return;
+   }
+
+   Delete()
+   {
+      if ptDestroy <> $
+      {
+         DeleteTimer(ptDestroy);
+         ptDestroy = $;
+      }
+
+      if poOwner <> $
+      {
+         % Take user off Caramo's name change warn list.
+         Send(Send(SYS,@GetCaramo),@RemoveFromWarnList,#who=poOwner);
+      }
+
+      propagate;
+   }
 
    ShowDesc()
    {
       AddPacket(4, deedpoll_desc_rsc);
 
       return;
+   }
+
+   ReqNewOwner(what = $)
+   {
+      if poOwner = $
+         OR what = $
+      {
+         return TRUE;
+      }
+
+      if IsClass(what,&BarloqueClerk)
+      {
+         return TRUE;
+      }
+
+      if IsClass(poOwner,&User)
+      {
+         Send(poOwner,@MsgSendUser,#message_rsc=deedpoll_cant_drop_rsc);
+      }
+
+      return FALSE;
    }
 
    CanSwap()
@@ -56,6 +133,11 @@ messages:
    {
       % No drop so that people can't load up on these and avoid real penalties
       return FALSE;
+   }
+
+   CanBeStoredInVault()
+   {
+       return FALSE;
    }
 
 end

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -160,6 +160,9 @@ properties:
    % Justicar
    piMinHPForJusticar = 100
 
+   % Cost for Caramo to change a player's name.
+   piNameChangeCost = 3000000
+
    % If enabled, unsafe penalties send the player to their last safe place.
    % This is intended to prevent being players 'kept offline' by enemies.
    pbReturnToSafetyPenaltiesEnable = TRUE
@@ -470,7 +473,12 @@ messages:
    {
       return piMinHPForJusticar;
    }
-   
+
+   GetNameChangeCost()
+   {
+      return piNameChangeCost;
+   }
+
    % This returns whether players go to a room's blink spot or their last safe place when they pen
    ReturnToSafetyPenaltiesEnabled()
    {

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -4042,8 +4042,7 @@ messages:
 
    ReceiveClient(client_msg = $,number_stuff = $,session_id = $)
    {
-      local i,liClient_cmd,oUser,lCharinfo,sName,sDesc,oLookup,iGender,rOldName,bLegal,
-            lBadNameContain,lBadNameIs,sTemp;
+      local i, liClient_cmd, oUser, lCharinfo, sName, sDesc, iGender, bLegal;
 
       liClient_cmd = First(client_msg);
 
@@ -4063,108 +4062,13 @@ messages:
 
          % Validate name and description
          sName = Nth(client_msg,3);
-         if StringLength(sName) < MIN_CHAR_NAME_LEN OR 
-            StringLength(sName) > MAX_CHAR_NAME_LEN
-         {
-            Debug("Got char name length out of range for user ", oUser);
-            bLegal = FALSE;
-         }
 
-         if NOT StringConsistsOf(sName, 
-             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_ '!@$^&*()+=:[]{};/?|<>")
-         {
-            Debug("Got char name with illegal characters for user ", oUser);
-            bLegal = FALSE;
-         }
+         bLegal = Send(self,@ValidateUserName,#oUser=oUser,#sName=sName);
 
          sDesc = Nth(client_msg,4);
          if StringLength(sDesc) > MAX_CHAR_DESCRIPTION_LEN
          {
             Debug("Got description length out of range for user ", oUser);
-            bLegal = FALSE;
-         }
-
-
-         oLookup = Send(SYS,@FindUserByString,#string=sName);
-         if oLookup <> $ AND oLookup <> oUser
-         {
-            bLegal = FALSE;
-         }
-
-         % No using monster or NPC names.
-         if Send(SYS,@FindMonsterByString,#string=sName) <> $
-            OR Send(SYS,@FindNPCByString,#string=sName) <> $
-            OR Send(SYS,@FindGuildByString,#string=sName) <> $
-         {
-            bLegal = FALSE;
-         }
-
-         % Check for people who put "a" or "an" in front of a monster name.
-         for i in plMonsterTemplates
-         {
-            if StringContain(sName,Send(i,@GetTrueName))
-            {
-               if psTemp = $
-               {
-                  psTemp = CreateString();
-               }
-
-               % Use the local temp string, substitute out the name, see if
-               %  we're left with "a" or "an"
-               SetString(psTemp,sName);
-               StringSubstitute(psTemp,Send(i,@GetTrueName),"");
-               if StringEqual(psTemp,"a")
-                  OR StringEqual(psTemp,"an")
-               {
-                  bLegal = FALSE;
-               }
-            }
-         }
-
-         % Don't do these lengthy checks if we're already looking bad.
-         if bLegal
-         {
-            % This is a list of bad things for the name to contain.
-            % Start with the dirty words.
-            lBadNameContain = plNaughtyWords;
-
-            % Confusing names
-            lBadNameContain = Cons("guardian angel", lBadNameContain);
-            lBadNameContain = Cons("guardianangel", lBadNameContain);
-
-            % This is a list of bad names in general.
-            lBadNameIs = [ % God's names.
-                           "Faren", "Shal'ille", "Qor", "Faren",
-                           "Kraanan", "Riija", "Jala",
-                           % Causes confusion.
-                           "You", system_hidden_admin
-                         ];
-
-            for i in lBadNameContain
-            {
-               if StringContain(sName,i)
-               {
-                  bLegal = FALSE;
-
-                  break;
-               }
-            }
-
-            for i in lBadNameIs
-            {
-               if StringEqual(sName, i)
-               {
-                  bLegal = FALSE;
-
-                  break;
-               }
-            }
-         }
-
-         % Pull the string from user.  This is the name we gmail to contact
-         %  our own guild.
-         if StringEqual(sName, "guild")
-         {
             bLegal = FALSE;
          }
 
@@ -4195,9 +4099,7 @@ messages:
          % such references expire through gameplay.
 
          Send(self,@RecreatedUser,#what=oUser);
-         rOldName = Send(oUser,@GetUserName);
          i = Send(oUser,@GetLastRestartTime);
-         DeleteTableEntry(phUsers,rOldName);
 
          if pbRecycleUsersEnabled
          {
@@ -4210,13 +4112,13 @@ messages:
          AddPacket(4,oUser);
          SendPacket(session_id);
 
-         if not isClass(oUser,&Guest)
+         if NOT isClass(oUser,&Guest)
          {
-            Debug("User suicide",oUser,"from",rOldName,"to",sName);
+            Debug("User suicide",oUser,"from",Send(oUser,@GetTrueName),
+                  "to",sName);
          }
 
-         SetResource(Send(oUser,@GetUserName),sName);
-         AddTableEntry(phUsers,Send(oUser,@GetUserName),oUser);
+         Send(self,@ChangeUserName,#oUser=oUser,#sName=sName);
 
          Send(oUser,@SetLastRestartTime,#time=i);
 
@@ -4234,6 +4136,131 @@ messages:
       }
 
       return;
+   }
+
+   ValidateUserName(oUser=$,sName=$)
+   {
+      local i, lBadNameContain, lBadNameIs, oLookup;
+
+      if oUser = $
+         OR sName = $
+      {
+         return FALSE;
+      }
+
+      if StringLength(sName) < MIN_CHAR_NAME_LEN
+         OR StringLength(sName) > MAX_CHAR_NAME_LEN
+      {
+         Debug("Got char name length out of range for user ", oUser);
+
+         return FALSE;
+      }
+
+      if NOT StringConsistsOf(sName, 
+          "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890_ '!@$^&*()+=:[]{};/?|<>")
+      {
+         Debug("Got char name with illegal characters for user ", oUser);
+
+         return FALSE;
+      }
+
+      oLookup = Send(SYS,@FindUserByString,#string=sName);
+      if oLookup <> $
+         AND oLookup <> oUser
+      {
+         return FALSE;
+      }
+
+      % No using monster or NPC names.
+      if Send(SYS,@FindMonsterByString,#string=sName) <> $
+         OR Send(SYS,@FindNPCByString,#string=sName) <> $
+         OR Send(SYS,@FindGuildByString,#string=sName) <> $
+      {
+         return FALSE;
+      }
+
+      % Check for people who put "a" or "an" in front of a monster name.
+      for i in plMonsterTemplates
+      {
+         if StringContain(sName,Send(i,@GetTrueName))
+         {
+            if psTemp = $
+            {
+               psTemp = CreateString();
+            }
+
+            % Use the local temp string, substitute out the name, see if
+            %  we're left with "a" or "an"
+            SetString(psTemp,sName);
+            StringSubstitute(psTemp,Send(i,@GetTrueName),"");
+            if StringEqual(psTemp,"a")
+               OR StringEqual(psTemp,"an")
+            {
+               return FALSE;
+            }
+         }
+      }
+
+      % This is a list of bad things for the name to contain.
+      % Start with the dirty words.
+      lBadNameContain = plNaughtyWords;
+
+      % Confusing names
+      lBadNameContain = Cons("guardian angel", lBadNameContain);
+      lBadNameContain = Cons("guardianangel", lBadNameContain);
+
+      % This is a list of bad names in general.
+      lBadNameIs = [ % God's names.
+                     "Faren", "Shal'ille", "Qor", "Faren",
+                     "Kraanan", "Riija", "Jala",
+                     % Causes confusion.
+                     "You", system_hidden_admin
+                   ];
+
+      for i in lBadNameContain
+      {
+         if StringContain(sName,i)
+         {
+            return FALSE;
+         }
+      }
+
+      for i in lBadNameIs
+      {
+         if StringEqual(sName, i)
+         {
+            return FALSE;
+         }
+      }
+
+      % Pull the string from user.  This is the name we gmail to contact
+      %  our own guild.
+      if StringEqual(sName, "guild")
+      {
+            return FALSE;
+      }
+
+      % Name should be valid.
+
+      return TRUE;
+   }
+
+   ChangeUserName(oUser=$,sName=$)
+   {
+      local rOldName;
+
+      if oUser = $
+         OR sName = $
+      {
+         return FALSE;
+      }
+
+      rOldName = Send(oUser,@GetUserName);
+      DeleteTableEntry(phUsers,rOldName);
+      SetResource(Send(oUser,@GetUserName),sName);
+      AddTableEntry(phUsers,Send(oUser,@GetUserName),oUser);
+
+      return TRUE;
    }
 
    GetHiddenAdminName()
@@ -5210,6 +5237,7 @@ messages:
       plItemTemplates = cons(create(&Letter),plItemTemplates);
       plItemTemplates = cons(create(&InscriptionItem),plItemTemplates);
       plItemTemplates = cons(create(&BallotItem),plItemTemplates);
+      plItemTemplates = cons(create(&NameChangeScroll),plItemTemplates);
 
       plItemTemplates = cons(create(&RoomKeyCopy),plItemTemplates);
       plItemTemplates = cons(create(&RoomKey),plItemTemplates);


### PR DESCRIPTION
Players can now go to Caramo and say "change name" or any variation
containing those two words, and she will give them a new "deed poll"
scroll on which they can write their new name.
If the name passes all the checks for creating a new character name, it
will be given to the player provided they can afford it. Money is taken
directly from player's bank account (no running around BQ with 3 mil).
Players receive a warning regarding the cost the first time they hand
back the scroll.

The name change code used on character creation has been moved to
separate messages in System for validating and creating user names. Name
change cost is a setting which can be changed live (default 3 mil).

The sign in Office of the Justicar has been updated with info regarding
the name change function. Name changes are posted to Book of Jala (with
both old and new name).

SetResource C function updated to set a dynamic resource from a string
to avoid working via temp string.

Also now change the player's name on suicide, so the old name becomes
available again.