### PR TITLE
Change linked-list of timers into min binary heap.

### DIFF
--- a/blakserv/adminfn.c
+++ b/blakserv/adminfn.c
@@ -213,6 +213,9 @@ void AdminUnsuspendUser(int session_id,admin_parm_type parms[],
 void AdminUnsuspendAccount(int session_id,admin_parm_type parms[],
                            int num_blak_parm,parm_node blak_parm[]);
 
+void AdminCheckTimerHeap(int session_id, admin_parm_type parms[],
+                         int num_blak_parm, parm_node blak_parm[]);
+
 void AdminCreateAccount(int session_id,admin_parm_type parms[],
                         int num_blak_parm,parm_node blak_parm[]);
 void AdminCreateAutomated(int session_id,admin_parm_type parms[],
@@ -391,6 +394,13 @@ admin_table_type admin_unsuspend_table[] =
 };
 #define LEN_ADMIN_UNSUSPEND_TABLE (sizeof(admin_unsuspend_table)/sizeof(admin_table_type))
 
+admin_table_type admin_check_table[] =
+{
+   { AdminCheckTimerHeap, {N}, F, A|M, NULL, 0, "timerheap",
+      "Checks the validity of the timer heap" },
+};
+#define LEN_ADMIN_CHECK_TABLE (sizeof(admin_check_table)/sizeof(admin_table_type))
+
 admin_table_type admin_setcfg_table[] =
 {
 	{ AdminSetConfigBool,     {S,S,S,N}, F, A|M, NULL, 0, "boolean",  
@@ -538,6 +548,7 @@ admin_table_type admin_save_table[] =
 admin_table_type admin_main_table[] = 
 { 
 	{ NULL, {N}, F, A|M, admin_add_table,    LEN_ADMIN_ADD_TABLE,    "add",    "Add subcommand" },
+	{ NULL, {N}, F, A|M, admin_check_table,  LEN_ADMIN_CHECK_TABLE,  "check",  "Check subcommand" },
 	{ NULL, {N}, F, A|M, admin_create_table, LEN_ADMIN_CREATE_TABLE, "create", "Create subcommand" },
 	{ NULL, {N}, F, A|M, admin_delete_table, LEN_ADMIN_DELETE_TABLE, "delete", "Delete subcommand" },
 	{ NULL, {N}, F, A|M, admin_disable_table,LEN_ADMIN_DISABLE_TABLE,"disable", "Disable subcommand" },
@@ -1995,6 +2006,25 @@ void AdminShowDynamicResources(int session_id,admin_parm_type parms[],
 {
 	aprintf("%-7s %s\n","ID","Name = Value");
 	ForEachDynamicRsc(AdminPrintResource);
+}
+
+// Check the validity of the timer min binary heap.
+// Prints the result.
+void AdminCheckTimerHeap(int session_id, admin_parm_type parms[],
+                         int num_blak_parm, parm_node blak_parm[])
+{
+   double startTime = GetMicroCountDouble();
+
+   // Perform the check, returns true or false.
+   bool retVal = TimerHeapCheck(0, 0);
+
+   aprintf("Timer heap check completed in %.3f microseconds.\n",
+      GetMicroCountDouble() - startTime);
+
+   if (retVal)
+      aprintf("Timer heap is valid.\n");
+   else
+      aprintf("Timer heap is NOT valid.\n");
 }
 
 void AdminShowTimers(int session_id,admin_parm_type parms[],

--- a/blakserv/timer.c
+++ b/blakserv/timer.c
@@ -45,20 +45,9 @@ __forceinline static void TimerSwapIndex(int i1, int i2)
 {
    timer_node temp;
 
-   temp.message_id = timer_heap[i1]->message_id;
-   temp.object_id = timer_heap[i1]->object_id;
-   temp.time = timer_heap[i1]->time;
-   temp.timer_id = timer_heap[i1]->timer_id;
-
-   timer_heap[i1]->message_id = timer_heap[i2]->message_id;
-   timer_heap[i1]->object_id = timer_heap[i2]->object_id;
-   timer_heap[i1]->time = timer_heap[i2]->time;
-   timer_heap[i1]->timer_id = timer_heap[i2]->timer_id;
-
-   timer_heap[i2]->message_id = temp.message_id;
-   timer_heap[i2]->object_id = temp.object_id;
-   timer_heap[i2]->time = temp.time;
-   timer_heap[i2]->timer_id = temp.timer_id;
+   memcpy(temp.data, timer_heap[i1]->data, sizeof(temp.data));
+   memcpy(timer_heap[i1]->data, timer_heap[i2]->data, sizeof(temp.data));
+   memcpy(timer_heap[i2]->data, temp.data, sizeof(temp.data));
 }
 
 __inline void TimerHeapHeapify(int Index)

--- a/blakserv/timer.h
+++ b/blakserv/timer.h
@@ -13,6 +13,8 @@
 #ifndef _TIMER_H
 #define _TIMER_H
 
+#define INIT_TIMER_NODES (2000)
+
 typedef struct timer_struct
 {
    union{
@@ -29,7 +31,7 @@ typedef struct timer_struct
    int heap_index;
 } timer_node;
 
-
+bool TimerHeapCheck(int i, int level);
 void InitTimer(void);
 void ResetTimer(void);
 void ClearTimer(void);

--- a/blakserv/timer.h
+++ b/blakserv/timer.h
@@ -15,10 +15,15 @@
 
 typedef struct timer_struct
 {
-   int timer_id;
-   int object_id;
-   int message_id;
-   UINT64 time;
+   union{
+      struct{
+         int timer_id;
+         int object_id;
+         int message_id;
+         UINT64 time;
+      };
+      char data[20];
+   };
 
    int garbage_ref;
    int heap_index;

--- a/blakserv/timer.h
+++ b/blakserv/timer.h
@@ -19,9 +19,11 @@ typedef struct timer_struct
    int object_id;
    int message_id;
    UINT64 time;
+
    int garbage_ref;
-   struct timer_struct *next;
+   int heap_index;
 } timer_node;
+
 
 void InitTimer(void);
 void ResetTimer(void);


### PR DESCRIPTION
Based on the [A\* min heap code](#1236). This will allow us some
extra room working with heavy use of timers, and also provide
an easier way to change timer values if we need it (compared to
delete/create new).
#### Commit 1

Timers are currently kept in a linked list, unfortunately the timers
generally have a cluster at the beginning of the list (mob movement)
so every insert/delete has to traverse minimum 30-100 elements before
potentially finding the correct place to modify.

Changing to min-heap means that worst-case scenario, 10 timers have
to be looked at (generally it is much better than this).

On my system, CreateTimer drops from 1us to 0.350us, DeleteTimer
from 1.1us to 0.6us and GetTimeRemaining from 8.6us to 1.5us.
#### Commit 2

Use a unnamed struct/anonymous union in timer_node to allow moving
data faster in the TimerSwapIndex function. I'm not 100% sure why
this is faster, can only think that the compiler can't optimise the 12 swaps
necessary to do it the other way. Moving the whole struct followed by
reassigning heap_index is comparable in speed to the 12 swaps.

I don't know if this is "good C/C++" or if it will even compile on other
compilers, so I put this part in a separate commit if I need to remove it.
#### Commit 3

Add comments to function definitions and put heap-related code
into a region.
#### Commit 4

Timer heap memory will now be expanded if it hits the maximum allocated
timer nodes (default 2000).

Added a new menu option to the admin menu, Check, which currently has
one option, timerheap. "Check timerheap" will traverse the timer heap
and check it for validity (children of a node larger than parent). The
result and time to run is displayed in admin window/server interface.
