### PR TITLE
Add post-cast delay to all wands, scrolls and potions AND rods. Start all SpellItems off identified, and remove karma check from Remove Curse potions. Rod delay time adjustable live.

### DIFF
--- a/kod/object/item/passitem/rod.kod
+++ b/kod/object/item/passitem/rod.kod
@@ -13,7 +13,7 @@ Rod is PassiveItem
 constants:
 
    include blakston.khd
-   
+
    ROD_HOLD_MAX = 5
 
 resources:
@@ -34,12 +34,16 @@ resources:
 
    rod_success_wav_default_rsc = healwand.wav
    rod_fail_wav_default_rsc = spelfail.wav
-   
-   rod_cannot_hold_more_rsc = "If you held another rod, their competing magics would all conflict and explode!"
+
+   rod_cannot_hold_more_rsc = \
+      "If you held another rod, their competing magics would all "
+      "conflict and explode!"
    rod_default_expire_msg = \
       "Your rod effect has expired."
    rod_default_secondary_expire_msg = \
       "Your rod's secondary effect has expired."
+
+   rod_cant_use_yet = "You cannot use that item yet."
 
 classvars:
 
@@ -59,22 +63,26 @@ classvars:
    use_success_wav = rod_success_wav_default_rsc
    duration_expire_msg = rod_default_expire_msg
    secondary_duration_expire_msg = rod_default_secondary_expire_msg
-   
+
    vbDurationEffect = FALSE
    viEffectDuration = 0
    vbSecondaryDurationEffect = FALSE
    viSecondaryEffectDuration = 0
 
+   viRodUseDelay = 1000 % Milliseconds
+
 properties:
 
    vrDesc = Rod_desc_rsc
-   
+
    % For rods with durations
    ptActiveTimer = $
    pbActive = FALSE
-   
+
    ptSecondaryActiveTimer = $
    pbSecondaryActive = FALSE
+
+   piRodUseDelay = 1000 % Milliseconds
 
 messages:
 
