### PR TITLE
Removing Solagh form feign death's reg cost

### DIFF
--- a/kod/object/passive/spell/fdeath.kod
+++ b/kod/object/passive/spell/fdeath.kod
@@ -20,8 +20,7 @@ resources:
    feigndeath_icon_rsc = ifeignde.bgf
    feigndeath_desc_rsc = \
       "Makes you appear to be deceased, that hopefully someone won't "
-      "really make you as such.  Requires one solagh and one rainbow "
-      "fern to cast."
+      "really make you as such.  Requires one rainbow fern to cast."
 
    feigndeath_user_killed = "~B~U~k[###]~n ~B~v%s was just killed by %s%s."
    feigndeath_angrymocker = "an angry guy named Mocker"
@@ -56,7 +55,6 @@ messages:
    ResetReagents()
    {
       plReagents = $;
-      plReagents = Cons([&Solagh,1],plReagents);
       plReagents = Cons([&RainbowFern,1],plReagents);
 
       return;


### PR DESCRIPTION
Spell is to useless to cost such an expensive reagent.

I'm requesting it be lowered.