### PR TITLE
Add remove curse potions to Frisconar and Zala.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcapoth.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/kocatwn/kcapoth.kod
@@ -109,15 +109,16 @@ messages:
 
    SetForSale()
    {
-      plFor_sale = [ 
-         [ 
+      plFor_sale = [
+         [
+            Create(&RemoveCursePotion,#labelled=TRUE),
             Create(&UncutSeraphym,#number=1),
             Create(&DragonflyEye,#number=2),
             Create(&FireSand,#number=4),
             Create(&WebMoss,#number=4),
             Create(&RainbowFern,#number=4),
             Create(&Solagh,#number=4)
-         ], 
+         ],
       $,$,$];
 
       return;

--- a/kod/object/active/holder/nomoveon/battler/monster/towns/tostwn/TsApoth.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns/tostwn/TsApoth.kod
@@ -83,8 +83,9 @@ messages:
 
    SetForSale()
    {
-      plFor_sale = [ 
+      plFor_sale = [
          [
+            Create(&RemoveCursePotion,#labelled=TRUE),
             Create(&Torch),
             Create(&BlueMushroom,#number=4),
             Create(&RedMushroom,#number=4),
@@ -96,7 +97,7 @@ messages:
          $,
          [
             SID_HOSPICE
-         ], 
+         ],
       $];
 
       return;


### PR DESCRIPTION
To help players deal with cursed items away from Marion, the Tos and Ko'catan apothecaries will now sell Remove Curse potions.