### PR TITLE
Bind monster stat points between 20 and 100, fix target handling in Ring of Flames, fix client crash with colored orc shield. Misc fixes.

### DIFF
--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -554,7 +554,7 @@ messages:
 
       piMood = 0;
 
-      iStatPoints = (viDifficulty + 1) * 10;
+      iStatPoints = Bound((viDifficulty + 1) * 10,20,100);
 
       if iStatPoints - 1 > 50
       {

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -1001,8 +1001,8 @@ properties:
 
    prHead = charinfo_head_ax_icon
    prEyes = charinfo_eyes_ax_icon
-   prMouth = charinfo_nose_ax_icon
-   prNose = charinfo_mouth_ax_icon
+   prMouth = charinfo_mouth_ax_icon
+   prNose = charinfo_nose_ax_icon
    prToupee = charinfo_hair_cd_icon
 
    % Animation type.  If none, then use piAction
@@ -14915,6 +14915,19 @@ messages:
       }
 
       propagate;
+   }
+
+   FixDefaultResources()
+   "Temporary message to clear up some issues with default resources."
+   {
+      if (prMouth = charinfo_nose_ax_icon
+         OR prNose = charinfo_mouth_ax_icon)
+      {
+         prNose = charinfo_nose_ax_icon;
+         prMouth = charinfo_mouth_ax_icon;
+      }
+
+      return;
    }
 
 end

--- a/kod/object/item/passitem/defmod/shield/orcshld.kod
+++ b/kod/object/item/passitem/defmod/shield/orcshld.kod
@@ -27,7 +27,9 @@ resources:
       "darker edge to the shield that you can't place your finger on, and "
       "one wonders if this device has some hidden attribute."
 
-   orcshield_cant = "You try to grab the handle of the shield, but it insistently slips out of your fingers."
+   orcshield_cant = \
+      "You try to grab the handle of the shield, but it insistently "
+      "slips out of your fingers."
 
    OrcShield_window_overlay_rsc = povosh.bgf
 
@@ -67,7 +69,7 @@ messages:
          
          return FALSE; 
       }
-      
+
       propagate;
    }
 
@@ -92,18 +94,6 @@ messages:
                [-ATCK_SPELL_HOLY,-20]
              ];
    }
-
-   SendOverlayAnimation(animation = $)
-   {
-      AddPacket(1,ANIMATE_NONE,2,2);
-      if (piItem_flags & ITEM_PALETTE_MASK) <> 0
-      {
-         AddPacket(1,ANIMATE_TRANSLATION,1,piItem_flags & ITEM_PALETTE_MASK);
-      }
-
-      return;
-   }   
-
 
 end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/kod/object/passive/spell/persench/eavesdrp.kod
