### PR TITLE
Improved Riija Sword durability healing

### DIFF
--- a/kod/object/item/passitem/weapon/riijaswd.kod
+++ b/kod/object/item/passitem/weapon/riijaswd.kod
@@ -187,7 +187,7 @@ messages:
       if Send(oSpell,@GetSchool) = SS_RIIJA
       {
          % Casting spells while the sword is wielded "heals" the sword.
-         piHits = bound(piHits + 1,1,Send(self,@GetMaxHits));
+         piHits = Send(self,@GetMaxHits);
 
          return 10;
       }


### PR DESCRIPTION
Players have the ability to 'look' at a Riija Sword and mend it one
point of durability thanks to a bug that turned out to be rather cool
and lore appropriate. Instead of removing that feature, this pull gets
rid of the 'grindy' portion of mending and just fully mends the sword if
you cast a Riija spell or look at it. Instead of clicking hundreds of
times, you'll only have to click once.

This shouldn't negatively affect the durability system for Riija swords,
because they weren't really breaking due to durability to begin with
(almost all of them are just held for spellpower purposes), so this is
just a cool little feature requested by players.
