### PR TITLE
Remove union/structs from timer_node.

### DIFF
--- a/blakserv/timer.c
+++ b/blakserv/timer.c
@@ -50,9 +50,20 @@ __forceinline static void TimerSwapIndex(int i1, int i2)
 {
    timer_node temp;
 
-   memcpy(temp.data, timer_heap[i1]->data, sizeof(temp.data));
-   memcpy(timer_heap[i1]->data, timer_heap[i2]->data, sizeof(temp.data));
-   memcpy(timer_heap[i2]->data, temp.data, sizeof(temp.data));
+   temp.time = timer_heap[i1]->time;
+   temp.timer_id = timer_heap[i1]->timer_id;
+   temp.object_id = timer_heap[i1]->object_id;
+   temp.message_id = timer_heap[i1]->message_id;
+
+   timer_heap[i1]->time = timer_heap[i2]->time;
+   timer_heap[i1]->timer_id = timer_heap[i2]->timer_id;
+   timer_heap[i1]->object_id = timer_heap[i2]->object_id;
+   timer_heap[i1]->message_id = timer_heap[i2]->message_id;
+
+   timer_heap[i2]->time = temp.time;
+   timer_heap[i2]->timer_id = temp.timer_id;
+   timer_heap[i2]->object_id = temp.object_id;
+   timer_heap[i2]->message_id = temp.message_id;
 }
 
 // Fixes the heap after a timer has been deleted or modified.

--- a/blakserv/timer.h
+++ b/blakserv/timer.h
@@ -17,16 +17,10 @@
 
 typedef struct timer_struct
 {
-   union{
-      struct{
-         int timer_id;
-         int object_id;
-         int message_id;
-         UINT64 time;
-      };
-      char data[20];
-   };
-
+   UINT64 time;
+   int timer_id;
+   int object_id;
+   int message_id;
    int garbage_ref;
    int heap_index;
 } timer_node;


### PR DESCRIPTION
Due to automatic padding for memory alignment, it is safer to copy this way.

Will do some more benchmarking to determine if there is a faster solution (new timer code does a lot of swaps) but this is still significantly faster than the linked-list implementation.
