### PR TITLE
Elemental status effects

### DIFF
--- a/kod/include/blakston.khd
+++ b/kod/include/blakston.khd
@@ -2002,6 +2002,14 @@
    ATCK_SPELL_UNHOLY     = 0x0020
    ATCK_SPELL_ACID       = 0x0040
    ATCK_SPELL_QUAKE      = 0x0080
+   
+   % Elemental status effect types
+   STATUS_SHOCKED        = 1
+   STATUS_CHILLED        = 2
+   STATUS_BURNING        = 3
+   STATUS_CORRODE        = 4
+   STATUS_HUMBLED        = 5
+   STATUS_MANTLED        = 6
 
    % For hunter swords
    ATCK_SPELL_HUNTERSWORD= 0x0100

--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -189,7 +189,7 @@ properties:
 
    % Mana regen timer.
    ptMana = $
-   
+
    % Reputation hashtable for monster territory/influence system
    phReputation = $
 
@@ -199,6 +199,11 @@ properties:
    plHurtMeRecently = $
    % 20 seconds default for players, 60 for monsters
    piHurtMeTime = 20000
+
+   % Elemental status effects. Each element is [value, type]
+   % Timer removes a portion of status effect every period
+   plStatusEffects = $
+   ptStatusEffectTimer = $
 
 messages:
 
@@ -273,6 +278,8 @@ messages:
          }
       }
 
+      Send(self,@ClearAllStatusEffects);
+
       propagate;
    }
 
@@ -313,7 +320,8 @@ messages:
    GetCurrentResistances()
    "Spells and items can change resistances temporarily."
    {
-      local oObjectAttribute, lCurResist, oEquipment, oEnchantment;
+      local oObjectAttribute, lCurResist, oEquipment, oEnchantment,
+            iHumbled, iHumbledDivisor, i;
 
       lCurResist = ListCopy(Send(self,@GetBaseResistances));
 
@@ -343,7 +351,22 @@ messages:
                               #resistance_list=lCurResist);
          }
       }
-
+      
+      iHumbled = Send(self,@GetStatusEffect,#type=STATUS_HUMBLED);
+      if iHumbled > 0
+      {
+         iHumbledDivisor = Send(SETTINGS_OBJECT,@GetElementalMultiple,
+                           #type=STATUS_HUMBLED);
+         
+         foreach i in lCurResist
+         {
+            if Nth(i,2) > 0
+            {
+               SetNth(i,2,bound(Nth(i,2) - (iHumbled/iHumbledDivisor),0,$));
+            }
+         }
+      } 
+      
       return lCurResist;
    }
 
@@ -1531,6 +1554,7 @@ messages:
    % Oo, 'e died
    Killed(what = $)
    {
+      Send(self,@ClearAllStatusEffects);
       return;
    }
 
@@ -1760,6 +1784,204 @@ messages:
       return;
    }
 
