### PR TITLE
Fix character select bugs, change charselect ad links.

### DIFF
--- a/blakserv/config.c
+++ b/blakserv/config.c
@@ -190,9 +190,9 @@ config_table_type config_table[] =
    
 { ADVERTISE_GROUP,        F, "[Advertise]",   CONFIG_GROUP, "" },
 { ADVERTISE_FILE1,        T, "File1",         CONFIG_STR,   "ad1.avi" },
-{ ADVERTISE_URL1,         T, "Url1",          CONFIG_STR,   "http://www.neardeathstudios.com" },
+{ ADVERTISE_URL1,         T, "Url1",          CONFIG_STR,   "http://openmeridian.org" },
 { ADVERTISE_FILE2,        T, "File2",         CONFIG_STR,   "ad2.avi" },
-{ ADVERTISE_URL2,         T, "Url2",          CONFIG_STR,   "http://meridian59.neardeathstudios.com" },
+{ ADVERTISE_URL2,         T, "Url2",          CONFIG_STR,   "http://openmeridian.org/forums" },
 
 { DEBUG_GROUP,            F, "[Debug]",       CONFIG_GROUP, "" },
 { DEBUG_CANMOVEINROOM,    T, "CanMoveInRoom", CONFIG_BOOL,  "No" },

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -999,11 +999,11 @@ properties:
    prRight_arm = player_rightarm_a_rsc
    prLeft_arm = player_leftarm_a_rsc
 
-   prHead = $
-   prEyes = $
-   prMouth = $
-   prNose = $
-   prToupee = $
+   prHead = charinfo_head_ax_icon
+   prEyes = charinfo_eyes_ax_icon
+   prMouth = charinfo_nose_ax_icon
+   prNose = charinfo_mouth_ax_icon
+   prToupee = charinfo_hair_cd_icon
 
    % Animation type.  If none, then use piAction
    % piAnimation should be PANM_NONE in between KOD calls.


### PR DESCRIPTION
Added default values for prHead, prEyes, prMouth, prNose and prToupee
for when a new user object is created.

Players trying to bypass the character creation dialog on a new
character slot will now be prevented from entering the game, and blocked
from reconnecting from 60 seconds. Though the default values are now
fixed, this is undesired behavior hence the short block time.

Changed the default links for the ads in character select screen to Open
Meridian homepage and forums (still nothing displayed there).