### PR TITLE
Fix room deletion bug, add rooms table printing cmd.

### DIFF
--- a/blakserv/adminfn.c
+++ b/blakserv/adminfn.c
@@ -98,7 +98,8 @@ void AdminShowMemory(int session_id,admin_parm_type parms[],
 void AdminShowCalled(int session_id,admin_parm_type parms[],
                      int num_blak_parm,parm_node blak_parm[]);
 void AdminShowCalledClass(class_node *c);
-
+void AdminShowRoomTable(int session_id, admin_parm_type parms[],
+                        int num_blak_parm, parm_node blak_parm[]);
 void AdminShowBlockers(int session_id,admin_parm_type parms[],
                        int num_blak_parm,parm_node blak_parm[]);
 void AdminShowObject(int session_id,admin_parm_type parms[],
@@ -343,6 +344,7 @@ admin_table_type admin_show_table[] =
 	{ AdminShowProtocol,      {N},   F, A|M, NULL, 0, "protocol",      "Show protocol message counts" },
 	{ AdminShowReferences,    {S,S,N}, F, A|M, NULL, 0, "references",  "Show what objects or lists reference a particular data value" },
 	{ AdminShowResource,      {S,N}, F, A|M, NULL, 0, "resource",      "Show a resource by resource name" },
+	{ AdminShowRoomTable,     {N},   F, A|M, NULL, 0, "roomtable",     "Show the rooms table" },
 	{ AdminShowStatus,        {N},   F, A|M, NULL, 0, "status",        "Show system status" },
 	{ AdminShowString,        {I,N}, F, A|M, NULL, 0, "string",        "Show one string by string id" },
 	{ AdminShowSuspended,     {N},   F, A|M, NULL, 0, "suspended",     "Show all suspended accounts" },
@@ -1498,6 +1500,12 @@ void AdminShowCalledClass(class_node *c)
          m = m->next;
       }
    }
+}
+
+void AdminShowRoomTable(int session_id, admin_parm_type parms[],
+                        int num_blak_parm, parm_node blak_parm[])
+{
+   PrintRoomTable();
 }
 
 void AdminShowBlockers(int session_id,admin_parm_type parms[],

--- a/blakserv/roomdata.h
+++ b/blakserv/roomdata.h
@@ -27,6 +27,7 @@ void        ResetRooms(void);
 int         LoadRoom(int resource_id);
 void        UnloadRoom(room_node *r);
 room_node*  GetRoomDataByID(int id);
+void PrintRoomTable();
 void ForEachRoom(void(*callback_func)(room_node *r));
 
 #endif


### PR DESCRIPTION
If the room being deleted wasn't first in the list, the previous rooms
in the list occupying that position in the rooms table were no longer
being referenced (only rooms past the deleted one). Specifically,
deleting rented rooms after a recreate dropped references to the other
room occupying that position in the table, which due to the order of
room loading tended to be around the kc1-kd4 area. This case is now
handled correctly.

Added an admin "show roomtable" command which prints the rooms table to
admin log, and allowed this issue to be debugged.