+   ApplyElementalStatusEffects(damage=1,aspell=0)
+   {
+      if aspell & ATCK_SPELL_SHOCK
+      {
+         Send(self,@AddStatusEffect,#value=damage,#type=STATUS_SHOCKED);
+      }
+      if aspell & ATCK_SPELL_COLD
+      {
+         Send(self,@AddStatusEffect,#value=damage,#type=STATUS_CHILLED);
+      }
+      if aspell & ATCK_SPELL_FIRE
+      {
+         Send(self,@AddStatusEffect,#value=damage,#type=STATUS_BURNING);
+      }
+      if aspell & ATCK_SPELL_ACID
+      {
+         Send(self,@AddStatusEffect,#value=damage,#type=STATUS_CORRODE);
+      }
+      if aspell & ATCK_SPELL_HOLY
+      {
+         Send(self,@AddStatusEffect,#value=damage,#type=STATUS_HUMBLED);
+      }
+      if aspell & ATCK_SPELL_UNHOLY
+      {
+         Send(self,@AddStatusEffect,#value=damage,#type=STATUS_MANTLED);
+      }
+      return;
+   }
+
+   AddStatusEffect(value=10,type=STATUS_SHOCKED)
+   {
+      local i;
+      
+      if NOT Send(SETTINGS_OBJECT,@GetEnableElementalStatusEffects)
+      {
+         % This server doesn't use elemental status effects.
+         return;
+      }
+      
+      if ptStatusEffectTimer = $
+      {
+         ptStatusEffectTimer = CreateTimer(self,@StatusEffectTimer,
+                                           Send(SETTINGS_OBJECT,
+                                           @GetStatusEffectReductionTime));
+      }
+      
+      if type=STATUS_SHOCKED
+         AND IsClass(self,&Player)
+      {
+         Post(self,@DrawDefense);
+      }
+      
+      if type=STATUS_CORRODE
+         AND IsClass(self,&Player)
+      {
+         Post(self,@DrawArmor);
+      }
+      
+      if type=STATUS_HUMBLED
+         AND IsClass(self,&Player)
+      {
+         Post(self,@DrawResistances);
+      }
+      
+      foreach i in plStatusEffects
+      {
+         if Nth(i,2) = type
+         {
+            SetNth(i,1,Nth(i,1)+value);
+            return;
+         }
+      }
+
+      plStatusEffects = Cons([value,type],plStatusEffects);
+      return;
+   }
+   
+   GetStatusEffect(type=STATUS_SHOCKED)
+   {
+      local i;
+
+      foreach i in plStatusEffects
+      {
+         if Nth(i,2) = type
+         {
+            return Nth(i,1);
+         }
+      }
+      return 0;
+   }
+   
+   ClearStatusEffect(type=STATUS_SHOCKED)
+   {
+      local i;
+      
+      foreach i in plStatusEffects
+      {
+         if Nth(i,2) = type
+         {
+            SetNth(i,1,0);
+            plStatusEffects = DelListElem(plStatusEffects,i);
+         }
+      }
+      
+      if plStatusEffects = $
+      {
+         if ptStatusEffectTimer <> $
+         {
+            DeleteTimer(ptStatusEffectTimer);
+            ptStatusEffectTimer = $;
+         }
+      }
+      
+      return;
+   }
+   
+   ClearAllStatusEffects()
+   {
+      plStatusEffects = $;
+      if ptStatusEffectTimer <> $
+      {
+         DeleteTimer(ptStatusEffectTimer);
+         ptStatusEffectTimer = $;
+      }
+      return;
+   }
+   
+   StatusEffectTimer(timer=$)
+   {
+      local i, iBurningDamage, oOpponent;
+      
+      ptStatusEffectTimer = $;
+      
+      foreach i in plStatusEffects
+      {
+         if Nth(i,2) = STATUS_SHOCKED
+            AND IsClass(self,&Player)
+         {
+            Post(self,@DrawDefense);
+         }
+         if Nth(i,2) = STATUS_CORRODE
+            AND IsClass(self,&Player)
+         {
+            Post(self,@DrawArmor);
+         }
+         if Nth(i,2) = STATUS_HUMBLED
+            AND IsClass(self,&Player)
+         {
+            Post(self,@DrawResistances);
+         }
+
+         if Nth(i,2) = STATUS_BURNING
+         {
+            iBurningDamage = (Nth(i,1) / Send(SETTINGS_OBJECT,
+                              @GetElementalMultiple,#type=STATUS_BURNING));
+            SetNth(i,1,0);
+            if iBurningDamage >= 1
+            {
+               if Send(self,@AssessDamage,#what=self,
+                              #damage=iBurningDamage,
+                              #aspell=ATCK_SPELL_FIRE,
+                              #report=FALSE) = $
+               {
+                  oOpponent = Send(self,@GetHighestHurtMeRecentlyBattler);
+                  if oOpponent <> $
+                  {
+                     Post(oOpponent,@KilledSomething,#what=self);
+                  }
+                  else
+                  {
+                     Post(self,@KilledSomething,#what=self);
+                  }
+               }
+            }
+         }
+         else
+         {
+            SetNth(i,1,Nth(i,1) - Send(SETTINGS_OBJECT,
+                                  @GetStatusEffectReductionAmount));
+         }
+
+         if Nth(i,1) <= 0
+         {
+            plStatusEffects = DelListElem(plStatusEffects,i);
+         }
+      }
+      
+      if plStatusEffects <> $
+      {
+         ptStatusEffectTimer = CreateTimer(self,@StatusEffectTimer,
+                                           Send(SETTINGS_OBJECT,
+                                           @GetStatusEffectReductionTime));
+      }
+      
+      return;
+   }
+   
+
    GetBoostedLevel()
    {
       return 0;
@@ -1795,6 +2017,24 @@ messages:
       }
 
       return;
+   }
+
+   GetHighestHurtMeRecentlyBattler()
+   {
+      local i, iHighestAmount, iHighestBattler;
+
+      iHighestAmount = 0;
+      iHighestBattler = $;
+      foreach i in plHurtMeRecently
+      {
+         if Nth(i,2) > iHighestAmount
+         {
+            iHighestAmount = Nth(i,2);
+            iHighestBattler = Nth(i,1);
+         }
+      }
+
+      return iHighestBattler;
    }
 
    GetHurtMeRecentlyAmount(who=$)

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -2050,7 +2050,7 @@ messages:
    "This returns the battler's ability to avoid being hit.  Ranges from "
    "1 to 2000."
    {
-      local iDefense;
+      local iDefense, iShocked;
 
       if piDefense = $
       {
@@ -2059,6 +2059,15 @@ messages:
       else
       {
          iDefense = piDefense;
+      }
+
+      % Check for Shocked status effect, which lowers defense.
+      iShocked = Send(self,@GetStatusEffect,#type=STATUS_SHOCKED);
+      if iShocked > 0
+      {
+         iDefense = iDefense - (iShocked * Send(SETTINGS_OBJECT,
+                                                @GetElementalMultiple,
+                                                #type=STATUS_SHOCKED));
       }
 
       return Bound(iDefense,1,2000);
@@ -2139,7 +2148,7 @@ messages:
       absolute=FALSE,precision=FALSE)
    {
       local iDamage, iResist, iPercentClass, i, each_obj, bAttackerEmpowered,
-            oSpell;
+            oSpell, iCorrode, iCorrodeMultiple, iCorrodeReduction;
 
       if NOT precision
       {
@@ -2180,6 +2189,17 @@ messages:
       {
          iDamage = Send(self,@ArmorCheck,#what=what,#bonus=bonus,#atype=atype,
             #aspell=aspell,#damage=damage);
+
+         iCorrode = Send(self,@GetStatusEffect,#type=STATUS_CORRODE);
+         if iCorrode > 0
+         {
+            iCorrodeMultiple = Send(SETTINGS_OBJECT,
+                               @GetElementalMultiple,#type=STATUS_CORRODE);
+         
+            iCorrodeReduction = (iCorrode/iCorrodeMultiple);
+            iDamage = bound(iDamage + iCorrodeReduction*100,1,damage);
+         }
+
          iResist = Send(self,@ResistanceCheck,#atype=atype,#aspell=aspell);
          iDamage = Send(self,@GetDamageFromResistance,#what=iDamage,#value=iResist);
          iDamage = iDamage + bonus;
@@ -2243,6 +2263,25 @@ messages:
       }
       
       Send(self,@AddHurtMeRecently,#who=what,#amount=iDamage);
+
+      % Apply possible elemental status effects
+      if atype = 0
+      {
+         if aspell <> 0
+         {
+            Send(self,@ApplyElementalStatusEffects,#damage=damage/100,
+                      #aspell=aspell);
+         }
+      }
+      else
+      {
+         % Apply only half the effects from partially magical attacks
+         if aspell <> 0
+         {
+            Send(self,@ApplyElementalStatusEffects,#damage=(damage/100/2),
+                      #aspell=aspell);
+         }
+      }
 
       return iDamage;
    }
@@ -4743,8 +4782,10 @@ messages:
    }
 
    GainHealthNormal(amount = $, precision = FALSE)
-   "for when holy touch is cast on a good monster"
+   "For when monsters heal themselves or each other."
    {
+      local iMantled, iMantledDivisor;
+
       if amount = $
       {
          return;
@@ -4753,6 +4794,14 @@ messages:
       if NOT precision
       {
          amount = amount * 100;
+      }
+
+      iMantled = Send(self,@GetStatusEffect,#type=STATUS_MANTLED);
+      if iMantled > 0
+      {
+         iMantledDivisor = Send(SETTINGS_OBJECT,
+                            @GetElementalMultiple,#type=STATUS_MANTLED);
+         amount = amount - (iMantled/iMantledDivisor)*100;
       }
 
       piHit_points = Bound(piHit_points+amount,1,piMax_hit_points*100);
@@ -5324,8 +5373,19 @@ messages:
 
    GetAttackTime()
    {
+      local iChilled, iChilledTotal, iChilledMultiple;
+
+      iChilledTotal = 0;
+      iChilled = Send(self,@GetStatusEffect,#type=STATUS_CHILLED);
+      if iChilled > 0
+      {
+         iChilledMultiple = Send(SETTINGS_OBJECT,
+                             @GetElementalMultiple,#type=STATUS_CHILLED);
+         iChilledTotal = iChilled * iChilledMultiple;
+      }
+
       return Send(self,@Fuzzy,#num=MOB_ATTACK_TIMER_WAIT)
-             + 3500-70*(3*viDifficulty+viSpeed);
+             + 3500-70*(3*viDifficulty+viSpeed) + iChilledTotal;
    }
 
    GetMoveTime()

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -5156,7 +5156,7 @@ messages:
    "Ranges from 1 to 2000."
    {
       local i, oWeapon, oShield, iParry, iDodge, iBlock, iAgility,
-            iDefense, iHealth, oMonster;
+            iDefense, iHealth, oMonster, iShocked;
 
       % Morphed?
       oMonster = Send(self,@GetIllusionForm);
@@ -5206,7 +5206,16 @@ messages:
       iDefense = iDefense + Send(Send(SYS,@GetParliament),
                                  @GetFactionDefenseBonus,#who=self);
 
-      return Bound(iDefense,1,2000);
+      % Check for Shocked status effect, which lowers defense.
+      iShocked = Send(self,@GetStatusEffect,#type=STATUS_SHOCKED);
+      if iShocked > 0
+      {
+         iDefense = iDefense - (iShocked * Send(SETTINGS_OBJECT,
+                                                @GetElementalMultiple,
+                                                #type=STATUS_SHOCKED));
+      }
+
+      return bound(iDefense,1,2000);
    }
 
    % The next three messages deal with the three defense skills.  These
@@ -5468,7 +5477,8 @@ messages:
    {
       local i, j, iResistance, oSoldierShield, gainchance, color_rsc,
             iDuration, oSpell, oGort,iLimit, origdamage, oWeapon, shrunken,
-            bAttackerEmpowered, bShielded;
+            bAttackerEmpowered, bShielded, iCorrode, iCorrodeMultiple,
+            iCorrodeReduction, iDamagePreArmor;
 
       if NOT precision
       {
@@ -5500,13 +5510,24 @@ messages:
                            #what=what,#damage=damage,
                            #atype=atype,#aspell=aspell);
          }
-         
+
+         iDamagePreArmor = damage;
          foreach i in plDefense_modifiers
          {
             damage = Send(i,@ModifyDefenseDamage,#who=self,#what=what,
                            #damage=damage,#atype=atype,#aspell=aspell,
                            #report_resistance=report_resistance);
             Send(i,@DefendingHit,#who=self,#what=what);
+         }
+
+         iCorrode = Send(self,@GetStatusEffect,#type=STATUS_CORRODE);
+         if iCorrode > 0
+         {
+            iCorrodeMultiple = Send(SETTINGS_OBJECT,
+                               @GetElementalMultiple,#type=STATUS_CORRODE);
+         
+            iCorrodeReduction = (iCorrode/iCorrodeMultiple);
+            damage = bound(damage + iCorrodeReduction*100,1,iDamagePreArmor);
          }
       
          iResistance = Send(self,@ResistanceCheck,#atype=atype,#aspell=aspell);
@@ -5698,8 +5719,27 @@ messages:
       {
          Send(shrunken,@DamageTaken,#what=what,#amount=damage/100);
       }
-      
+
       Send(self,@AddHurtMeRecently,#who=what,#amount=damage);
+
+      % Apply possible elemental status effects
+      if atype = 0
+      {
+         if aspell <> 0
+         {
+            Send(self,@ApplyElementalStatusEffects,#damage=damage/100,
+                      #aspell=aspell);
+         }
+      }
+      else
+      {
+         % Apply only half the effects from partially magical attacks
+         if aspell <> 0
+         {
+            Send(self,@ApplyElementalStatusEffects,#damage=(damage/100/2),
+                      #aspell=aspell);
+         }
+      }
 
       return damage;
    }
@@ -6422,7 +6462,7 @@ messages:
    "Have we waited long enough since the last attack/spell? Sets new "
    "valid attack time (time in msec, default 1 second)."
    {
-      local i;
+      local i, iChilled, iChilledMultiple, iChilledTotal;
 
       if ptAttackTimer <> $
       {
@@ -6440,6 +6480,22 @@ messages:
 
       if i > 0
       {
+         iChilled = Send(self,@GetStatusEffect,#type=STATUS_CHILLED);
+         if iChilled > 0
+         {
+            iChilledMultiple = Send(SETTINGS_OBJECT,
+                                @GetElementalMultiple,#type=STATUS_CHILLED);
+            iChilledTotal = iChilled * iChilledMultiple;
+            
+            if iChilledTotal > 100
+            {
+               while iChilledTotal > 100
+               {
+                  i = i + 100;
+                  iChilledTotal = iChilledTotal - 100;
+               }
+            }
+         }
          ptAttackTimer = CreateTimer(self,@AttackTimer,i);
       }
 
@@ -6860,7 +6916,7 @@ messages:
    GainHealthNormal(amount = $, precision = FALSE)
    "Don't add beyond piMax_health"
    {
-      local iOldhealth;
+      local iOldhealth, iMantled, iMantledDivisor;
 
       if amount = $
       {
@@ -6876,10 +6932,18 @@ messages:
       }
 
       iOldhealth = piHealth;
-
-      if amount < 0
+      
+      iMantled = Send(self,@GetStatusEffect,#type=STATUS_MANTLED);
+      if iMantled > 0
       {
-         return;
+         iMantledDivisor = Send(SETTINGS_OBJECT,
+                            @GetElementalMultiple,#type=STATUS_MANTLED);
+         amount = amount - (iMantled/iMantledDivisor)*100;
+      }
+
+      if amount < 1
+      {
+         return 0;
       }
 
       if piHealth > piMax_health*100
@@ -15035,7 +15099,7 @@ messages:
 
    SumDamageReduction()
    {
-      local iArmor, d;
+      local iArmor, d, iCorrode, iCorrodeMultiple;
 
       iArmor = 0;
 
@@ -15049,6 +15113,18 @@ messages:
          if IsClass(d,&ArmorOfGort)
          {
             iArmor = iArmor + (Send(self,@GetEnchantedState,#what=d) / 25);
+         }
+      }
+      
+      iCorrode = Send(self,@GetStatusEffect,#type=STATUS_CORRODE);
+      if iCorrode > 0
+      {
+         iCorrodeMultiple = Send(SETTINGS_OBJECT,
+                            @GetElementalMultiple,#type=STATUS_CORRODE);
+         
+         if iArmor > 0
+         {
+            iArmor = Bound(iArmor - (iCorrode/iCorrodeMultiple),0,$);
          }
       }
 

--- a/kod/object/item/passitem/ring/resring.kod
+++ b/kod/object/item/passitem/ring/resring.kod
@@ -125,6 +125,7 @@ messages:
             Send(poOwner,@MsgSendUser,#message_rsc=resistring_working_rsc);
 
             if IsClass(what,&User)
+               AND what <> poOwner
             {
                Send(what,@MsgSendUser,#message_rsc=resistring_attacker_rsc,
                      #parm1=Send(who,@GetName));

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -242,6 +242,26 @@ properties:
    % serves as a baseline for calculation.
    piBaseRating = 0
 
+   % Do we do elemental status effects at all?
+   piEnableElementalStatusEffects = TRUE
+
+   % Status effect multiples
+   % Shocked temporarily reduces defense by a multiple of damage taken (X*m defense)
+   % Chilled temporarily slows attack and cast timers (X*m ms)
+   % Burning temporarily deals burning damage over time by a divisor (X/m damage)
+   % Corrode temporarily lowers armor (X/m armor)
+   % Humbled temporarily lowers resistances (X/m resist)
+   % Mantled temporarily lowers the effect of healing on the victim (X/m healing)
+   piShockedMultiple = 4
+   piChilledMultiple = 30
+   piBurningDivisor = 3
+   piCorrodeDivisor = 6
+   piHumbledDivisor = 3
+   piMantledDivisor = 6
+   
+   piStatusEffectReductionTime = 3000
+   piStatusEffectReductionAmount = 10
+
    % Percent of mana required/used for broadcasting. Default 0 (no cost).
    piBroadcastManaPercent = 0
 
@@ -658,6 +678,45 @@ messages:
    {
       return piBaseRating;
    }
+   
+   GetElementalMultiple(type=STATUS_SHOCKED)
+   {
+      if type = STATUS_SHOCKED
+      {
+         return piShockedMultiple;
+      }
+      if type = STATUS_CHILLED
+      {
+         return piChilledMultiple;
+      }
+      if type = STATUS_BURNING
+      {
+         return bound(piBurningDivisor,2,100);
+      }
+      if type = STATUS_CORRODE
+      {
+         return bound(piCorrodeDivisor,1,100);
+      }
+      if type = STATUS_HUMBLED
+      {
+         return bound(piHumbledDivisor,1,100);
+      }
+      if type = STATUS_MANTLED
+      {
+         return bound(piMantledDivisor,1,100);
+      }
+      return 0;
+   }
+   
+   GetStatusEffectReductionTime()
+   {
+      return piStatusEffectReductionTime;
+   }
+   
+   GetStatusEffectReductionAmount()
+   {
+      return piStatusEffectReductionAmount;
+   }
 
    GetBroadcastManaCost()
    {
@@ -697,6 +756,11 @@ messages:
    GetPostMaxHPBuildingSystem()
    {
       return piPostMaxHPBuildingSystem;
+   }
+   
+   GetEnableElementalStatusEffects()
+   {
+      return piEnableElementalStatusEffects;
    }
 
 end


### PR DESCRIPTION
This is another optional server setting. If enabled, the various magical elements
inflict status effects on players.
- Fire deals diminishing burn damage over time.
- Ice slows the battler for a short time.
- Shock lowers victim's defense temporarily.
- Acid lowers victim's armor temporarily.
- Holy lowers victim's resistances temporarily.
- Unholy interferes with victim's healing for a short time.

The intent here is twofold. First, we differentiate the elements in real ways
by giving them effects other than damage. Second, we introduce interesting
new ways to interact and conflict. Is your opponent an agile dodger? Hit him
with a shocking fury to cut through his defense, but you can only take
advantage if you're quick. Is your enemy an armored tank? Drop a splash
of acid and follow it up with a weapon strike while his armor is low. Is your
opponent abusing healing? Throw out some unholy damage and put a
stop to those shenanigans.

These apply to mobs, too, so content creators can build new mobs with
these in mind. For instance, a mob that is highly resistant to everything
may be brought down by players coordinating large amounts of Holy damage
to cut its resists down - no Undead theme required for the mob, either.

Future skills and gear interactions can include things like "You apply more
Shock status with shock spells." as a way to 'improve' characters without
them just doing more damage.

---

Notes: players/mobs killed by burning damage have their deaths attributed
to the battler that did the most damage recently (since it's impossible to pick
out who exactly did which exact point of burning damage).

Partially magical attacks like touch spells and enchanted weapons apply
status effects at half effectiveness. For example, if you do 30 damage
with holy touch, only 15 'points' of STATUS_HUMBLED will be applied.
Because we have no pure holy spell, STATUS_HUMBLED will always
be weaker than the other status effects - but that's a good thing, because
its effect is extremely powerful (lowers all resists).

Holy (lowered resists) and Unholy (interferes with healing) were both
designed with PvP uses in mind, ala enchanted weapons available
to most anyone.

Acid (STATUS_CORRODE) can only boost damage taken to the amount
armor would have lowered it. In other words, it can't make armor go negative,
and it's useless on unarmored targets.

Ice (STATUS_CHILLED) is very weak on purpose because its effect,
slowing postcast/postattack timers, would be extremely strong and
annoying in greater amounts. It will be best be used against crazy
fast attackers like Champion mobs, since the slow is flat in nature.
A mob that attacks every 2000 ms won't be bothered much by +300 ms
delay, but a mob that attacks every 250 ms will.

All status effects were purposely designed with no reporting or text both
to cut down spam and to make them more dangerous. For example,
you will not receive any messages or screams that you're on fire from
STATUS_BURNING. You'll just see your screen flash red and your HP
drop a little. This is on purpose to make the effects feel like integral
aspects of the elements in play and force you to pay attention. These
effects reduce significantly every three seconds, so they should easily
become instinct for players (just got hit by shocking fury, my defense
is down!)

You will, however, see your defense/resists/armor drop in the stats screen
for the appropriate effects.
