### PR TITLE
Revert system save trance breaking, fix up some message calls in Player/DM.

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2376,8 +2376,6 @@
    EVENT_DISRUPT = 9
    % Player is moving to a new room but has not yet
    EVENT_REQNEWOWNER = 10
-   % Break trance for system save.
-   EVENT_SYSTEMSAVE = 11
 
    %%% Hot spot definitions
 

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -3514,6 +3514,7 @@ messages:
          {
             if pbLogged_On
                OR IsClass(what,&Phase)
+               OR IsClass(what,&Boon)
             {
                if First(i) <> $
                {

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -3512,7 +3512,7 @@ messages:
       {
          if Nth(i,2) = what
          {
-            if Send(self,@IsLoggedOn)
+            if pbLogged_On
                OR IsClass(what,&Phase)
             {
                if First(i) <> $
@@ -14310,7 +14310,7 @@ messages:
    {
       if poOwner = $
          OR piBound_Room = $
-         OR NOT Send(self,@IsLoggedOn)
+         OR NOT pbLogged_on
       {
          return;
       }
@@ -14398,8 +14398,8 @@ messages:
          AND Send(self,@GetDeathRiftProtection) = TRUE
       {
          Send(self,@AdminGoToSafety);
-         
-         if Send(self,@IsLoggedOn)
+
+         if pbLogged_on
          {
             Send(self,@MsgSendUser,#message_rsc=death_rift_stayed_too_long);
          }

--- a/kod/object/active/holder/nomoveon/battler/player/user.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user.kod
@@ -2396,11 +2396,6 @@ messages:
    {
       Send(self,@CancelIfOffer);
 
-      % Break trance for all spells except multicast and radius enchantment.
-      % Other spells could possibly fail due to system save, this way the
-      % user will at least get a fail message.
-      Send(self,@BreakTrance,#event=EVENT_SYSTEMSAVE);
-
       Send(self,@SysMsgSendUser,#message_rsc=user_garbage_collecting);
       Send(self,@WaveSendUser,#what=self,#wave_rsc=user_saving_wav_rsc);
 

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
@@ -1042,11 +1042,8 @@ messages:
          }
          if oObject <> $
          {
-            Send(poOwner,@NewHold,#what=oObject,
-                  #new_row=Send(self,@GetRow),
-                  #new_col=Send(self,@GetCol),
-                  #fine_row=Send(self,@GetFineRow),
-                  #fine_col=Send(self,@GetFineCol));
+            Send(poOwner,@NewHold,#what=oObject,#new_row=piRow,#new_col=piCol,
+                  #fine_row=piFine_row,#fine_col=piFine_col);
 
             return;
          }
@@ -1225,9 +1222,8 @@ messages:
          {
             oObject = Create(&EventSign);
 
-            Send(poOwner,@NewHold,#what=oObject,
-                  #new_row=Send(self,@GetRow),
-                  #new_col=Send(self,@GetCol));
+            Send(poOwner,@NewHold,#what=oObject,#new_row=piRow,#new_col=piCol,
+                  #fine_row=piFine_row,#fine_col=piFine_col);
 
             return;
          }
@@ -1418,7 +1414,8 @@ messages:
                   % Also makes the monster not affect Karma when killed.
                   Send(oObject,@SetDontDispose);
 
-                  Send(poOwner,@NewHold,#what=oObject,#new_row=piRow,#new_col=piCol);
+                  Send(poOwner,@NewHold,#what=oObject,#new_row=piRow,
+                        #new_col=piCol,#fine_row=piFine_row,#fine_col=piFine_col);
 
                   if NOT pbStealth
                   {
@@ -1796,7 +1793,8 @@ messages:
          if StringEqual(string,"call tester")
          {
             Send(poOwner,@NewHold,#what=Create(&GraphicTester),
-                 #new_row=Send(self,@GetRow),#new_col=Send(self,@GetCol));
+                  #new_row=piRow,#new_col=piCol,
+                  #fine_row=piFine_row,#fine_col=piFine_col);
 
             return;
          }

--- a/kod/object/passive/skill/secwind.kod
+++ b/kod/object/passive/skill/secwind.kod
@@ -149,7 +149,7 @@ messages:
       iTimer = Send(who,@GetSecondWindTimer);
       if iTimer = $
       {
-         return;
+         propagate;
       }
 
       if IsTimer(iTimer)

--- a/kod/object/passive/spell/multicst.kod
+++ b/kod/object/passive/spell/multicst.kod
@@ -104,15 +104,8 @@ messages:
       return 0;
    }
 
-   BreakTrance(who = $, state = $, event = 0)
+   BreakTrance(who = $, state = $)
    {
-      % Don't break on system saves.
-      if event <> $
-         AND event = EVENT_SYSTEMSAVE
-      {
-         return FALSE;
-      }
-
       % If caster runs out of mana or loses trance, spell ends.
       if IsClass(First(state),&Prism)
       {

--- a/kod/object/passive/spell/radiusench.kod
+++ b/kod/object/passive/spell/radiusench.kod
@@ -649,7 +649,6 @@ messages:
          OR event = EVENT_DISRUPT
          OR event = EVENT_CAST
          OR event = EVENT_USE
-         OR event = EVENT_SYSTEMSAVE
          OR piOldAreaEnchStyle
       {
          return FALSE;

--- a/kod/util.kod
+++ b/kod/util.kod
@@ -645,20 +645,17 @@ messages:
          }
       }
 
-      iCount = 0;
+      iCount = 1;
       % User wasn't on scoreboard. Get the position in list of
       % where we need to add them.
       for lEntry in lList
       {
-         iCount = iCount + 1;
-         if Nth(lEntry,2) > iPoints
-         {
-            continue;
-         }
-         else
+         if Nth(lEntry,2) < iPoints
          {
             break;
          }
+
+         iCount = iCount + 1;
       }
 
       % User's score should be less than iCount - 1 but more than

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -953,19 +953,19 @@ messages:
    {
       local i;
 
-      phUsers = $;
-      phRooms = $;
-      phSpells = $;
-      phItemAtts = $;
-
       Send(self,@CleanReflectionList);
 
       for i in plUsers_logged_on
       {
          Send(i,@GarbageCollecting);
       }
-	  
-	  Send(poStatistics,@GarbageCollecting);
+
+      phUsers = $;
+      phRooms = $;
+      phSpells = $;
+      phItemAtts = $;
+
+      Send(poStatistics,@GarbageCollecting);
 
       return;
    }


### PR DESCRIPTION
The EVENT_SYSTEMSAVE trance break seems to cause more problems than it fixes via messages being called during garbage collect. Existing checks catch all but the rarest instance of incorrect object references during saves, so reverting this change.

Use pbLogged_On in player.kod rather than calling the message on self.

Use fine coords for placing items in dm.kod for more precision.