### PR TITLE
change reflecs level and tp value

### DIFF
--- a/kod/object/passive/spell/summrefl.kod
+++ b/kod/object/passive/spell/summrefl.kod
@@ -45,9 +45,9 @@ classvars:
 
    viSpell_num = SID_REFLECTION
    viSchool = SS_RIIJA
-   viSpell_level = 3
+   viSpell_level = 5
    viMana = 15
-   viMeditate_ratio = 30
+   viMeditate_ratio = 75
 
    viSpellExertion = 4
    viCast_time = 1000


### PR DESCRIPTION
Every toon has been getting riija 3 for reflections. if you have a toon thats not a pure mage its usualy a great idea to add 10 int and get 3 riija for flecs. almost everyone pvping is using flecs.

so i propose we raise flecs to level five. this will need 20 int to get flecs wich is way more costly that 10.
also the spell is way to strong to cost 30 tp. i raised it to 75

hopefully we will see more than flecs on the battlefield
