### PR TITLE
Handle cancelling faction quests correctly. Fix some skills not improving correctly.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -8747,10 +8747,11 @@ messages:
    "stamina, all the way down to half for those with high staminas."
    {
       local i, dodgeskill, oSkill, monster_level, gain, gainmult, roll,
-            oWeapon, lBuilderGroup;
+            oWeapon, lBuilderGroup, bGainedHP;
 
       gain = 0;
       roll = FALSE;
+      bGainedHP = FALSE;
 
       % Some things just never allow advancement.
       % Can advance in arena if realdeath is on in an arena.
@@ -8967,13 +8968,16 @@ messages:
          % TRUE if player gains a HP, FALSE if they don't.
          if roll
          {
-            return Send(self,@RollForTougher,#iLevel=monster_level);
+            bGainedHP = Send(self,@RollForTougher,#iLevel=monster_level);
          }
       }
 
       % Draw the tougher chance bar. Send this here because RollForTougher
       % will also draw it, no need to do so twice.
-      Post(self,@DrawHPChance);
+      if NOT roll
+      {
+         Post(self,@DrawHPChance);
+      }
 
       if (piFlags & PFLAG_DODGED)
          AND NOT group_member_kill
@@ -9004,7 +9008,8 @@ messages:
          }
       }
 
-      return FALSE;
+      % If RollForTougher returned TRUE, we gained a hitpoint.
+      return bGainedHP;
    }
 
    RollForTougher(iLevel=0)

--- a/kod/object/passive/questnode.kod
+++ b/kod/object/passive/questnode.kod
@@ -1408,28 +1408,29 @@ messages:
             {
                Send(oQuester,@UpdateFactionService,#full=TRUE);
             }
-
+            % Post these prize types, because the player will cancel any
+            % faction quests they have open in ResignFaction
             if iPrizeFaction = QN_PRIZE_FACTION_DUKE
             {
-               Send(oQuester,@ResignFaction);
-               Send(oQuester,@JoinFaction,#new_faction=FACTION_DUKE);
+               Post(oQuester,@ResignFaction);
+               Post(oQuester,@JoinFaction,#new_faction=FACTION_DUKE);
             }
 
             if iPrizeFaction = QN_PRIZE_FACTION_PRINCESS
             {
-               Send(oQuester,@ResignFaction);
-               Send(oQuester,@JoinFaction,#new_faction=FACTION_PRINCESS);
+               Post(oQuester,@ResignFaction);
+               Post(oQuester,@JoinFaction,#new_faction=FACTION_PRINCESS);
             }
 
             if iPrizeFaction = QN_PRIZE_FACTION_REBEL
             {
-               Send(oQuester,@ResignFaction);
-               Send(oQuester,@JoinFaction,#new_faction=FACTION_REBEL);
+               Post(oQuester,@ResignFaction);
+               Post(oQuester,@JoinFaction,#new_faction=FACTION_REBEL);
             }
 
             if iPrizeFaction = QN_PRIZE_FACTION_NEUTRAL
             {
-               Send(oQuester,@ResignLoyaltyFailed);
+               Post(oQuester,@ResignLoyaltyFailed);
             }
          }
 


### PR DESCRIPTION
If a player fails a faction loyalty quest, DeadlineExpired is sent to all faction quests including the one that just failed. QuestNode handles this correctly and doesn't try to fail the quest twice, but the correct behavior here is to Post the rewards so that the failing quest is cleaned up (and removed from the player's quest list) before trying to clear all active faction quests for that player.

Fixed dodge/block/parry not improving due to some code being skipped in AdvancementCheck.