### PR TITLE
Increase rarity of Hold & Blind wands

### DIFF
--- a/kod/object/passive/trestype/fireelet.kod
+++ b/kod/object/passive/trestype/fireelet.kod
@@ -27,11 +27,10 @@ messages:
 
    Constructed()
    {
-      plTreasure = [ [ &LightningWand, 10 ],
+      plTreasure = [ [ &LightningWand, 30 ],
                      [ &HospiceWand, 30 ],
                      [ &EnfeebleWand, 10 ],
-                     [ &MarkOfDishonorWand, 30 ],
-                     [ &BlindWand, 20 ]
+                     [ &MarkOfDishonorWand, 30 ]
                   ];
 
       propagate;

--- a/kod/object/passive/trestype/ghostt.kod
+++ b/kod/object/passive/trestype/ghostt.kod
@@ -34,13 +34,12 @@ messages:
                      [ &RingInvisibility, 4],
                      [ &Gauntlet, 3 ],
                      [ &PlateArmor, 6 ],
-                     [ &KnightShield, 13 ],
+                     [ &KnightShield, 15 ],
                      [ &Scimitar, 17],
                      [ &VampireWand, 4],
                      [ &DiscipleRobe, 4],
                      [ &FineLute, 5],
                      [ &Key, 9 ],
-                     [ &HoldWand, 2],
                      [ &TruceScroll, 1]
                    ];
 

--- a/kod/object/passive/trestype/orcpitt.kod
+++ b/kod/object/passive/trestype/orcpitt.kod
@@ -27,7 +27,7 @@ messages:
 
    Constructed()
    {
-      plTreasure = [ [ &OrcTooth, 42 ],
+      plTreasure = [ [ &OrcTooth, 44 ],
                      [ &Scimitar, 12 ],
                      [ &Arrow, 12 ],
                      [ &NeruditeArmor, 9],
@@ -37,8 +37,6 @@ messages:
                      [ &Flask, 2],
                      [ &OrcShield, 2],
                      [ &PlateArmor, 2],
-                     [ &HoldWand, 1 ],
-                     [ &BlindWand, 1 ],
                      [ &HeatScroll, 1]
                    ];
 

--- a/kod/object/passive/trestype/verytght.kod
+++ b/kod/object/passive/trestype/verytght.kod
@@ -34,7 +34,7 @@ messages:
                      [ &Diamond, 9 ],
                      [ &Ruby, 8 ],
                      [ &BlueDragonScale, 17],
-                     [ &DarkAngelFeather, 15]
+                     [ &DarkAngelFeather, 15],
                      [ &MysticSword, 3 ],
                      [ &PlateArmor, 3 ]
                    ];

--- a/kod/object/passive/trestype/verytght.kod
+++ b/kod/object/passive/trestype/verytght.kod
@@ -32,10 +32,9 @@ messages:
                      [ &PurpleMushroom, 14 ],
                      [ &Sapphire, 12 ],
                      [ &Diamond, 9 ],
-                     [ &Ruby, 7 ],
+                     [ &Ruby, 8 ],
                      [ &BlueDragonScale, 17],
-                     [ &DarkAngelFeather, 15],
-                     [ &HoldWand, 1],
+                     [ &DarkAngelFeather, 15]
                      [ &MysticSword, 3 ],
                      [ &PlateArmor, 3 ]
                    ];


### PR DESCRIPTION
These flagship spells are currently out of place in wand form. For the
same reason we don't have Spore Burst, Earthquake, or Purge
scrolls/wands, Hold and Blind don't belong in readily available / free
item form. That being said, they're not gamebreaking in very small
amounts, so they'll still be available on rare occasions.

A Moxal quest has a 1% chance to give a BlindWand, and the Lich (if
implemented) will drop them at 5%.

The Ko'catan ale trade quest has a 1% chance to give a HoldWand, and
Izzio's junk item list can also spawn them.

The spike in value and rarity will make them extremely unviable in all
but the rarest situations. And those rare situations make for good
stories, so if someone wants to have one crazy fight with wands per
year, I say more power to them.
- Assumption here is that existing ones are deleted.
