### PR TITLE
Spellcasting $/error checks, allow NPCs to respond to "level 1" queries with numbers instead of words, fix errors with modified herald shields, UserSay() refactoring, disallow tokens in Survival Arena.

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2367,6 +2367,8 @@
    EVENT_DISRUPT = 9
    % Player is moving to a new room but has not yet
    EVENT_REQNEWOWNER = 10
+   % Break trance for system save.
+   EVENT_SYSTEMSAVE = 11
 
    %%% Hot spot definitions
 

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -64,11 +64,17 @@ resources:
 
    monster_level = "level"
    monster_one = "one"
+   monster_num_one = "1"
    monster_two = "two"
+   monster_num_two = "2"
    monster_three = "three"
+   monster_num_three = "3"
    monster_four = "four"
+   monster_num_four = "4"
    monster_five = "five"
+   monster_num_five = "5"
    monster_six = "six"
+   monster_num_six = "6"
 
    monster_sch_weaponcraft = "Weaponcraft"
    monster_sch_kraanan = "Kraanan magic"
@@ -3216,36 +3222,42 @@ messages:
       }
 
       if StringContain(string,monster_one)
+         OR StringContain(string,monster_num_one)
       {
          iLevel = 1;
       }
       else
       {
          if StringContain(string,monster_two)
+            OR StringContain(string,monster_num_two)
          {
             iLevel = 2;
          }
          else
          {
             if StringContain(string,monster_three)
+               OR StringContain(string,monster_num_three)
             {
                iLevel = 3;
             }
             else
             {
                if StringContain(string,monster_four)
+                  OR StringContain(string,monster_num_four)
                {
                   iLevel = 4;
                }
                else
                {
                   if StringContain(string,monster_five)
+                     OR StringContain(string,monster_num_five)
                   {
                      iLevel = 5;
                   }
                   else
                   {
                      if StringContain(string,monster_six)
+                        OR StringContain(string,monster_num_six)
                      {
                         iLevel = 6;
                      }

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -163,8 +163,17 @@ resources:
    player_join_faction = \
       "~IYour name is entered on the roll of membership for %s%s's political "
       "faction."
-   player_lost_token = \
+   player_lost_token_hall = \
       "The token refuses to enter the guild hall and writhes in your hands.  "
+      "You cannot hold it."
+   player_lost_token_arena = \
+      "The token refuses to enter the arena and writhes in your hands.  "
+      "You cannot hold it."
+   player_lost_token_survival = \
+      "You suddenly lose your grasp on the token as you are pulled "
+      "across dimensions."
+   player_lost_token_generic = \
+      "The token refuses to enter this room and writhes in your hands.  "
       "You cannot hold it."
    player_intrigue_shut = "~IThe Royal Court no longer needs your services."
    player_lost_intriguing = \
@@ -13034,28 +13043,56 @@ messages:
    }
 
    CheckTokenInNewRoom(what=$)
-   "If we are carrying a token, lets drop it"
+   "If we are carrying a token, lets drop it."
    {
-      local i;
+      local i, bFound;
 
       if what = $
-         OR NOT ((IsClass(poOwner,&GuildHall)
-                  OR IsClass(poOwner,&OutofGrace)
-                  OR Send(poOwner,@IsArena)))
+         OR poOwner = $
+         OR Send(poOwner,@CanTokenEnterRoom)
       {
          return;
       }
+
+      bFound = FALSE;
 
       for i in plPassive
       {
          if IsClass(i,&Token)
          {
-            Send(self,@MsgSendUser,#message_rsc=player_lost_token);
-            Send(i,@NewUnused,#where=what); 
+            bFound = TRUE;
+            Send(i,@NewUnused,#where=what);
          }
       }
 
-      return TRUE;
+      if bFound
+      {
+         % Give a different message depending on the room.
+         if IsClass(poOwner,&GuildHall)
+         {
+            Send(self,@MsgSendUser,#message_rsc=player_lost_token_hall);
+
+            return;
+         }
+
+         if Send(poOwner,@IsArena)
+         {
+            Send(self,@MsgSendUser,#message_rsc=player_lost_token_arena);
+
+            return;
+         }
+
+         if IsClass(poOwner,&SurvivalRoom)
+         {
+            Send(self,@MsgSendUser,#message_rsc=player_lost_token_survival);
+
+            return;
+         }
+
+         Send(self,@MsgSendUser,#message_rsc=player_lost_token_generic);
+      }
+
+      return;
    }
 
    GetFactionService()

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -354,18 +354,57 @@ resources:
    user_guildofficer_rsc = "guildofficer"
 
    user_default_url = "http://openmeridian.org/"
-   
+
    user_safety_on_wav_rsc = safety_on.wav
    user_safety_off_wav_rsc = safety_off.wav
-   
+
+   % Guild MOTD user say commands.
+   user_say_guild_motd = "motd"
    guild_motd_command = "set motd "
    guild_clear_motd_command = "clear motd"
-   
-   autocombine_on_msg = "You decide to combine spell items as you get them."
-   autocombine_off_msg = "You decide to stop combining spell items as you get them."
+
+   % Autocombine user say commands.
+   user_say_autocombine = "autocombine"
+   user_say_autocombine_on = "autocombine on"
+   user_say_autocombine_off = "autocombine off"
+
+   autocombine_on_msg = \
+      "You decide to combine spell items as you get them."
+   autocombine_off_msg = \
+      "You decide to stop combining spell items as you get them."
+
+   % Autoloot user say commands.
+   user_say_autoloot = "autoloot"
+   user_say_autoloot_on = "autoloot on"
+   user_say_autoloot_off = "autoloot off"
 
    autoloot_on_msg = "You decide to pick up treasure as it drops."
    autoloot_off_msg = "You stop picking up treasure as it drops."
+
+   % Reagent bag user say commands.
+   user_say_reagentbag = "reagentbag"
+   user_say_reagentbag_on = "reagentbag on"
+   user_say_reagentbag_off = "reagentbag off"
+
+   % Inventory sorting user say commands.
+   user_say_inventory = "inventory"
+   user_say_inv_sort_clear = "inventory sort clear"
+   user_say_inv_sort_report = "inventory sort report"
+   user_say_inv_sort_add = "inventory sort add "
+   user_say_inv_sort_help = "inventory sort help"
+   user_say_inv_sort = "sort inventory"
+
+   % Survival arena user say commands.
+   user_say_survival = "survival"
+   user_say_start_solo_survival = "start solo survival"
+   user_say_start_pub_survival = "start public survival"
+   user_say_join_pub_survival = "join public survival"
+   user_say_start_guild_survival = "start guild survival"
+   user_say_join_guild_survival = "join guild survival"
+   % Extra survival arena options for DMs.
+   user_say_survival_opt_unnatural = "--unnatural"
+   user_say_survival_opt_pvpon = "--pvpon"
+   user_say_survival_opt_starthere = "--thisbase"
 
    guild_survival_too_late = \
       "Your guild is already running a survival room. You will have to wait."
@@ -387,7 +426,7 @@ resources:
       
    survival_err_cant_join = \
       "That survival arena has already begun, and you cannot join."
-   
+
    phased_out_cant_drop = "You can't drop items while phased out of existence."
                                
    reagentbag_auto_on = "You start putting new reagents in your bag."
@@ -4482,8 +4521,7 @@ messages:
 
    UserSay(type=$,string=$)
    {
-      local i, oSpell, lEnchantData, bTranceBlocksSay, lSurvivalOptions,
-            poForceBaseRoom, lSortInfo, oTemplateItem, n, bFound;
+      local i, oSpell, lEnchantData, bTranceBlocksSay;
 
       % A room can completely block a piece of communication if it chooses.
       % An excellent example is Out Of Grace, which blocks all tells to 
@@ -4498,337 +4536,50 @@ messages:
 
       if type = SAY_NORMAL
       {
-         if StringContain(String,"start solo survival")
+         if StringContain(string,user_say_survival)
+            AND Send(poOwner,@GetRoomNum) <> RID_OUTOFGRACE
          {
-            lSurvivalOptions = $;
-            if NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
-               OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
-               OR Send(poOwner,@GetRoomNum) = RID_FIELD1
+            % If UserSaySurvival handles the string, don't keep checking.
+            if Send(self,@UserSaySurvival,#string=string)
             {
-               Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
-
                return;
             }
-
-            Send(Send(SYS,@GetSurvivalRoomMaintenance),@CreateRoom,#who=self);
-
-            return;
          }
 
-         if StringContain(String,"start guild survival")
+         if StringContain(string,user_say_inventory)
          {
-            lSurvivalOptions = $;
-            if poGuild = $
+            % If UserSayInventory handles the string, don't keep checking.
+            if Send(self,@UserSayInventory,#string=string)
             {
-               Send(self,@MsgSendUser,#message_rsc=survival_err_no_guild);
-
                return;
             }
+         }
 
-            if NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
-               OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
-               OR Send(poOwner,@GetRoomNum) = RID_FIELD1
+         if StringContain(string,user_say_autocombine)
+         {
+            % If UserSayAutocombine handles the string, don't keep checking.
+            if Send(self,@UserSayAutocombine,#string=string)
             {
-               Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
-
                return;
             }
-
-            if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindRoomByGuild,
-                     #oGuild=poGuild) = $
-            {
-               Send(Send(SYS,@GetSurvivalRoomMaintenance),@CreateRoom,
-                     #who=self,#guild_survival=TRUE);
-            }
-            else
-            {
-               Send(self,@MsgSendUser,#message_rsc=survival_err_already_guild);
-            }
-
-            return;
          }
 
-         if StringContain(String,"start public survival")
+         if StringContain(string,user_say_autoloot)
          {
-            lSurvivalOptions = $;
-            if (NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
-               OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
-               OR Send(poOwner,@GetRoomNum) = RID_FIELD1)
-               AND NOT IsClass(self,&Admin)
+            % If UserSayAutoloot handles the string, don't keep checking.
+            if Send(self,@UserSayAutoloot,#string=string)
             {
-               Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
-
                return;
             }
-
-            poForceBaseRoom = $;
-            if IsClass(self,&DM)
-            {
-               if StringContain(String,"--unnatural")
-               {
-                  lSurvivalOptions = Cons(OPT_NATURAL,lSurvivalOptions);
-               }
-               if StringContain(String,"--pvpon")
-               {
-                  lSurvivalOptions = Cons(OPT_PVP_ON,lSurvivalOptions);
-               }
-               if StringContain(String,"--thisbase")
-               {
-                  poForceBaseRoom = poOwner;
-               }
-            }
-
-            if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindPublicRoom) = $
-            {
-               Send(Send(SYS,@GetSurvivalRoomMaintenance),@CreateRoom,
-                     #who=self,#iPublic=TRUE,#sString=string,
-                     #lSurvivalOptions=lSurvivalOptions,
-                     #poForceBaseRoom=poForceBaseRoom);
-            }
-            
-            if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindPublicRoom) = $
-            {
-               Send(Send(SYS,@GetSurvivalRoomMaintenance),@CreateRoom,
-                     #who=self,#iPublic=TRUE,
-                     #lSurvivalOptions=lSurvivalOptions,
-                     #poForceBaseRoom=poForceBaseRoom);
-            }
-            else
-            {
-               Send(self,@MsgSendUser,#message_rsc=survival_err_already_public);
-            }
-
-            return;
          }
 
-         if StringEqual(String,"join guild survival")
+         if StringContain(string,user_say_reagentbag)
          {
-            if poGuild = $
+            % If UserSayReagentBag handles the string, don't keep checking.
+            if Send(self,@UserSayReagentBag,#string=string)
             {
-               Send(self,@MsgSendUser,#message_rsc=survival_err_no_guild);
-
                return;
             }
-
-            if NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
-               OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
-               OR Send(poOwner,@GetRoomNum) = RID_FIELD1
-            {
-               Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
-
-               return;
-            }
-
-            if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindRoomByGuild,
-                     #oGuild=poGuild) = $
-            {
-               Send(self,@MsgSendUser,#message_rsc=survival_no_guild_rooms);
-
-               return;
-            }
-
-            if Send(Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                     @FindRoomByGuild,#oGuild=poGuild),@GetAllowJoins)
-            {
-               Send(Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                     @FindRoomByGuild,#oGuild=poGuild),@Teleport,#what=self);
-            }
-            else
-            {
-               Send(self,@MsgSendUser,#message_rsc=guild_survival_too_late);
-            }
-
-            return;
-         }
-
-         if StringEqual(String,"inventory sort clear")
-         {
-            plClassOrderPreferences = $;
-            Send(self,@MsgSendUser,#message_rsc=inventory_sort_cleared);
-            return;
-         }
-
-         if StringEqual(String,"inventory sort report")
-         {
-            Send(self,@MsgSendUser,#message_rsc=inventory_sort_report_header);
-
-            lSortInfo = Send(SYS,@GetSortInfo);
-
-            for i in plClassOrderPreferences
-            {
-               bFound = FALSE;
-               for n in lSortInfo
-               {
-                  if Nth(n,2) = i
-                  {
-                     Send(self,@MsgSendUser,#message_rsc=inventory_sort_report,
-                                      #parm1=Nth(n,1));
-                     bFound = TRUE;
-                     break;
-                  }
-               }
-               
-               if bFound
-               {
-                  continue;
-               }
-               
-               oTemplateItem = Send(SYS,@FindTemplateItemByClass,
-                                        #cClass=i);
-               
-               if oTemplateItem <> $
-               {
-                  Send(self,@MsgSendUser,#message_rsc=inventory_sort_report,
-                                      #parm1=Send(oTemplateItem,@GetName));
-               }
-            }
-            
-            return;
-         }
-
-         if StringContain(String,"inventory sort add ")
-         {
-            StringSubstitute(String,"inventory sort add ","");
-            
-            lSortInfo = Send(SYS,@GetSortInfo);
-            
-            for i in lSortInfo
-            {
-               if StringEqual(String,First(i))
-               {
-                  if plClassOrderPreferences <> $
-                     AND FindListElem(plClassOrderPreferences,Nth(i,2)) <> 0
-                  {
-                     Send(self,@MsgSendUser,
-                               #message_rsc=inventory_already_in_list);
-                     return;
-                  }
-                  
-                  plClassOrderPreferences =
-                          AppendListElem(Nth(i,2),plClassOrderPreferences);
-                          
-                  Send(self,@MsgSendUser,#message_rsc=inventory_class_added,
-                                         #parm1=Nth(i,1));
-                  return;
-               }
-            }
-            
-            oTemplateItem = Send(SYS,@FindTemplateItemByName,#string=String);
-            
-            if oTemplateItem <> $
-            {
-               plClassOrderPreferences =
-                   AppendListElem(GetClass(oTemplateItem),
-                                  plClassOrderPreferences);
-               Send(self,@MsgSendUser,#message_rsc=inventory_class_added,
-                                      #parm1=Send(oTemplateItem,@GetName));
-               return;
-            }
-            
-            Send(self,@MsgSendUser,#message_rsc=inventory_sort_no_item);
-            
-            return;
-         }
-
-         if StringEqual(String,"inventory sort help")
-         {
-            Send(self,@MsgSendUser,#message_rsc=inventory_sort_help);
-            return;
-         }
-
-         if StringEqual(String,"sort inventory")
-         {
-            plPassive = Send(SYS,@SortItemsByType,#lItems=plPassive,
-                                 #lClassOrder=plClassOrderPreferences);
-            Send(self,@ToCliInventory);
-            Send(self,@ToCliUseList);
-            return;
-         }
-
-         if StringEqual(String,"join public survival")
-         {
-            if NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
-               OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
-               OR Send(poOwner,@GetRoomNum) = RID_FIELD1
-            {
-               Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
-
-               return;
-            }
-            
-            if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindPublicRoom) = $
-            {
-               Send(self,@MsgSendUser,#message_rsc=survival_no_public_rooms);
-
-               return;
-            }
-
-            if Send(Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                     @FindPublicRoom),@GetAllowJoins)
-            {
-               Send(Send(Send(SYS,@GetSurvivalRoomMaintenance),
-                     @FindPublicRoom),@Teleport,#what=self);
-            }
-            else
-            {
-               Send(self,@MsgSendUser,#message_rsc=public_survival_too_late);
-            }
-
-            return;
-         }
-
-         if StringContain(String,"autocombine on")
-            AND NOT Send(self,@IsAutoCombining)
-         {
-            Send(self,@SetAutoCombine,#value=TRUE);
-            Send(self,@MsgSendUser,#message_rsc=autocombine_on_msg);
-
-            return;
-         }
-
-         if StringContain(String,"autocombine off")
-            AND Send(self,@IsAutoCombining)
-         {
-            Send(self,@SetAutoCombine,#value=FALSE);
-            Send(self,@MsgSendUser,#message_rsc=autocombine_off_msg);
-
-            return;
-         }
-
-         if StringContain(String,"autoloot on")
-            AND NOT Send(self,@IsAutolooting)
-         {
-            Send(self,@SetAutoloot,#value=TRUE);
-            Send(self,@MsgSendUser,#message_rsc=autoloot_on_msg);
-
-            return;
-         }
-
-         if StringContain(String,"autoloot off")
-            AND Send(self,@IsAutolooting)
-         {
-            Send(self,@SetAutoloot,#value=FALSE);
-            Send(self,@MsgSendUser,#message_rsc=autoloot_off_msg);
-
-            return;
-         }
-
-         if StringContain(String,"reagentbag on")
-            AND NOT Send(self,@GetReagentBagAuto)
-         {
-            Send(self,@SetReagentBagAuto,#value=TRUE);
-            Send(self,@MsgSendUser,#message_rsc=reagentbag_auto_on);
-
-            return;
-         }
-
-         if StringContain(String,"reagentbag off")
-            AND Send(self,@GetReagentBagAuto)
-         {
-            Send(self,@SetReagentBagAuto,#value=FALSE);
-            Send(self,@MsgSendUser,#message_rsc=reagentbag_auto_off);
-
-            return;
          }
       }
 
@@ -4840,24 +4591,13 @@ messages:
 
       if type = SAY_GUILD
       {
-         if StringContain(string,guild_motd_command)
-            AND poGuild <> $
-            AND (Send(poGuild,@GetRank,#who=self) = RANK_MASTER
-               OR Send(poGuild,@GetRank,#who=self) = RANK_LIEUTENANT)
+         if StringContain(string,user_say_guild_motd)
          {
-            Send(poGuild,@SetGuildMOTD,#who=self,#string=string);
-
-            return;
-         }
-         if StringContain(string,guild_clear_motd_command)
-            AND poGuild <> $
-            AND Send(poGuild,@GetGuildMaster) = self
-            AND (Send(poGuild,@GetRank,#who=self) = RANK_MASTER
-               OR Send(poGuild,@GetRank,#who=self) = RANK_LIEUTENANT)
-         {
-            Send(poGuild,@SetGuildMOTD,#who=self,#string=$);
-
-            return;
+            % If UserSayGuildMOTD handles the string, don't keep checking.
+            if Send(self,@UserSayGuildMOTD,#string=string)
+            {
+               return;
+            }
          }
 
          % If the user has tells squelched, block guild sends too.
@@ -4971,6 +4711,400 @@ messages:
       Debug("Got unknown user say type",type);
 
       return;
+   }
+
+   UserSayGuildMOTD(string = $)
+   {
+      if poGuild = $
+      {
+         return FALSE;
+      }
+
+      if StringContain(string,guild_motd_command)
+         AND (Send(poGuild,@GetRank,#who=self) = RANK_MASTER
+            OR Send(poGuild,@GetRank,#who=self) = RANK_LIEUTENANT)
+      {
+         Send(poGuild,@SetGuildMOTD,#who=self,#string=string);
+
+         return TRUE;
+      }
+
+      if StringContain(string,guild_clear_motd_command)
+         AND Send(poGuild,@GetGuildMaster) = self
+         AND (Send(poGuild,@GetRank,#who=self) = RANK_MASTER
+            OR Send(poGuild,@GetRank,#who=self) = RANK_LIEUTENANT)
+      {
+         Send(poGuild,@SetGuildMOTD,#who=self,#string=$);
+
+         return TRUE;
+      }
+
+      return FALSE;
+   }
+
+   UserSayInventory(string = $)
+   {
+      local i, lSortInfo, oTemplateItem, n, bFound;
+
+      if StringEqual(string,user_say_inv_sort_clear)
+      {
+         plClassOrderPreferences = $;
+         Send(self,@MsgSendUser,#message_rsc=inventory_sort_cleared);
+
+         return TRUE;
+      }
+
+      if StringEqual(string,user_say_inv_sort_report)
+      {
+         Send(self,@MsgSendUser,#message_rsc=inventory_sort_report_header);
+
+         lSortInfo = Send(SYS,@GetSortInfo);
+
+         for i in plClassOrderPreferences
+         {
+            bFound = FALSE;
+            for n in lSortInfo
+            {
+               if Nth(n,2) = i
+               {
+                  Send(self,@MsgSendUser,#message_rsc=inventory_sort_report,
+                        #parm1=Nth(n,1));
+                  bFound = TRUE;
+
+                  break;
+               }
+            }
+
+            if bFound
+            {
+               continue;
+            }
+
+            oTemplateItem = Send(SYS,@FindTemplateItemByClass,#cClass=i);
+
+            if oTemplateItem <> $
+            {
+               Send(self,@MsgSendUser,#message_rsc=inventory_sort_report,
+                     #parm1=Send(oTemplateItem,@GetName));
+            }
+         }
+
+         return TRUE;
+      }
+
+      if StringContain(string,user_say_inv_sort_add)
+      {
+         StringSubstitute(string,user_say_inv_sort_add,"");
+
+         lSortInfo = Send(SYS,@GetSortInfo);
+
+         for i in lSortInfo
+         {
+            if StringEqual(string,First(i))
+            {
+               if plClassOrderPreferences <> $
+                  AND FindListElem(plClassOrderPreferences,Nth(i,2)) <> 0
+               {
+                  Send(self,@MsgSendUser,#message_rsc=inventory_already_in_list);
+
+                  return TRUE;
+               }
+
+               plClassOrderPreferences =
+                       AppendListElem(Nth(i,2),plClassOrderPreferences);
+
+               Send(self,@MsgSendUser,#message_rsc=inventory_class_added,
+                     #parm1=Nth(i,1));
+
+               return TRUE;
+            }
+         }
+
+         oTemplateItem = Send(SYS,@FindTemplateItemByName,#string=string);
+
+         if oTemplateItem <> $
+         {
+            plClassOrderPreferences = AppendListElem(GetClass(oTemplateItem),
+                                             plClassOrderPreferences);
+            Send(self,@MsgSendUser,#message_rsc=inventory_class_added,
+                  #parm1=Send(oTemplateItem,@GetName));
+
+            return TRUE;
+         }
+
+         Send(self,@MsgSendUser,#message_rsc=inventory_sort_no_item);
+
+         return TRUE;
+      }
+
+      if StringEqual(string,user_say_inv_sort_help)
+      {
+         Send(self,@MsgSendUser,#message_rsc=inventory_sort_help);
+
+         return TRUE;
+      }
+
+      if StringEqual(string,user_say_inv_sort)
+      {
+         plPassive = Send(SYS,@SortItemsByType,#lItems=plPassive,
+                           #lClassOrder=plClassOrderPreferences);
+         Send(self,@ToCliInventory);
+         Send(self,@ToCliUseList);
+
+         return TRUE;
+      }
+
+      return FALSE;
+   }
+
+   UserSaySurvival(string = $)
+   {
+      local lSurvivalOptions, oForceBaseRoom;
+
+      if StringContain(string,user_say_start_solo_survival)
+      {
+         if NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
+            OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
+            OR Send(poOwner,@GetRoomNum) = RID_FIELD1
+         {
+            Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
+
+            return TRUE;
+         }
+
+         Send(Send(SYS,@GetSurvivalRoomMaintenance),@CreateRoom,#who=self);
+
+         return TRUE;
+      }
+
+      if StringEqual(string,user_say_join_pub_survival)
+      {
+         if NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
+            OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
+            OR Send(poOwner,@GetRoomNum) = RID_FIELD1
+         {
+            Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
+
+            return TRUE;
+         }
+
+         if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindPublicRoom) = $
+         {
+            Send(self,@MsgSendUser,#message_rsc=survival_no_public_rooms);
+
+            return TRUE;
+         }
+
+         if Send(Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                  @FindPublicRoom),@GetAllowJoins)
+         {
+            Send(Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                  @FindPublicRoom),@Teleport,#what=self);
+         }
+         else
+         {
+            Send(self,@MsgSendUser,#message_rsc=public_survival_too_late);
+         }
+
+         return TRUE;
+      }
+
+      if StringContain(string,user_say_start_pub_survival)
+      {
+         lSurvivalOptions = $;
+         if (NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
+            OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
+            OR Send(poOwner,@GetRoomNum) = RID_FIELD1)
+            AND NOT IsClass(self,&Admin)
+         {
+            Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
+
+            return TRUE;
+         }
+
+         oForceBaseRoom = $;
+         if IsClass(self,&DM)
+         {
+            if StringContain(string,user_say_survival_opt_unnatural)
+            {
+               lSurvivalOptions = Cons(OPT_NATURAL,lSurvivalOptions);
+            }
+            if StringContain(string,user_say_survival_opt_pvpon)
+            {
+               lSurvivalOptions = Cons(OPT_PVP_ON,lSurvivalOptions);
+            }
+            if StringContain(string,user_say_survival_opt_starthere)
+            {
+               oForceBaseRoom = poOwner;
+            }
+         }
+
+         if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindPublicRoom) = $
+         {
+            Send(Send(SYS,@GetSurvivalRoomMaintenance),@CreateRoom,
+                  #who=self,#iPublic=TRUE,#sString=string,
+                  #lSurvivalOptions=lSurvivalOptions,
+                  #oForceBaseRoom=oForceBaseRoom);
+         }
+         
+         if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindPublicRoom) = $
+         {
+            Send(Send(SYS,@GetSurvivalRoomMaintenance),@CreateRoom,
+                  #who=self,#iPublic=TRUE,
+                  #lSurvivalOptions=lSurvivalOptions,
+                  #oForceBaseRoom=oForceBaseRoom);
+         }
+         else
+         {
+            Send(self,@MsgSendUser,#message_rsc=survival_err_already_public);
+         }
+
+         return TRUE;
+      }
+
+      if StringEqual(string,user_say_join_guild_survival)
+      {
+         if poGuild = $
+         {
+            Send(self,@MsgSendUser,#message_rsc=survival_err_no_guild);
+
+            return TRUE;
+         }
+
+         if NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
+            OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
+            OR Send(poOwner,@GetRoomNum) = RID_FIELD1
+         {
+            Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
+
+            return TRUE;
+         }
+
+         if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindRoomByGuild,
+                  #oGuild=poGuild) = $
+         {
+            Send(self,@MsgSendUser,#message_rsc=survival_no_guild_rooms);
+
+            return TRUE;
+         }
+
+         if Send(Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                  @FindRoomByGuild,#oGuild=poGuild),@GetAllowJoins)
+         {
+            Send(Send(Send(SYS,@GetSurvivalRoomMaintenance),
+                  @FindRoomByGuild,#oGuild=poGuild),@Teleport,#what=self);
+         }
+         else
+         {
+            Send(self,@MsgSendUser,#message_rsc=guild_survival_too_late);
+         }
+
+         return TRUE;
+      }
+
+      if StringContain(string,user_say_start_guild_survival)
+      {
+         lSurvivalOptions = $;
+         if poGuild = $
+         {
+            Send(self,@MsgSendUser,#message_rsc=survival_err_no_guild);
+
+            return TRUE;
+         }
+
+         if NOT Send(poOwner,@CheckRoomFlag,#flag=ROOM_SAFELOGOFF)
+            OR Send(poOwner,@GetRoomNum) = RID_UNDERWORLD
+            OR Send(poOwner,@GetRoomNum) = RID_FIELD1
+         {
+            Send(self,@MsgSendUser,#message_rsc=survival_err_not_safe);
+
+            return TRUE;
+         }
+
+         if Send(Send(SYS,@GetSurvivalRoomMaintenance),@FindRoomByGuild,
+                  #oGuild=poGuild) = $
+         {
+            Send(Send(SYS,@GetSurvivalRoomMaintenance),@CreateRoom,
+                  #who=self,#guild_survival=TRUE);
+         }
+         else
+         {
+            Send(self,@MsgSendUser,#message_rsc=survival_err_already_guild);
+         }
+
+         return TRUE;
+      }
+
+      return FALSE;
+   }
+
+   UserSayReagentBag(string = $)
+   {
+      if StringContain(string,user_say_reagentbag_on)
+         AND NOT Send(self,@GetReagentBagAuto)
+      {
+         Send(self,@SetReagentBagAuto,#value=TRUE);
+         Send(self,@MsgSendUser,#message_rsc=reagentbag_auto_on);
+
+         return TRUE;
+      }
+
+      if StringContain(string,user_say_reagentbag_off)
+         AND Send(self,@GetReagentBagAuto)
+      {
+         Send(self,@SetReagentBagAuto,#value=FALSE);
+         Send(self,@MsgSendUser,#message_rsc=reagentbag_auto_off);
+
+         return TRUE;
+      }
+
+      return FALSE;
+   }
+
+   UserSayAutocombine(string = $)
+   {
+      if StringContain(string,user_say_autocombine_on)
+         AND NOT Send(self,@IsAutoCombining)
+      {
+         Send(self,@SetAutoCombine,#value=TRUE);
+         Send(self,@MsgSendUser,#message_rsc=autocombine_on_msg);
+
+         return TRUE;
+      }
+
+      if StringContain(string,user_say_autocombine_off)
+         AND Send(self,@IsAutoCombining)
+      {
+         Send(self,@SetAutoCombine,#value=FALSE);
+         Send(self,@MsgSendUser,#message_rsc=autocombine_off_msg);
+
+         return TRUE;
+      }
+
+      return FALSE;
+   }
+
+   UserSayAutoloot(string = $)
+   {
+      if StringContain(string,user_say_autoloot_on)
+         AND NOT Send(self,@IsAutolooting)
+      {
+         Send(self,@SetAutoloot,#value=TRUE);
+         Send(self,@MsgSendUser,#message_rsc=autoloot_on_msg);
+
+         return TRUE;
+      }
+
+      if StringContain(string,user_say_autoloot_off)
+         AND Send(self,@IsAutolooting)
+      {
+         Send(self,@SetAutoloot,#value=FALSE);
+         Send(self,@MsgSendUser,#message_rsc=autoloot_off_msg);
+
+         return TRUE;
+      }
+
+      return FALSE;
    }
 
    UserSayGuild(string = $)

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2325,8 +2325,13 @@ messages:
    {
       Send(self,@CancelIfOffer);
 
+      % Break trance for all spells except multicast and radius enchantment.
+      % Other spells could possibly fail due to system save, this way the
+      % user will at least get a fail message.
+      Send(self,@BreakTrance,#event=EVENT_SYSTEMSAVE);
+
       Send(self,@SysMsgSendUser,#message_rsc=user_garbage_collecting);
-      Send(self, @WaveSendUser, #what = self, #wave_rsc = user_saving_wav_rsc);
+      Send(self,@WaveSendUser,#what=self,#wave_rsc=user_saving_wav_rsc);
 
       AddPacket(1,BP_WAIT);
       SendPacket(poSession);
@@ -5641,6 +5646,15 @@ messages:
    UserCast(oSpell=$,lTargets=$)
    {
       local i, bFound, iSpell, iSpellNum, iSpellPower, lFinalTargets;
+
+      % Check for valid spell first. This is mainly an issue during
+      % system saves where a user might cast something with the wrong
+      % object ID.
+      if oSpell = $
+         OR NOT IsClass(oSpell,&Spell)
+      {
+         return;
+      }
 
       % Command minions to aid in combat
       if lTargets <> $

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -5612,6 +5612,7 @@ messages:
       }
 
       if index <> $
+         AND plNew_mail <> $
       {
          if Length(plNew_mail) < index
          {

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -3967,6 +3967,16 @@ messages:
       return FALSE;
    }
 
+   CanTokenEnterRoom()
+   {
+      if Send(self,@IsArena)
+      {
+         return FALSE;
+      }
+
+      return TRUE;
+   }
+
    IsValidTarget(who=$)
    "Used for Arenas to see if something is a valid target.  Non-arenas just "
    "return FALSE."

--- a/kod/object/active/holder/room/ghall.kod
+++ b/kod/object/active/holder/room/ghall.kod
@@ -1302,5 +1302,10 @@ messages:
       return FALSE;
    }
 
+   CanTokenEnterRoom()
+   {
+      return FALSE;
+   }
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/active/holder/room/monsroom/survivalroom.kod
+++ b/kod/object/active/holder/room/monsroom/survivalroom.kod
@@ -1728,10 +1728,16 @@ messages:
    LastUserLeft()
    {
       Post(self,@Delete);
+
       propagate;
    }
 
    CanHavePlayerPortal(who = $)
+   {
+      return FALSE;
+   }
+
+   CanTokenEnterRoom()
    {
       return FALSE;
    }

--- a/kod/object/active/holder/room/outgrace.kod
+++ b/kod/object/active/holder/room/outgrace.kod
@@ -116,5 +116,10 @@ messages:
       return FALSE;
    }
 
+   CanTokenEnterRoom()
+   {
+      return FALSE;
+   }
+
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/item/passitem/defmod/shield/guilshld.kod
+++ b/kod/object/item/passitem/defmod/shield/guilshld.kod
@@ -584,6 +584,7 @@ messages:
    SendOverlays()
    {
       if prShield_emblem_held <> $
+         AND prShield_emblem_drop <> $
       {
          AddPacket(1,1);
          AddPacket(4,prShield_emblem_drop,1,1,1,ANIMATE_NONE,2,2);
@@ -618,6 +619,7 @@ messages:
    SendLookOverlays()
    {
       if prShield_emblem_held <> $
+         AND prShield_emblem_drop <> $
       {
          AddPacket(1,1);
          AddPacket(4,prShield_emblem_drop,1,1,1,ANIMATE_NONE,2,1);

--- a/kod/object/passive/spell/itemench/artifice.kod
+++ b/kod/object/passive/spell/itemench/artifice.kod
@@ -65,7 +65,7 @@ messages:
 
       if lTargets = $
       {
-         return;
+         return FALSE;
       }
 
       oWeapon = First(lTargets);

--- a/kod/object/passive/spell/itemench/artifice.kod
+++ b/kod/object/passive/spell/itemench/artifice.kod
@@ -63,6 +63,11 @@ messages:
    {
       local oWeapon;
 
+      if lTargets = $
+      {
+         return;
+      }
+
       oWeapon = First(lTargets);
 
       % Check that target is enchantable, and is a weapon

--- a/kod/object/passive/spell/itemench/enchwp.kod
+++ b/kod/object/passive/spell/itemench/enchwp.kod
@@ -74,7 +74,7 @@ messages:
 
       if lTargets = $
       {
-         return;
+         return FALSE;
       }
 
       oWeapon = First(lTargets);
@@ -85,7 +85,7 @@ messages:
          Send(who,@MsgSendUser,#message_rsc=enchantweapon_no_can,
                #parm1=Send(oWeapon,@GetDef),#parm2=Send(oWeapon,@GetName));
 
-         return False;
+         return FALSE;
       }
 
       if Send(oWeapon,@CheckTypeFlag,#flag=ATCK_WEAP_MAGIC) <> 0
@@ -95,7 +95,7 @@ messages:
          Send(who,@MsgSendUser,#message_rsc=enchantweapon_already_done,
                #parm1=Send(oWeapon,@GetName));
 
-         return False;
+         return FALSE;
       }
 
       propagate;   % Check other things higher up

--- a/kod/object/passive/spell/itemench/enchwp.kod
+++ b/kod/object/passive/spell/itemench/enchwp.kod
@@ -72,6 +72,11 @@ messages:
    {
       local oWeapon;
 
+      if lTargets = $
+      {
+         return;
+      }
+
       oWeapon = First(lTargets);
 
       if oWeapon = $

--- a/kod/object/passive/spell/itemench/glow.kod
+++ b/kod/object/passive/spell/itemench/glow.kod
@@ -76,6 +76,11 @@ messages:
    {
       local oLute, oWeapon, oTarget, oGlow, iCurrentGlow;
 
+      if lTargets = $
+      {
+         return;
+      }
+
       oTarget = First(lTargets);
 
       if NOT (IsClass(oTarget,&Weapon)

--- a/kod/object/passive/spell/itemench/glow.kod
+++ b/kod/object/passive/spell/itemench/glow.kod
@@ -78,7 +78,7 @@ messages:
 
       if lTargets = $
       {
-         return;
+         return FALSE;
       }
 
       oTarget = First(lTargets);

--- a/kod/object/passive/spell/itemench/holywp.kod
+++ b/kod/object/passive/spell/itemench/holywp.kod
@@ -73,7 +73,7 @@ messages:
 
       if lTargets = $
       {
-         return;
+         return FALSE;
       }
 
       oWeapon = First(lTargets);

--- a/kod/object/passive/spell/itemench/holywp.kod
+++ b/kod/object/passive/spell/itemench/holywp.kod
@@ -71,6 +71,11 @@ messages:
    {
       local oWeapon;
 
+      if lTargets = $
+      {
+         return;
+      }
+
       oWeapon = First(lTargets);
 
       if oWeapon = $

--- a/kod/object/passive/spell/itemench/identify.kod
+++ b/kod/object/passive/spell/itemench/identify.kod
@@ -58,6 +58,11 @@ messages:
    {
       local oTarget;
 
+      if lTargets = $
+      {
+         return;
+      }
+
       oTarget = First(lTargets);
 
       % Check that target is a weapon or armor

--- a/kod/object/passive/spell/itemench/identify.kod
+++ b/kod/object/passive/spell/itemench/identify.kod
@@ -60,7 +60,7 @@ messages:
 
       if lTargets = $
       {
-         return;
+         return FALSE;
       }
 
       oTarget = First(lTargets);

--- a/kod/object/passive/spell/itemench/mend.kod
+++ b/kod/object/passive/spell/itemench/mend.kod
@@ -64,7 +64,7 @@ messages:
 
       if lTargets = $
       {
-         return;
+         return FALSE;
       }
 
       oTarget = First(lTargets);

--- a/kod/object/passive/spell/itemench/mend.kod
+++ b/kod/object/passive/spell/itemench/mend.kod
@@ -62,6 +62,11 @@ messages:
    {
       local oTarget, iHits, iMaxHits;
 
+      if lTargets = $
+      {
+         return;
+      }
+
       oTarget = First(lTargets);
 
       % Check that target is an item that can be mended.

--- a/kod/object/passive/spell/itemench/reveal.kod
+++ b/kod/object/passive/spell/itemench/reveal.kod
@@ -75,7 +75,7 @@ messages:
 
       if lTargets = $
       {
-         return;
+         return FALSE;
       }
 
       oTarget = First(lTargets);

--- a/kod/object/passive/spell/itemench/reveal.kod
+++ b/kod/object/passive/spell/itemench/reveal.kod
@@ -73,6 +73,11 @@ messages:
    {
       local oTarget;
 
+      if lTargets = $
+      {
+         return;
+      }
+
       oTarget = First(lTargets);
 
       % Check that target is a weapon or armor

--- a/kod/object/passive/spell/itemench/shroud.kod
+++ b/kod/object/passive/spell/itemench/shroud.kod
@@ -64,7 +64,7 @@ messages:
 
       if lTargets = $
       {
-         return;
+         return FALSE;
       }
 
       oTarget = First(lTargets);

--- a/kod/object/passive/spell/itemench/shroud.kod
+++ b/kod/object/passive/spell/itemench/shroud.kod
@@ -62,6 +62,11 @@ messages:
    {
       local oWeapon, oTarget;
 
+      if lTargets = $
+      {
+         return;
+      }
+
       oTarget = First(lTargets);
 
       % Check that target is an item

--- a/kod/object/passive/spell/itemench/unholywp.kod
+++ b/kod/object/passive/spell/itemench/unholywp.kod
@@ -75,7 +75,7 @@ messages:
 
       if lTargets = $
       {
-         return;
+         return FALSE;
       }
 
       oWeapon = First(lTargets);

--- a/kod/object/passive/spell/itemench/unholywp.kod
+++ b/kod/object/passive/spell/itemench/unholywp.kod
@@ -32,7 +32,8 @@ resources:
       "Requires two fairy wings and an orc tooth to cast."
 
    unholyweapon_spell_intro = \
-      "Qor Lv. 2: Dedicates your weapon to Qor, enhancing its effectiveness against the holy."
+      "Qor Lv. 2: Dedicates your weapon to Qor, enhancing its "
+      "effectiveness against the holy."
 
    unholyweapon_label_rsc = "supplicant of Qor."
 
@@ -71,6 +72,12 @@ messages:
    CanPayCosts(who=$,lTargets=$,iSpellPower=0)
    {
       local oWeapon;
+
+      if lTargets = $
+      {
+         return;
+      }
+
       oWeapon = First(lTargets);
 
       if oWeapon = $

--- a/kod/object/passive/spell/multicst.kod
+++ b/kod/object/passive/spell/multicst.kod
@@ -104,12 +104,19 @@ messages:
       return 0;
    }
 
-   BreakTrance(who = $, state = $)
+   BreakTrance(who = $, state = $, event = 0)
    {
-      % If caster runs out of mana or loses trance, spell ends.
-      if IsClass(first(state),&prism)
+      % Don't break on system saves.
+      if event <> $
+         AND event = EVENT_SYSTEMSAVE
       {
-         Send(first(state),@CasterBrokeTrance,#who=who);
+         return FALSE;
+      }
+
+      % If caster runs out of mana or loses trance, spell ends.
+      if IsClass(First(state),&Prism)
+      {
+         Send(First(state),@CasterBrokeTrance,#who=who);
          Send(who,@RemoveEnchantment,#what=self,#state=state);
 
          propagate;

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -646,6 +646,7 @@ messages:
          OR event = EVENT_DISRUPT
          OR event = EVENT_CAST
          OR event = EVENT_USE
+         OR event = EVENT_SYSTEMSAVE
          OR piOldAreaEnchStyle
       {
          return FALSE;

--- a/kod/object/passive/spell/shatter.kod
+++ b/kod/object/passive/spell/shatter.kod
@@ -21,7 +21,7 @@ resources:
    shatter_desc_rsc = \
       "The icy magic of Faren shatters one or more items in "
       "the inventory of the target.  "
-      "Requires red and purple mushrooms to cast."
+      "Requires three red and three purple mushrooms to cast."
 
    shatter_sound = fshatter.wav
 
@@ -56,8 +56,8 @@ classvars:
    vrSucceed_wav = shatter_sound
    viFlash = FLASH_BAD
 
-   % in seconds, since it works off gettime()
-   viPostCast_time = 5        
+   % in seconds, since it works off GetTime().
+   viPostCast_time = 5
 
    vrToo_few_hp = shatter_not_enough_hp
 
@@ -65,14 +65,14 @@ properties:
 
    % Must have this many HP to cast the spell.  Added this to reduce
    % griefing: mules who shatter will likely be killed, and then have
-   % to get the HP back.  
+   % to get the HP back.
    piMinHitPoints = 40
 
 messages:
 
    ResetReagents()
    {
-      % separate message so can change, then set from admin mode
+      % Separate message so can change, then set from admin mode.
 
       plReagents = $;
       plReagents = Cons([&RedMushroom,3],plReagents);
@@ -88,23 +88,25 @@ messages:
 
    CanPayCosts(who = $, lTargets = $, bItemCast = FALSE)
    {
-      local target, i;
-      
+      local oTarget, i;
+
       % Can cast spell if the 1 target item is a user
       if Length(lTargets) <> 1
       {
          return FALSE;
       }
 
-      target = First(lTargets);
-      if NOT IsClass(target,&Player)
+      oTarget = First(lTargets);
+      if oTarget = $
+         OR NOT IsClass(oTarget,&Player)
       {
-         if not bItemCast
+         if NOT bItemCast
          {
-            Send(who,@MsgSendUser,#message_rsc=spell_bad_target, 
-                 #parm1=vrName,#parm2=Send(target,@GetDef),#parm3=Send(target,@GetName));
+            Send(who,@MsgSendUser,#message_rsc=spell_bad_target,
+                  #parm1=vrName,#parm2=Send(oTarget,@GetDef),
+                  #parm3=Send(oTarget,@GetName));
          }
-         
+
          return FALSE;
       }
 
@@ -114,9 +116,15 @@ messages:
    CastSpell(who = $, lTargets = $, iSpellPower=0)
    {
       local oShatter, oTarget, count, oChosen, iNumber, iPercent;
-            
+
+      if Length(lTargets) <> 1
+      {
+         return FALSE;
+      }
+
       oTarget = First(lTargets);
-      if NOT IsClass(oTarget,&Player)
+      if oTarget = $
+         OR NOT IsClass(oTarget,&Player)
       {
          return;
       }
@@ -128,60 +136,66 @@ messages:
       {
          count = count - 1;
          oShatter = Send(oTarget,@GetRandomItem);
-         if oShatter = $  { break; }
-         if NOT send(oShatter,@CanShatter)
+         if oShatter = $
+         {
+            break;
+         }
+
+         if NOT Send(oShatter,@CanShatter)
          {
             continue;
          }
 
-         if oChosen = $ or send(oShatter,@GetValue) > send(oChosen,@GetValue)
+         if oChosen = $
+            OR Send(oShatter,@GetValue) > Send(oChosen,@GetValue)
          {
             oChosen = oShatter;
          }
       }
-      
-      oShatter = oChosen;      
-      if oShatter = $ OR NOT send(oShatter,@CanShatter) 
+
+      oShatter = oChosen;
+      if oShatter = $
+         OR NOT Send(oShatter,@CanShatter)
       {
          % You get here if the spell failed to find something shatterable.
          Send(who,@MsgSendUser,#message_rsc=shatter_failed_caster,
-              #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
+               #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
          Send(oTarget,@MsgSendUser,#message_rsc=shatter_failed_target,
-              #parm1=Send(who,@GetCapDef),#parm2=Send(who,@GetName));
-              
+               #parm1=Send(who,@GetCapDef),#parm2=Send(who,@GetName));
+
          propagate;
       }
 
       if Send(oTarget,@ReqLeaveHold,#what=oShatter)
       {
-         if send(oShatter,@IsPlural)
+         if Send(oShatter,@IsPlural)
          {
             Send(oTarget,@MsgSendUser,#message_rsc=shatter_cast_plural_rsc,
-                 #parm1=Send(oShatter,@GetName));
+                  #parm1=Send(oShatter,@GetName));
          }
          else
          {
             Send(oTarget,@MsgSendUser,#message_rsc=shatter_cast_rsc,
-                 #parm1=Send(oShatter,@GetName));
+                  #parm1=Send(oShatter,@GetName));
          }
-         
+
          Send(who,@MsgSendUser,#message_rsc=shatter_succeed,
-              #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName),
-              #parm3=Send(oShatter,@GetName));
-            
+               #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName),
+               #parm3=Send(oShatter,@GetName));
+
          count = count -1;
 
          % Only delete a percent of a number item
-         If IsClass(oShatter,&NumberItem)
+         if IsClass(oShatter,&NumberItem)
          {
-            iNumber = send(oShatter,@GetNumber);
+            iNumber = Send(oShatter,@GetNumber);
             iPercent = bound(iSpellpower-29,20,70);
             iPercent = Random(iPercent/2,iPercent+30);
 
             % Always shatter at least one item 'cause we round down.
-            iNumber = bound((iNumber*iPercent)/100,1,$);
+            iNumber = Bound((iNumber*iPercent)/100,1,$);
 
-            send(oShatter,@SubtractNumber,#number=iNumber);
+            Send(oShatter,@SubtractNumber,#number=iNumber);
          }
          else
          {
@@ -189,14 +203,13 @@ messages:
          }
       }
 
-      propagate;      
+      propagate;
    }
 
    SpellBannedInArena()
    {
       return TRUE;
    }
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/util/survivalmaint.kod
+++ b/kod/util/survivalmaint.kod
@@ -76,7 +76,7 @@ messages:
    }
    
    CreateRoom(who=$,guild_survival=FALSE,iPublic=FALSE,sString=$,
-              lSurvivalOptions=$,poForceBaseRoom=$)
+              lSurvivalOptions=$,oForceBaseRoom=$)
    {
       local poRoom, poBaseRoom, plAllRooms, iRID, i, plPlayersLoggedOn, z,
             plExcludedRoomsObjs, iNatural, iPvP, o;
@@ -126,7 +126,7 @@ messages:
          {
             if StringContain(sString,Send(i,@GetName))
             {
-               poForceBaseRoom = i;
+               oForceBaseRoom = i;
 
                break;
             }
@@ -144,10 +144,10 @@ messages:
       % rooms.  Set poBaseRoom to the chosen room so it can be checked
       % in the following code.
       if NOT IsClass(who,&DM)
-         AND poForceBaseRoom <> $
+         AND oForceBaseRoom <> $
       {
-         poBaseRoom = poForceBaseRoom;
-         poForceBaseRoom = $;
+         poBaseRoom = oForceBaseRoom;
+         oForceBaseRoom = $;
       }
       else
       {
@@ -179,9 +179,9 @@ messages:
 
       % If we still have a forced base room, it was given by a DM.
       % Set the base room to the forced one.
-      if poForceBaseRoom <> $
+      if oForceBaseRoom <> $
       {
-         poBaseRoom = poForceBaseRoom;
+         poBaseRoom = oForceBaseRoom;
       }
 
       iRID = Send(self,@GetNextAvailableRID);


### PR DESCRIPTION
* Rarely on system save players can end up trying to cast a spell with an
incorrect object ID. The individual checks on spells will help prevent
this, and there is now additional layers of safety by UserCast checking
for the Spell class, and BreakTrance being called with EVENT_SYSTEMSAVE
on GC. MultiCastSpells and RadiusEnchantments won't break on save, as
they work differently (they have enchantments active).
* Some users try to use the number when asking an NPC for level (i.e. level 1) instead of the word "one"; now both ways will work.
* Admin modified herald shields cause errors to be logged on the server,
and also "missing resource" boxes for the holder of the shield. The
shield will now send the correct data (i.e. nothing) if
prShield_emblem_drop is modified to be $. The shield now also displays
correctly in the inventory.
* Changed the user text commands in UserSay() from debug strings to
resources to facilitate multi-language integration. Moved the string
checks for each group of user commands to separate messages, gated by a
single string check for each. This allows less string checks to be
performed per user say (will be important when more languages are
added).
* Rooms now have a CanTokenEnterRoom() message to determine whether a
token can enter the room or not. Arenas, guild halls, OoG and Survival
Arenas return FALSE, all other rooms TRUE. This message is used by
CheckTokenInNewRoom() in Player, which is checked every time the player
changes rooms. Arenas, Survival Arenas and guild halls give a
specialised fail message, any other room that returns FALSE for
CanTokenEnterRoom() gives a generic one.