+++ b/kod/object/passive/spell/persench/eavesdrp.kod
@@ -157,9 +157,9 @@ messages:
       {
          Send(who,@MsgSendUser,#message_rsc=Eavesdrop_no_rooms);
       }
-      
+
       iLength = Random(1,iLength);
-      oRoom = Send(SYS,@FindRoomByNum,#num=nth(lRooms,iLength));
+      oRoom = Send(SYS,@FindRoomByNum,#num=Nth(lRooms,iLength));
 
       % Use "safe" t'port coords.
       iRow = Send(oRoom,@GetTeleportRow);
@@ -167,7 +167,7 @@ messages:
 
       oListener = Create(&Listener,#Enchanted=who,#iSpellpower=iSpellpower);
       Send(oRoom,@NewHold,#what=oListener,#new_row=iRow,#new_col=iCol);
-   
+
       return [Send(self,@GetDuration,#iSpellpower=iSpellpower),oListener];
    }
 
@@ -185,22 +185,34 @@ messages:
    GetYellList(who=$)
    "Returns a list of rooms in the yell zone of who's current location."
    {
-      local oRoom, lRooms;
+      local iNum, oRoom, lRooms;
 
-      %% Get yell list from current room and select a room to eavesdrop.
+      // Get yell list from current room and select a room to eavesdrop.
       oRoom = Send(who,@GetOwner);
-      lRooms = Send(oRoom,@GetYellZone);
-      
-      %% Eliminate the room we're in, unless there is no yell list.
-      if FindListElem(lRooms,Send(oRoom,@GetRoomNum))
+
+      if (oRoom = $)
       {
-         if lRooms = $ OR length(lRooms) < 2
+         return $;
+      }
+
+      iNum = Send(oRoom,@GetRoomNum);
+      lRooms = Send(oRoom,@GetYellZone);
+
+      if (lRooms = $)
+      {
+         return [iNum];
+      }
+
+      // Eliminate the room we're in, unless there is no yell list.
+      if (FindListElem(lRooms,iNum))
+      {
+         if (Length(lRooms) < 2)
          {
-            lRooms = [oRoom];
+            lRooms = [iNum];
          }
          else
          {
-            lRooms = DelListElem(lRooms,oRoom);
+            lRooms = DelListElem(lRooms,iNum);
          }
       }
 

--- a/kod/object/passive/spell/walspell/rngflame.kod
+++ b/kod/object/passive/spell/walspell/rngflame.kod
@@ -24,7 +24,7 @@ resources:
       "Creates a ring of flames around target.  "
       "Requires red mushrooms and firesand to cast."
 
-   RingOfFlames_caster = "A blazing hot ring of flames appears around %s%q."
+   RingOfFlames_caster = "A blazing hot ring of flames appears around %s%s."
    RingOfFlames_target = "A blazing hot ring of flames appears around you!"
    RingOfFlames_failed_rsc = \
       "There is too much summoning magic focused here to create a ring of "
@@ -78,26 +78,30 @@ messages:
    {
       local oTarget;
 
-      if lTargets = $
+      if (lTargets = $
+         OR NOT vbCanCastOnOthers)
       {
-         Debug("Ring of Flames cast will nil target list");
-
-         return;
+         oTarget = who;
       }
-
-      oTarget = First(lTargets);
+      else
+      {
+         oTarget = First(lTargets);
+      }
 
       if oTarget = $
       {
-         Debug("Ring of Flames cast will nil target");
+         Debug("Ring of Flames cast with nil target");
 
          return;
       }
 
-      Send(oTarget,@MsgSendUser,#message_rsc=RingOfFlames_target,
-            #parm1=Send(oTarget,@GetCapDef),#parm2=Send(oTarget,@GetName));
+      Send(oTarget,@MsgSendUser,#message_rsc=RingOfFlames_target);
 
-      Send(who,@MsgSendUser,#message_rsc=RingOfFlames_caster);
+      if (oTarget <> who)
+      {
+         Send(who,@MsgSendUser,#message_rsc=RingOfFlames_caster,
+               #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
+      }
 
       propagate;
    }

--- a/kod/object/passive/trestype.kod
+++ b/kod/object/passive/trestype.kod
@@ -289,8 +289,9 @@ messages:
             {
                iSafetyCntr = 0;
 
-               while (NOT Send(oTreasure,@SpellItemIsAccessible))
-                     AND iSafetyCntr++ < 5
+               while ((IsClass(oTreasure,&SpellItem)
+                     AND NOT Send(oTreasure,@SpellItemIsAccessible))
+                  AND iSafetyCntr++ < 5)
                {
                   oTreasure = Send(self,@GenerateTreasure,#level=level,
                                     #who=who,#mob=mob,#tokengen=tokengen,

--- a/kod/util/gameevent/invasion/ratinvasion.kod
+++ b/kod/util/gameevent/invasion/ratinvasion.kod
@@ -104,36 +104,42 @@ messages:
    
    Update()
    {
+      local oRoom;
+
+      oRoom = Send(SYS,@FindRoomByNum,#num=piActiveRoom);
+
+      if (oRoom = $)
+      {
+         propagate;
+      }
+
       if piPhase = 1
       {
-         if Send(self,@CountMonsters,#type=&SmallRat) = 0
+         if Send(oRoom,@CountMonsters,#class=&SmallRat) = 0
          {
             Send(self,@PhaseTwo);
          }
       }
-
-      if piPhase = 2
+      else if piPhase = 2
       {
-         if Send(self,@CountMonsters,#type=&GiantRat) = 0
-            AND Send(self,@CountMonsters,#type=&SmallRat) = 0
+         if Send(oRoom,@CountMonsters,#class=&GiantRat) = 0
+            AND Send(oRoom,@CountMonsters,#class=&SmallRat) = 0
          {
             Send(self,@PhaseThree);
          }
       }
-
-      if piPhase = 3
+      else if piPhase = 3
       {
-         if Send(self,@CountMonsters,#type=&GiantRatSoldier) = 0
-            AND Send(self,@CountMonsters,#type=&GiantRat) = 0
-            AND Send(self,@CountMonsters,#type=&SmallRat) = 0
+         if Send(oRoom,@CountMonsters,#class=&GiantRatSoldier) = 0
+            AND Send(oRoom,@CountMonsters,#class=&GiantRat) = 0
+            AND Send(oRoom,@CountMonsters,#class=&SmallRat) = 0
          {
             Send(self,@FinalPhase);
          }
       }
-
-      if piPhase = 4
+      else if piPhase = 4
       {
-         if Send(self,@CountMonsters,#type=&GiantRatKing) = 0
+         if Send(oRoom,@CountMonsters,#class=&GiantRatKing) = 0
          {
             % Call NotifyEngineEndEvent to handle ending the event properly. 
             % This deletes the event from the GameEventEngine. It also calls


### PR DESCRIPTION
Bugfix PR. Everything here is live on 105.
##### Commit 1

Monster stat point allocation must use values lower than 100 otherwise
the math does not work and stats are incorrectly set. This can occur for
difficulty 10 mobs.
##### Commit 2

Ring of Flames now correctly handles casting on self, and cast messages
are correctly displayed when casting on others.
##### Commit 3

Orc shield color translation was being sent after animation/group data
instead of before. Shield handles this correctly.
##### Commit 4

Fix CountMonsters call in RatInvasion - should be called on the event room, with mob class.
##### Commit 5

Treasure generation should not call SpellItemIsAccessible on every replacement item for an inaccessible SpellItem, so check class of replacement item first.
##### Commit 6

Fix mismatched player default nose/mouth resources.Affected players which were not yet created (<New Character> slots) which could be used for statues in Hall of Forgotten Heroes. Run "send c player FixDefaultResources" after updating with this commit to fix the issue.
##### Commit 7

Fix eavesdrop yell list handling. Yell list checks were using room number and room object interchangeably. Caused errors when used in some rooms.
