### PR TITLE
Game-time related code refactoring.

### DIFF
--- a/blakcomp/function.c
+++ b/blakcomp/function.c
@@ -160,7 +160,7 @@ id_struct BuiltinIds[] = {
 {"getusername",   I_MISSING,   16,  0,   I_MESSAGE},
 {"getusericon",   I_MISSING,   17,  0,   I_MESSAGE},
 {"sendcharinfo",  I_MISSING,   18,  0,   I_MESSAGE},
-{"newhour",       I_MISSING,   19,  0,   I_MESSAGE},
+{"newgamehour",   I_MISSING,   19,  0,   I_MESSAGE},
 {"guest",         I_MISSING,   20,  0,   I_CLASS},
 {"name",          I_MISSING,   21,  0,   I_PARAMETER},
 {"icon",          I_MISSING,   22,  0,   I_PARAMETER},

--- a/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
+++ b/kod/object/active/holder/nomoveon/battler/player/user/dm.kod
@@ -1802,7 +1802,7 @@ messages:
          if StringEqual(string,dm_morning_command)
             OR StringEqual(string,"morning")
          {
-            Send(SYS,@SetHour,#num=6);
+            Send(SYS,@SetHour,#iNum=6);
 
             return;
          }
@@ -1810,7 +1810,7 @@ messages:
          if StringEqual(string,dm_afternoon_command)
             OR StringEqual(string,"afternoon")
          {
-            Send(SYS,@SetHour,#num=13);
+            Send(SYS,@SetHour,#iNum=13);
 
             return;
          }
@@ -1818,7 +1818,7 @@ messages:
          if StringEqual(string,dm_evening_command)
             OR StringEqual(string,"evening")
          {
-            Send(SYS,@SetHour,#num=18);
+            Send(SYS,@SetHour,#iNum=18);
 
             return;
          }
@@ -1826,7 +1826,7 @@ messages:
          if StringEqual(string,dm_night_command)
             OR StringEqual(string,"night")
          {
-            Send(SYS,@SetHour,#num=23);
+            Send(SYS,@SetHour,#iNum=23);
 
             return;
          }
@@ -1834,7 +1834,7 @@ messages:
          if StringEqual(string,dm_restore_time_command)
             OR StringEqual(string,"restore time")
          {
-            Send(SYS,@RecalcLightAndWeather);
+            Send(SYS,@SystemInitGameHour);
 
             return;
          }

--- a/kod/object/item/passitem/defmod/shield/soldshld.kod
+++ b/kod/object/item/passitem/defmod/shield/soldshld.kod
@@ -261,7 +261,7 @@ messages:
       return;
    }
 
-   NewDay()
+   NewGameDay()
    "Called every new M59 day."
    {
       piDaysUntilRankLoss = piDaysUntilRankLoss - 1;

--- a/kod/object/item/passitem/questitem/srsttkn.kod
+++ b/kod/object/item/passitem/questitem/srsttkn.kod
@@ -120,7 +120,7 @@ messages:
       return FALSE;
    }
 
-   NewYear()
+   NewGameYear()
    {
       if pbTemporary
       {

--- a/kod/object/passive/spell/nodebrst.kod
+++ b/kod/object/passive/spell/nodebrst.kod
@@ -139,7 +139,7 @@ messages:
       return;
    }
 
-   NewDay()
+   NewGameDay()
    {
       plRecentCasters = $;
 

--- a/kod/util/gameevent.kod
+++ b/kod/util/gameevent.kod
@@ -119,6 +119,21 @@ messages:
       return;
    }
 
+   NewGameHour()
+   {
+      return;
+   }
+
+   NewGameDay()
+   {
+      return;
+   }
+
+   NewGameYear()
+   {
+      return;
+   }
+
    StartEvent()
    {
       if vbAnnounce

--- a/kod/util/gameevent/qormas.kod
+++ b/kod/util/gameevent/qormas.kod
@@ -1138,7 +1138,7 @@ messages:
       return;
    }
 
-   NewDay()
+   NewGameDay()
    {
       ++piGameDayCount;
 

--- a/kod/util/gameeventengine.kod
+++ b/kod/util/gameeventengine.kod
@@ -120,9 +120,7 @@ messages:
 
       foreach i in plActiveEvents
       {
-         Send(i,@UserKilled,
-            #who=who,
-            #killer=killer);
+         Send(i,@UserKilled,#who=who,#killer=killer);
       }
 
       return;
@@ -183,6 +181,42 @@ messages:
       foreach i in plActiveEvents
       {
          Send(i,@NewMonth);
+      }
+
+      return;
+   }
+
+   NewGameHour()
+   {
+      local i;
+
+      foreach i in plActiveEvents
+      {
+         Send(i,@NewGameHour);
+      }
+
+      return;
+   }
+
+   NewGameDay()
+   {
+      local i;
+
+      foreach i in plActiveEvents
+      {
+         Send(i,@NewGameDay);
+      }
+
+      return;
+   }
+
+   NewGameYear()
+   {
+      local i;
+
+      foreach i in plActiveEvents
+      {
+         Send(i,@NewGameYear);
       }
 
       return;

--- a/kod/util/nodeattk.kod
+++ b/kod/util/nodeattk.kod
@@ -186,7 +186,7 @@ messages:
       return;
    }
 
-   NewDay()
+   NewGameDay()
    {
       local iDelay, iIndex, iNodeNumber, bNodeActivated;
 

--- a/kod/util/parlia.kod
+++ b/kod/util/parlia.kod
@@ -139,13 +139,14 @@ messages:
       return;
    }
 
-   NewDay()
+   NewGameDay()
    {
       % Every game day, we re-figure our numbers.
-      send(self,@CalcIntrigueNumbers);
+      Send(self,@CalcIntrigueNumbers);
+
       return;
    }
-      
+
    SendInfoMail(who=$)
    "Admin supported. Send a summary email of the faction scenario to the given user."
    {

--- a/kod/util/realtime.kod
+++ b/kod/util/realtime.kod
@@ -457,13 +457,19 @@ messages:
 
       Send(EVENTENGINE_OBJECT,@NewMinute);
 
+      iMinute = Send(self,@GetMinute);
+
+      if (iMinute = 0)
+      {
+         Send(self,@NewHour);
+      }
+
       if plCallbacks <> $
       {
          iYear = Send(self,@GetYear);
          iMonth = Send(self,@GetMonth);
          iDay = Send(self,@GetDay);
          iHour = Send(self,@GetHour);
-         iMinute = Send(self,@GetMinute);
 
          foreach i in plCallbacks
          {
@@ -500,23 +506,48 @@ messages:
 
    NewHour()
    {
-      Send(EVENTENGINE_OBJECT,@NewHour);
+      local iHour;
+
       piTimeZoneOffset = GetTimeZoneOffset();
+
+      Send(EVENTENGINE_OBJECT,@NewHour);
+
+      iHour = Send(self,@GetHour);
+      if (iHour = 0)
+      {
+         Send(self,@NewDay);
+      }
 
       return;
    }
 
    NewDay()
    {
+      local iDay;
+
       Send(EVENTENGINE_OBJECT,@NewDay);
+
+      iDay = Send(self,@GetDay);
+      if (iDay = 1)
+      {
+         Send(self,@NewMonth);
+      }
 
       return;
    }
 
    NewMonth()
    {
+      local iMonth;
+
       Send(EVENTENGINE_OBJECT,@NewMonth);
 
+      iMonth = Send(self,@GetMonth);
+      if (iMonth = 1)
+      {
+         Send(self,@NewYear);
+      }
+   
       return;
    }
 
@@ -526,15 +557,16 @@ messages:
 
       return;
    }
-   
+
    GetTimeZoneOffset_K()
    {
       return GetTimeZoneOffset();
    }
-   
+
    SetTimeZoneOffset()
    {
       piTimeZoneOffset = GetTimeZoneOffset();
+
       return;
    }
 
@@ -542,10 +574,10 @@ messages:
    {
       return GetTime();
    }
-   
+
    GetYear()
    {
-      local iTime,iYear;
+      local iTime, iYear;
 
       iTime = GetTime() - piTimeZoneOffset;
       iYear=(iTime / 31536000) + OFFSET_YEAR;
@@ -569,7 +601,7 @@ messages:
 
    GetMonth()
    {
-      local i,iMonthDays,iMonth,iYearDays;
+      local i, iMonthDays, iMonth, iYearDays;
 
       iYearDays = Send(self,@GetYearDay);
 
@@ -610,7 +642,7 @@ messages:
 
    GetDay()
    {
-      local i,iDay,iMonthDays;
+      local i, iDay, iMonthDays;
 
       if Send(self,@IsLeapYear,#iYear=Send(self,@GetYear))
       {
@@ -636,7 +668,7 @@ messages:
 
    GetHour()
    {
-      local iTime,iHour;
+      local iTime, iHour;
 
       iTime = GetTime() - piTimeZoneOffset;
       iHour = (iTime MOD 86400) / 3600;
@@ -648,10 +680,10 @@ messages:
 
       return iHour;
    }
-   
+
    GetMinute()
    {
-      local iTime,iMinute;
+      local iTime, iMinute;
 
       iTime = GetTime() - piTimeZoneOffset;
       iMinute = (iTime MOD 3600) / 60;

--- a/kod/util/rntmaint.kod
+++ b/kod/util/rntmaint.kod
@@ -292,7 +292,7 @@ messages:
       return;
    }
 
-   NewDay()
+   NewGameDay()
    {
       local i;
 

--- a/kod/util/system.kod
+++ b/kod/util/system.kod
@@ -798,7 +798,7 @@ messages:
          Send(self,@RefigureAllAbilityTotals);
       }
 
-      Send(self,@RecalcLightAndWeather);
+      Send(self,@SystemInitGameHour);
       Send(self,@ReturnShrineAllegiance);
       Send(self,@RecreateStatistics);  % Must create after anything you want to measure
 
@@ -1041,7 +1041,7 @@ messages:
       Send(poHolder2,@Delete);
       poHolder2 = Create(&Holder);
 
-      Send(self,@RecalcLightAndWeather);
+      Send(self,@SystemInitGameHour);
 
       return;
    }
@@ -1363,24 +1363,35 @@ messages:
       return piHour;
    }
 
-   SetHour(num = $)
+   SetHour(iNum = $)
    {
-      piHour = num mod 24;
+      if (iNum = $)
+      {
+         Debug("SetHour passed $ iNum!");
+
+         return;
+      }
+
+      % Take 1 because NewGameHour will increment hour.
+      piHour = (iNum - 1) MOD 24;
       Send(self,@NewGameHour);
+
       return;
    }
 
-   NewHour()
+   NewGameHour()
    {
-      piHour = (piHour + 1) mod 24;
-      %Send(self,@RecalcLightAndWeather);
+      piHour = (piHour + 1) MOD 24;
+
+      % Tell GameEventEngine object we have a new hour.
+      Send(EVENTENGINE_OBJECT,@NewGameHour);
 
       if piHour = 0
       {
-         Send(self,@NewDay);
+         Send(self,@NewGameDay);
       }
 
-      Send(self,@NewGameHour);
+      Send(self,@SysRecalcLightAndDayPhase);
 
       % Change the color of rainbow ferns.
       Send(&RainbowFern,@ChangeColor,#iHour=piHour);
@@ -1388,49 +1399,17 @@ messages:
       return;
    }
 
-   NewDay()
-   {
-      piDay = (piDay + 1) mod 240;
-
-      if piDay = 0
-      {
-         Send(self,@NewYear);
-      }
-
-      ++pbDecay_counter;
-      ++piLogoffPenaltyDecayCounter;
-      if pbDecay_counter >= 3
-      {
-         pbDecay_counter = 0;
-         SendList(plUsers,0,@DecayPKillCount);
-      }
-
-      if piLogoffPenaltyDecayCounter >= piLogoffPenaltyDecayTime
-      {
-         piLogoffPenaltyDecayCounter = 0;
-         SendList(plUsers,0,@DecayLogoffPenaltyCount);
-      }
-
-      Send(self,@RecalcWeatherConditions);
-      Send(self,@NewGameDay);
-
-      Send(poParliament,@NewDay);
-      Send(poNodeAttack,@NewDay);
-      Send(poRentableRoomMaintenance,@NewDay);
-      Send(&SoldierShield,@NewDay);
-
-      Send(Send(self,@FindSpellByNum,#num=SID_NODEBURST),@NewDay);
-
-      Send(self,@VerifyUsersLoggedOn);
-
-      return;
-   }
-
-   NewYear()
+   NewGameYear()
    {
       local i;
-      Send(self,@NewYearClean);
+
+      % Clean currently does nothing.
+      Send(self,@NewGameYearClean);
+
       piYear = piYear + 1;
+
+      % Tell GameEventEngine object we have a new year.
+      Send(EVENTENGINE_OBJECT,@NewGameYear);
 
       % Determine if anyone needs to lose their newbie tag.
       foreach i in plUsers
@@ -1445,7 +1424,7 @@ messages:
       
       % Notify stat reset tokens that a game year has passed
       % (deletes temporary tokens without unecessary timers)
-      Send(&StatsResetToken,@NewYear);
+      Send(&StatsResetToken,@NewGameYear);
 
       return;
    }
@@ -2084,7 +2063,7 @@ messages:
       return 110;
    }
 
-   NewYearClean()
+   NewGameYearClean()
    {
       return;
    }
@@ -3942,12 +3921,12 @@ messages:
    {
       ptRecreateTimer = $;
       Send(self,@RecalcWeatherConditions);
-      Send(self,@RecalcLightAndWeather);
+      Send(self,@SystemInitGameHour);
 
       return;
    }
 
-   RecalcLightAndWeather()
+   SystemInitGameHour()
    {
       local i,iTime,iDay,iMinutes;
 
@@ -3965,7 +3944,7 @@ messages:
       % That number ranges from 0 to 119, so div by 5 is our game hour
       piHour = iMinutes/5;
 
-      Send(self,@NewGameHour);
+      Send(self,@SysRecalcLightAndDayPhase);
 
       return;
    }
@@ -4032,8 +4011,8 @@ messages:
       return;
    }
 
-   NewGameHour()
-   "Recalculates the light and weather, based on piHour"
+   SysRecalcLightAndDayPhase()
+   "Recalculates the light and day phase, based on piHour"
    {
       local i,iLight_hour;
 
@@ -4055,7 +4034,7 @@ messages:
       }
 
       % shift hour so doesn't get light /dark until later
-      iLight_hour = (piHour-2) mod 24;
+      iLight_hour = (piHour - 2) MOD 24;
 
       if iLight_hour <= 12
       {
@@ -4076,7 +4055,6 @@ messages:
          piBrightness = 75;
       }
 
-
       foreach i in plBackground_objects
       {
          Send(i,@NewGameHour);
@@ -4092,6 +4070,41 @@ messages:
 
    NewGameDay()
    {
+      piDay = (piDay + 1) MOD 240;
+
+      % Tell GameEventEngine object we have a new day.
+      Send(EVENTENGINE_OBJECT,@NewGameDay);
+
+      if piDay = 0
+      {
+         Send(self,@NewGameYear);
+      }
+
+      ++pbDecay_counter;
+      ++piLogoffPenaltyDecayCounter;
+      if pbDecay_counter >= 3
+      {
+         pbDecay_counter = 0;
+         SendList(plUsers,0,@DecayPKillCount);
+      }
+
+      if piLogoffPenaltyDecayCounter >= piLogoffPenaltyDecayTime
+      {
+         piLogoffPenaltyDecayCounter = 0;
+         SendList(plUsers,0,@DecayLogoffPenaltyCount);
+      }
+
+      Send(self,@RecalcWeatherConditions);
+
+      Send(poParliament,@NewGameDay);
+      Send(poNodeAttack,@NewGameDay);
+      Send(poRentableRoomMaintenance,@NewGameDay);
+      Send(&SoldierShield,@NewGameDay);
+
+      Send(Send(self,@FindSpellByNum,#num=SID_NODEBURST),@NewGameDay);
+
+      Send(self,@VerifyUsersLoggedOn);
+
       return;
    }
 
@@ -4105,24 +4118,20 @@ messages:
    }
 
    TestGameDayTimer()
+   "Cycles to the next game midnight."
    {
       local i;
+
+      Send(self,@NewGameHour);
 
       foreach i in plUsers_logged_on
       {
          Send(i,@MsgSendUser,#message_rsc=system_new_hour,#parm1=piHour);
       }
 
-      Send(self,@NewGameHour);
-
-      piHour = (piHour + 1) mod 24;
       if piHour <> 0
       {
-         CreateTimer(self,@TestGameDayTimer,500);
-      }
-      else
-      {
-         Send(self,@RecalcLightAndWeather);
+         CreateTimer(self,@TestGameDayTimer,1500);
       }
 
       return;
@@ -4949,7 +4958,7 @@ messages:
       {
          poParliament = Create(&Parliament);
          Send(poParliament,@Recreate,#initial=True);
-         Send(poParliament,@NewDay);
+         Send(poParliament,@NewGameDay);
       }
 
       return TRUE;


### PR DESCRIPTION
Paging @treymd to please check this code :) Initial issue was Qormas not
receiving NewDay calls from System or RealTime.

Renamed the game time related code in system.kod from NewHour etc. to
NewGameHour. Called messages that deal with game time as opposed to real
time now include Game in the message name. This was done to separate
them from future calls from RealTime that also use NewHour etc. but
refer to real hours vs. game ones.

System's RecalcLightAndWeather message renamed to SystemInitGameHour to
better describe what it actually does (setting initial game hour based
on GetTime()).

Renamed System's NewGameHour to SysRecalcLightAndDayPhase to better
describe what it does.

Added calls from System's time messages to GameEventEngine to update it
on game time.

RealTime's NewMinute message will now trigger RealTime's NewHour call on
the hour and so on.