@@ -83,9 +91,11 @@ messages:
       Send(self,@SetHits,#number=viStartHits);
       Send(self,@SetMaxHits,#number=viStartMaxHits);
 
+      piRodUseDelay = viRodUseDelay;
+
       propagate;
    }
-   
+
    NewOwner()
    {
       Send(self,@SetHits,#number=0);
@@ -107,9 +117,11 @@ messages:
                iRodCount = iRodCount + 1;
             }
          }
+
          if iRodCount >= ROD_HOLD_MAX
          {
             Send(what,@MsgSendUser,#message_rsc=rod_cannot_hold_more_rsc);
+
             return FALSE;
          }
       }
@@ -124,15 +136,23 @@ messages:
 
    ReqNewApply(what = $, apply_on = $)
    {
-      If NOT IsClass(poOwner,&User)
+      if NOT IsClass(poOwner,&User)
       {
          return FALSE;
       }
 
-      If Send(self,@GetHits) < viConsumesHits
+      if Send(self,@GetHits) < viConsumesHits
       {
          Send(poOwner,@MsgSendUser,#message_rsc=use_fail_msg);
          Send(poOwner,@WaveSendUser,#wave_rsc=use_fail_wav);
+
+         return FALSE;
+      }
+      
+      if NOT Send(what,@IsOkayAttackTime,#time=piRodUseDelay)
+      {
+         Send(what,@MsgSendUser,#message_rsc=rod_cant_use_yet);
+
          return FALSE;
       }
 
@@ -147,10 +167,10 @@ messages:
       if Send(self,@GetHits) <= 0
       {
          Send(poOwner,@MsgSendUser,#message_rsc=Rod_broken,
-           #parm1=Send(self,@GetCapDef),#parm2=Send(self,@GetName));
+               #parm1=Send(self,@GetCapDef),#parm2=Send(self,@GetName));
          vrDesc = vrBrokenDesc;
       }
-      
+
       return;
    }
 
@@ -167,7 +187,7 @@ messages:
          pbActive = TRUE;
          ptActiveTimer = CreateTimer(self,@DurationEffectExpire,viEffectDuration);
       }
-      
+
       if vbSecondaryDurationEffect
       {
          if ptSecondaryActiveTimer <> $
@@ -182,10 +202,12 @@ messages:
       }
 
       Send(poOwner,@MsgSendUser,#message_rsc=use_success_msg);
-      Send(Send(poOwner,@GetOwner),@SomethingWaveRoom,#what=poOwner,#wave_rsc=use_success_wav);
+      Send(Send(poOwner,@GetOwner),@SomethingWaveRoom,#what=poOwner,
+            #wave_rsc=use_success_wav);
+
       return;
    }
-   
+
    SomethingKilled(what = $, victim = $)
    {
       % Gain a charge upon our owner killing a monster.
@@ -194,20 +216,22 @@ messages:
          AND Send(self,@GetHits) < Send(self,@GetMaxHits)
       {
          Send(self,@SetHits,#number=Send(self,@GetHits)+1);
+
          return TRUE;
       }
 
       return FALSE;
    }
-   
+
    FullyRecharge()
    {
       if Send(self,@GetHits) < Send(self,@GetMaxHits)
       {
          Send(self,@SetHits,#number=Send(self,@GetMaxHits));
+
          return TRUE;
       }
-      
+
       return FALSE;
    }
 
@@ -217,7 +241,7 @@ messages:
       {
          return;
       }
-      
+
       if number = 0
       {
          vrDesc = vrBrokenDesc;
@@ -233,7 +257,24 @@ messages:
 
       propagate;
    }
-   
+
+   SetRodDelay(iTime=0)
+   "If no parameter is sent, sets the rod back to default (1000ms) delay. "
+   "If iTime is greater than 0, will set the rod use delay to that many "
+   "milliseconds."
+   {
+      if iTime < 1
+      {
+         piRodUseDelay = viRodUseDelay;
+      }
+      else
+      {
+         piRodUseDelay = iTime;
+      }
+
+      return;
+   }
+
    AppendDesc()
    {
       if viConsumesHits <> 1
@@ -243,7 +284,7 @@ messages:
          AppendTempString(rod_consumes_charges_b_rsc);
       }
 
-      AppendTempString("\n\n");   
+      AppendTempString("\n\n");
       AppendTempString(rod_charges_left_a_rsc);
       Send(SYS,@AppendCardinalToTempString,#number=piHits);
       AppendTempString(rod_charges_left_b_rsc);
@@ -252,12 +293,12 @@ messages:
 
       return;
    }
-   
+
    DurationEffectExpire()
    {
       ptActiveTimer = $;
       pbActive = FALSE;
-      
+
       if poOwner <> $
          AND IsClass(poOwner,&User)
          AND Send(poOwner,@IsLoggedOn)
@@ -272,7 +313,7 @@ messages:
    {
       ptSecondaryActiveTimer = $;
       pbSecondaryActive = FALSE;
-      
+
       if poOwner <> $
          AND IsClass(poOwner,&User)
          AND Send(poOwner,@IsLoggedOn)
@@ -282,25 +323,25 @@ messages:
 
       return;
    }
-   
+
    IsActive()
    {
       return pbActive;
    }
-   
+
    IsSecondaryActive()
    {
       return pbSecondaryActive;
    }
-   
+
    Delete()
    {
-      If ptActiveTimer <> $
+      if ptActiveTimer <> $
       {
          DeleteTimer(ptActiveTimer);
          ptActiveTimer = $;
       }
-      
+
       if ptSecondaryActiveTimer <> $
       {
          DeleteTimer(ptSecondaryActiveTimer);
@@ -311,5 +352,4 @@ messages:
    }
 
 end
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/spelitem.kod
+++ b/kod/object/item/passitem/spelitem.kod
@@ -45,6 +45,9 @@ resources:
       "You combine the %s with your current stock, for a total "
       "of %d uses with %d power."
 
+   spellitem_cannot_use_yet = \
+      "You cannot use that item yet."
+
 classvars:
 
    vrLabelName = Spellitem_label_name_rsc
@@ -198,14 +201,33 @@ messages:
 
    ReqNewApply(what=$,apply_on=$)
    {
+      local iPostCastDelay, oSpell;
+
       % Prevent use if you can't fight.
-      if (IsClass(what,&Player))
-         AND (Send(what,@CheckPlayerFlag,#flag=PFLAG_NO_FIGHT))
-         OR pbDisabled
-         OR (IsClass(apply_on,&Player)
-             AND Send(apply_on,@IsInCannotInteractMode))
+      if IsClass(what,&Player)
       {
-         return FALSE;
+         if Send(what,@CheckPlayerFlag,#flag=PFLAG_NO_FIGHT)
+            OR pbDisabled
+            OR (IsClass(apply_on,&Player)
+               AND Send(apply_on,@IsInCannotInteractMode))
+         {
+            return FALSE;
+         }
+
+         oSpell = Send(SYS,@FindSpellByNum,#num=viSpellEffect);
+         iPostCastDelay = Send(oSpell,@GetPostCastDelay);
+
+         % Bind this at reasonable levels
+         iPostCastDelay = Bound(iPostCastDelay,1,10);
+
+         % Check the attack timer, and start a new one if we use the item.
+         % Only allow one use per second.
+         if NOT Send(what,@IsOkayAttackTime,#seconds=iPostCastDelay)
+         {
+            Send(what,@MsgSendUser,#message_rsc=spellitem_cannot_use_yet);
+
+            return FALSE;
+         }
       }
 
       return TRUE;

--- a/kod/object/item/passitem/spelitem.kod
+++ b/kod/object/item/passitem/spelitem.kod
@@ -106,7 +106,7 @@ properties:
 
 messages:
 
-   Constructor(labelled=FALSE,model=$,iSpellpower=$,gobadtime=$,
+   Constructor(labelled=TRUE,model=$,iSpellpower=$,gobadtime=$,
                maker=$,Ability=$)
    {
       local oItemAtt;

--- a/kod/object/item/passitem/spelitem.kod
+++ b/kod/object/item/passitem/spelitem.kod
@@ -45,8 +45,8 @@ resources:
       "You combine the %s with your current stock, for a total "
       "of %d uses with %d power."
 
-   spellitem_cannot_use_yet = \
-      "You cannot use that item yet."
+   spellitem_cannot_use_yet = "You cannot use that item yet."
+   spellitem_disabled = "This item is currently disabled."
 
 classvars:
 
@@ -80,6 +80,8 @@ classvars:
    viHits_init_min = 1
    viHits_init_max = 1
 
+   vbDisabled = FALSE
+
 properties:
 
    vrName = Spellitem_name_rsc
@@ -96,7 +98,6 @@ properties:
    poMaker = $
    piSkill = $
    piLabelColor = 0
-   pbDisabled = FALSE
 
    % If true, user has to pass spell's karma check.  Otherwise, can always cast.
    pbCheckKarma = TRUE
@@ -203,11 +204,17 @@ messages:
    {
       local iPostCastDelay, oSpell;
 
+      if vbDisabled
+      {
+         Send(what,@MsgSendUser,#message_rsc=spellitem_disabled);
+
+         return FALSE;
+      }
+
       % Prevent use if you can't fight.
       if IsClass(what,&Player)
       {
          if Send(what,@CheckPlayerFlag,#flag=PFLAG_NO_FIGHT)
-            OR pbDisabled
             OR (IsClass(apply_on,&Player)
                AND Send(apply_on,@IsInCannotInteractMode))
          {
@@ -215,6 +222,16 @@ messages:
          }
 
          oSpell = Send(SYS,@FindSpellByNum,#num=viSpellEffect);
+
+         % If we don't have a spell, the item might have been disabled
+         % or just not implemented correctly.
+         if oSpell = $
+         {
+            Send(what,@MsgSendUser,#message_rsc=spellitem_disabled);
+
+            return FALSE;
+         }
+
          iPostCastDelay = Send(oSpell,@GetPostCastDelay);
 
          % Bind this at reasonable levels

--- a/kod/object/item/passitem/spelitem/potion/rmcursep.kod
+++ b/kod/object/item/passitem/spelitem/potion/rmcursep.kod
@@ -49,6 +49,8 @@ classvars:
 
 properties:
 
+   pbCheckKarma = FALSE
+
 messages:
 
 

--- a/kod/object/item/passitem/spelitem/scroll/earthscl.kod
+++ b/kod/object/item/passitem/spelitem/scroll/earthscl.kod
@@ -28,10 +28,11 @@ classvars:
    viSpellEffect = SID_EARTHQUAKE
    viColor = XLAT_TO_ORANGE
 
+   vbDisabled = TRUE
+
 properties:
 
    vrDesc = EarthquakeScroll_desc_rsc
-   pbDisabled = TRUE
 
 messages:
 

--- a/kod/object/item/passitem/spelitem/wand.kod
+++ b/kod/object/item/passitem/spelitem/wand.kod
@@ -29,8 +29,6 @@ resources:
       "You carefully aim your wand at %s%s, but you suddenly "
       "realize your target is gone."
    Wand_fails = "You point your wand but nothing happens."
-   wand_cannot_use_yet = \
-      "You cannot use that item yet."
 
 classvars:
 
@@ -61,20 +59,6 @@ properties:
    piGoBadTime = -1
 
 messages:
-
-   ReqNewApply(what=$,apply_on=$)
-   {
-      % Wands can be used as attacks - check the attack timer.
-      if IsClass(what,&Player)
-         AND NOT Send(what,@CheckAttackTimer)
-      {
-         Send(what,@MsgSendUser,#message_rsc=wand_cannot_use_yet);
-
-         return FALSE;
-      }
-
-      propagate;
-   }
 
    CastSpell(what=$,apply_on=$)
    {

--- a/kod/object/passive/spell.kod
+++ b/kod/object/passive/spell.kod
@@ -2066,6 +2066,11 @@ messages:
       return (viCast_time*iPercent)/100;
    }
 
+   GetPostCastDelay()
+   {
+      return viPostCast_Time;
+   }
+
    DoPreTranceEffects(who=$,lTargets=$,iSpellpower=$)
    {
       return;


### PR DESCRIPTION
Players are reporting that these items are being spammed in PvP with ill effects (perma-hold, perma-truce among others). Using a spell item will now have the same delay as the spell would normally. While the items can still be spammed, and might need further mitigation, this serves as a good first step.

Rods have also been given a delay of default 1000ms, which can be adjusted live.

Also start all SpellItems off identified - a common complaint from players was that they couldn't reliably use these items while building because they often weren't sure what the item would do (and some have identical colors). Although this makes Reveal and Identify less useful, I think it is necessary.

Removed the karma requirement from Remove Curse potions - until we have a large population, this is needed to prevent players requiring a Shal 2 mule for getting rid of cursed items.