### PR TITLE
Refactoring conditional directives that break parts of statements.

### DIFF
--- a/libarchive/archive_write_set_format_iso9660.c
+++ b/libarchive/archive_write_set_format_iso9660.c
@@ -39,6 +39,7 @@
 #endif
 #include <stdio.h>
 #include <stdarg.h>
+#include <stdbool.h>
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
@@ -4701,6 +4702,7 @@ isofile_gen_utility_names(struct archive_write *a, struct isofile *file)
 	char *p, *dirname, *slash;
 	size_t len;
 	int ret = ARCHIVE_OK;
+	bool test;
 
 	iso9660 = a->format_data;
 
@@ -4759,11 +4761,12 @@ isofile_gen_utility_names(struct archive_write *a, struct isofile *file)
 		 */
 		while (u16len >= 2) {
 #if defined(_WIN32) || defined(__CYGWIN__)
-			if (u16[u16len-2] == 0 &&
-			    (u16[u16len-1] == '/' || u16[u16len-1] == '\\'))
+			test = u16[u16len-2] == 0 &&
+			    (u16[u16len-1] == '/' || u16[u16len-1] == '\\');
 #else
-			if (u16[u16len-2] == 0 && u16[u16len-1] == '/')
+			test = u16[u16len-2] == 0 && u16[u16len-1] == '/';
 #endif
+			if (test)
 			{
 				u16len -= 2;
 			} else
@@ -4778,10 +4781,11 @@ isofile_gen_utility_names(struct archive_write *a, struct isofile *file)
 		ulen_last = u16len;
 		while (u16len > 0) {
 #if defined(_WIN32) || defined(__CYGWIN__)
-			if (u16[0] == 0 && (u16[1] == '/' || u16[1] == '\\'))
+			test = u16[0] == 0 && (u16[1] == '/' || u16[1] == '\\');
 #else
-			if (u16[0] == 0 && u16[1] == '/')
+			test = u16[0] == 0 && u16[1] == '/';
 #endif
+			if (test)
 			{
 				ulast = u16 + 2;
 				ulen_last = u16len -1;

--- a/libpng/png.c
+++ b/libpng/png.c
@@ -12,6 +12,7 @@
  */
 
 #include "pngpriv.h"
+#include <stdbool.h>
 
 /* Generate a compiler error if there is an old png.h in the search path. */
 typedef png_libpng_version_1_5_13 Your_png_h_is_not_version_1_5_13;
@@ -1172,6 +1173,7 @@ png_check_IHDR(png_structp png_ptr,
    int filter_type)
 {
    int error = 0;
+   bool test;
 
    /* Check for width and height valid values */
    if (width == 0)
@@ -1187,21 +1189,22 @@ png_check_IHDR(png_structp png_ptr,
    }
 
 #  ifdef PNG_SET_USER_LIMITS_SUPPORTED
-   if (width > png_ptr->user_width_max)
-
+   test = width > png_ptr->user_width_max;
 #  else
-   if (width > PNG_USER_WIDTH_MAX)
+   test = width > PNG_USER_WIDTH_MAX;
 #  endif
+   if (test)
    {
       png_warning(png_ptr, "Image width exceeds user limit in IHDR");
       error = 1;
    }
 
 #  ifdef PNG_SET_USER_LIMITS_SUPPORTED
-   if (height > png_ptr->user_height_max)
+   test = height > png_ptr->user_height_max;
 #  else
-   if (height > PNG_USER_HEIGHT_MAX)
+   test = height > PNG_USER_HEIGHT_MAX;
 #  endif
+   if (test)
    {
       png_warning(png_ptr, "Image height exceeds user limit in IHDR");
       error = 1;

--- a/libpng/pngread.c
+++ b/libpng/pngread.c
@@ -15,6 +15,7 @@
  */
 
 #include "pngpriv.h"
+#include <stdbool.h>
 
 #ifdef PNG_READ_SUPPORTED
 
@@ -79,11 +80,13 @@ png_create_read_struct_2,(png_const_charp user_png_ver, png_voidp error_ptr,
  * encounter a png_error() will longjmp here.  Since the jmpbuf is
  * then meaningless we abort instead of returning.
  */
+   bool test;
 #ifdef USE_FAR_KEYWORD
-   if (setjmp(tmp_jmpbuf))
+   test = setjmp(tmp_jmpbuf);
 #else
-   if (setjmp(png_jmpbuf(png_ptr))) /* Sets longjmp to match setjmp */
+   test = setjmp(png_jmpbuf(png_ptr)); /* Sets longjmp to match setjmp */
 #endif
+   if (test)
       PNG_ABORT();
 #ifdef USE_FAR_KEYWORD
    png_memcpy(png_jmpbuf(png_ptr), tmp_jmpbuf, png_sizeof(jmp_buf));

--- a/libpng/pngtest.c
+++ b/libpng/pngtest.c
@@ -42,6 +42,7 @@
 #  include <stdio.h>
 #  include <stdlib.h>
 #  include <string.h>
+#  include <stdbool.h>
 #  define FCLOSE(file) fclose(file)
 
 #ifndef PNG_STDIO_SUPPORTED
@@ -850,11 +851,13 @@ test_one_file(PNG_CONST char *inname, PNG_CONST char *outname)
 
 #ifdef PNG_SETJMP_SUPPORTED
    pngtest_debug("Setting jmpbuf for read struct");
+   bool test;
 #ifdef USE_FAR_KEYWORD
-   if (setjmp(tmp_jmpbuf))
+   test = setjmp(tmp_jmpbuf);
 #else
-   if (setjmp(png_jmpbuf(read_ptr)))
+   test = setjmp(png_jmpbuf(read_ptr));
 #endif
+   if (test)
    {
       fprintf(STDERR, "%s -> %s: libpng read error\n", inname, outname);
       png_free(read_ptr, row_buf);
@@ -874,12 +877,14 @@ test_one_file(PNG_CONST char *inname, PNG_CONST char *outname)
 
 #ifdef PNG_WRITE_SUPPORTED
    pngtest_debug("Setting jmpbuf for write struct");
+   bool test;
 #ifdef USE_FAR_KEYWORD
 
-   if (setjmp(tmp_jmpbuf))
+   test = setjmp(tmp_jmpbuf);
 #else
-   if (setjmp(png_jmpbuf(write_ptr)))
+   test = setjmp(png_jmpbuf(write_ptr));
 #endif
+   if (test)
    {
       fprintf(STDERR, "%s -> %s: libpng write error\n", inname, outname);
       png_destroy_read_struct(&read_ptr, &read_info_ptr, &end_info_ptr);

--- a/libpng/pngwutil.c
+++ b/libpng/pngwutil.c
@@ -12,6 +12,7 @@
  */
 
 #include "pngpriv.h"
+#include <stdbool.h>
 
 #ifdef PNG_WRITE_SUPPORTED
 
@@ -704,11 +705,13 @@ png_write_IHDR(png_structp png_ptr, png_uint_32 width, png_uint_32 height,
          break;
 
       case PNG_COLOR_TYPE_RGB:
+	bool test;
 #ifdef PNG_WRITE_16BIT_SUPPORTED
-         if (bit_depth != 8 && bit_depth != 16)
+         test = bit_depth != 8 && bit_depth != 16;
 #else
-         if (bit_depth != 8)
+         test = bit_depth != 8;
 #endif
+	if (test)
             png_error(png_ptr, "Invalid bit depth for RGB image");
 
          png_ptr->channels = 3;
@@ -737,11 +740,13 @@ png_write_IHDR(png_structp png_ptr, png_uint_32 width, png_uint_32 height,
          break;
 
       case PNG_COLOR_TYPE_RGB_ALPHA:
+	 bool test;
 #ifdef PNG_WRITE_16BIT_SUPPORTED
-         if (bit_depth != 8 && bit_depth != 16)
+         test = bit_depth != 8 && bit_depth != 16;
 #else
-         if (bit_depth != 8)
+         test = bit_depth != 8;
 #endif
+	 if (test)
             png_error(png_ptr, "Invalid bit depth for RGBA image");
 
          png_ptr->channels = 4;
@@ -1395,11 +1400,13 @@ png_write_tRNS(png_structp png_ptr, png_const_bytep trans_alpha,
       png_save_uint_16(buf, tran->red);
       png_save_uint_16(buf + 2, tran->green);
       png_save_uint_16(buf + 4, tran->blue);
+      bool test;
 #ifdef PNG_WRITE_16BIT_SUPPORTED
-      if (png_ptr->bit_depth == 8 && (buf[0] | buf[2] | buf[4]))
+      test = png_ptr->bit_depth == 8 && (buf[0] | buf[2] | buf[4]);
 #else
-      if (buf[0] | buf[2] | buf[4])
+      test = buf[0] | buf[2] | buf[4];
 #endif
+      if (test)
       {
          png_warning(png_ptr,
            "Ignoring attempt to write 16-bit tRNS chunk when bit_depth is 8");
@@ -1447,11 +1454,13 @@ png_write_bKGD(png_structp png_ptr, png_const_color_16p back, int color_type)
       png_save_uint_16(buf, back->red);
       png_save_uint_16(buf + 2, back->green);
       png_save_uint_16(buf + 4, back->blue);
+      bool test;
 #ifdef PNG_WRITE_16BIT_SUPPORTED
-      if (png_ptr->bit_depth == 8 && (buf[0] | buf[2] | buf[4]))
+      test = png_ptr->bit_depth == 8 && (buf[0] | buf[2] | buf[4]);
 #else
-      if (buf[0] | buf[2] | buf[4])
+      test = buf[0] | buf[2] | buf[4];
 #endif
+      if (test)
       {
          png_warning(png_ptr,
              "Ignoring attempt to write 16-bit bKGD chunk when bit_depth is 8");


### PR DESCRIPTION
  A suggestion to compile entire statements and expressions, as suggested by code style guidelines from the Linux Kernel and practitioners.

```
https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/tree/Documentation/CodingStyle#n892
https://www.cqse.eu/en/blog/living-in-the-ifdef-hell/
```

It might improve code understanding, maintainability and error-proneness.
