### PR TITLE
Champion & Legendary mobs

### DIFF
--- a/kod/object/active/holder/nomoveon/battler.kod
+++ b/kod/object/active/holder/nomoveon/battler.kod
@@ -42,14 +42,14 @@ resources:
    % battler_defender_miss - Psychochild's attack is blocked by you.
    % battler_defender_fail - Psychochild's scimitar scrapes you, failing to cause any real harm.
 
-   battler_attacker_hit = "%sYour %s %s %s%s for ~k~B%i~B%s damage."
-   battler_attacker_slay = "%sYour %s %s %s%s."
-   battler_attacker_miss = "%sYour attack %s %s%s."
-   battler_attacker_fail = "%sYour %s %s %s%s, failing to cause any real harm."
-   battler_defender_hit = "%s%s%s's %s %s you for ~r~B%i~B%s damage."
-   battler_defender_slay = "%s%s%s's %s %s you."
-   battler_defender_miss = "%s%s%s's attack %s you."
-   battler_defender_fail = "%s%s%s's %s %s you, failing to cause any real harm."
+   battler_attacker_hit = "%sYour %s %s %s%s%s for ~k~B%i~B%s damage."
+   battler_attacker_slay = "%sYour %s %s %s%s%s."
+   battler_attacker_miss = "%sYour attack %s %s%s%s."
+   battler_attacker_fail = "%sYour %s %s %s%s%s, failing to cause any real harm."
+   battler_defender_hit = "%s%s%s%s's %s %s you for ~r~B%i~B%s damage."
+   battler_defender_slay = "%s%s%s%s's %s %s you."
+   battler_defender_miss = "%s%s%s%s's attack %s you."
+   battler_defender_fail = "%s%s%s%s's %s %s you, failing to cause any real harm."
 
    battler_punch = "punch"
    battler_attack = "attack"
@@ -153,6 +153,8 @@ resources:
    battler_pierce_wound = "pierces"
    battler_pierce_damage = "lacerates"
    battler_pierce_slay = "fells"
+   
+   battler_champion_none = ""
 
 classvars:
 
@@ -1425,21 +1427,27 @@ messages:
             if damage = $
             {
                Send(self,@MsgSendUser,#message_rsc=battler_attacker_slay,
-                     #parm1=rColor,#parm2=rWeaponName,#parm3=rDamageDesc,
-                     #parm4=Send(what,@GetDef),#parm5=Send(what,@GetName));
-            }
-            else if damage > 99
-            {
-               Send(self,@MsgSendUser,#message_rsc=battler_attacker_hit,
-                     #parm1=rColor,#parm2=rWeaponName,#parm3=rDamageDesc,
-                     #parm4=Send(what,@GetDef),#parm5=Send(what,@GetName),
-                     #parm6=damage/100,#parm7=rColor);
+               #parm1=rColor,#parm2=rWeaponName,#parm3=rDamageDesc,
+               #parm4=Send(what,@GetDef),#parm5=Send(what,@GetChampString),
+               #parm6=Send(what,@GetName));
             }
             else
             {
-               Send(self,@MsgSendUser,#message_rsc=battler_attacker_fail,
-                     #parm1=rColor,#parm2=rWeaponName,#parm3=rDamageDesc,
-                     #parm4=Send(what,@GetDef),#parm5=Send(what,@GetName));
+               if damage > 99
+               {
+                  Send(self,@MsgSendUser,#message_rsc=battler_attacker_hit,
+                  #parm1=rColor,#parm2=rWeaponName,#parm3=rDamageDesc,
+                  #parm4=Send(what,@GetDef),#parm5=Send(what,@GetChampString),
+                  #parm6=Send(what,@GetName),
+                  #parm7=damage/100,#parm8=rColor);
+               }
+               else
+               {
+                  Send(self,@MsgSendUser,#message_rsc=battler_attacker_fail,
+                  #parm1=rColor,#parm2=rWeaponName,#parm3=rDamageDesc,
+                  #parm4=Send(what,@GetDef),#parm5=Send(what,@GetChampString),
+                  #parm6=Send(what,@GetName));
+               }
             }
          }
       }
@@ -1459,23 +1467,29 @@ messages:
          if damage = $
          {
             Send(what,@MsgSendUser,#message_rsc=battler_defender_slay,
-                  #parm1=rColor,#parm2=Send(self,@GetCapDef),
-                  #parm3=Send(self,@GetName),#parm4=rWeaponName,
-                  #parm5=rDamageDesc);
-         }
-         else if damage > 99
-         {
-            Send(what,@MsgSendUser,#message_rsc=battler_defender_hit,
-                  #parm1=rColor,#parm2=Send(self,@GetCapDef),
-                  #parm3=Send(self,@GetName),#parm4=rWeaponName,
-                  #parm5=rDamageDesc,#parm6=damage/100,#parm7=rColor);
+              #parm1=rColor,#parm2=Send(self,@GetCapDef),
+              #parm3=Send(self,@GetChampString),
+              #parm4=Send(self,@GetName),#parm5=rWeaponName,
+              #parm6=rDamageDesc);
          }
          else
          {
-            Send(what,@MsgSendUser,#message_rsc=battler_defender_fail,
-                  #parm1=rColor,#parm2=Send(self,@GetCapDef),
-                  #parm3=Send(self,@GetName),#parm4=rWeaponName,
-                  #parm5=rDamageDesc);
+            if damage > 99
+            {
+               Send(what,@MsgSendUser,#message_rsc=battler_defender_hit,
+                 #parm1=rColor,#parm2=Send(self,@GetCapDef),
+                 #parm3=Send(self,@GetChampString),
+                 #parm4=Send(self,@GetName),#parm5=rWeaponName,
+                 #parm6=rDamageDesc,#parm7=damage/100,#parm8=rColor);
+            }
+            else
+            {
+               Send(what,@MsgSendUser,#message_rsc=battler_defender_fail,
+                 #parm1=rColor,#parm2=Send(self,@GetCapDef),
+                 #parm3=Send(self,@GetChampString),
+                 #parm4=Send(self,@GetName),#parm5=rWeaponName,
+                 #parm6=rDamageDesc);
+            }
          }
       }
 
@@ -1504,7 +1518,8 @@ messages:
               #parm1=rColor,
               #parm2=Send(what,@GetDefenseDesc,#stroke_obj=stroke_obj),
               #parm3=Send(what,@GetDef),
-              #parm4=Send(what,@GetName));
+              #parm4=Send(what,@GetChampString),
+              #parm5=Send(what,@GetName));
          Send(stroke_obj,@SendMissMessageToAttacker,#who=self,#victim=what,
               #color_rsc=rColor,#weapon_used=Send(self,@LookupPlayerWeapon),
               #bText=FALSE);
@@ -1523,9 +1538,11 @@ messages:
          }
       
          Send(what,@MsgSendUser,#message_rsc=battler_defender_miss,
-               #parm1=rColor,#parm2=Send(self,@GetCapDef),
-               #parm3=Send(self,@GetName),
-               #parm4=Send(what,@GetDefenseDesc,#stroke_obj=stroke_obj));
+              #parm1=rColor,
+              #parm2=Send(self,@GetCapDef),
+              #parm3=Send(self,@GetChampString),
+              #parm4=Send(self,@GetName),
+              #parm5=Send(what,@GetDefenseDesc,#stroke_obj=stroke_obj));
          % Flag them as "dodging", so they can potentially improve.
          Send(what,@SetPlayerFlag,#flag=PFLAG_DODGED,#value=TRUE);
       }
@@ -1985,6 +2002,21 @@ messages:
    GetBoostedLevel()
    {
       return 0;
+   }
+   
+   GetChampString()
+   {
+      return battler_champion_none;
+   }
+   
+   GetChampStatus()
+   {
+      return 0;
+   }
+   
+   GetChampionRewardMultiplier()
+   {
+      return 1;
    }
 
    CreateReputationHash()

--- a/kod/object/active/holder/nomoveon/battler/monster.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster.kod
@@ -30,6 +30,28 @@ constants:
 
    % Number of ms to lose one boosted health or mana point.
    BOOST_DECAY_TIME = 30000 
+   
+   % Champion mob types
+   NORMAL_MOB = 0
+   CHAMPION_TOUGH = 1
+   CHAMPION_SWIFT = 2
+   CHAMPION_DEADLY = 3
+   CHAMPION_INDOMITABLE = 4
+   CHAMPION_LEGENDARY = 5
+   
+   TIER_ONE_CHAMPION_REWARD_MULTIPLIER = 3
+   TIER_TWO_CHAMPION_REWARD_MULTIPLIER = 10
+   TIER_THREE_CHAMPION_REWARD_MULTIPLIER = 100
+   
+   % Champion abilities 
+   % Stored in the form [type, value] in plChampionAbilities
+   CHAMPION_ABIL_MAGIC_RESISTANCE = 1
+   CHAMPION_ABIL_WEAPON_RESISTANCE = 2
+   CHAMPION_ABIL_EAGLE_EYES = 3
+   CHAMPION_ABIL_FREE_ACTION = 4
+   CHAMPION_ABIL_ELEMENTAL_DAMAGE_TYPE = 5
+   CHAMPION_ABIL_PURGE = 6
+   CHAMPION_ABIL_DISARM = 7
 
 resources:
 
@@ -263,6 +285,22 @@ resources:
    monster_faction_heretic = "Cult of the Three"
    monster_faction_undead = "Minions of Death"
 
+   champion_none = ""
+   champion_tough_prefix = "tough "
+   champion_speed_prefix = "swift "
+   champion_damage_prefix = "deadly "
+   champion_all_prefix = "indomitable "
+   champion_super_prefix = "legendary "
+   
+   legendary_name_none = "Allan please add legendary name"
+   legendary_name_default = "Ror'thark the Merciless"
+   
+   champion_purge_msg = "The attack tears at the magics surrounding you!"
+   champion_disarm_msg = "The skilled strike knocks you off balance!"
+   
+   indomitable_arrived = "An indomitable %s steps forward, ready for combat!"
+   legendary_arrived = "~BA legendary %s appears, intent on destroying you!"
+
 classvars:
 
    vrKocName = monster_koc_name
@@ -367,6 +405,9 @@ classvars:
    viDead_drawfx = 0
 
    viFaction = FACTION_NEUTRAL
+   
+   viCanSpawnAsChampion = TRUE
+   viHasLegendaryNames = FALSE
 
 properties:
 
@@ -486,6 +527,13 @@ properties:
 
    piLastTimeAttacked = 0
    poLastAttacker = $
+   
+   % Keeps track of a mob's randomly generated extra strengths
+   piChampionStatus = 0
+   plChampionAbilities = $
+   
+   % Usually taken from monster's viSpeed
+   piSpeed = 0
 
    % some monsters are created on the fly (ex: avar) we may need to set this at
    % runtime
@@ -510,6 +558,7 @@ messages:
       piSpellChance = viSpellChance;
       piVisionDistance = viVisionDistance + piSurvivalLevel;
       piBoostedLevel = piSurvivalLevel;
+      piSpeed = viSpeed;
 
       if Send(self,@MobIsSeller)
       {
@@ -1043,9 +1092,16 @@ messages:
    "Monster just entered this room. Right now, thats only possible on a"
    "creation. So, lets pause for a few beats if we got users."
    {
+      local iRand;
+
       if what = $
       {
          Send(self,@ClearBasicTimers);
+         
+         if piChampionStatus <> 0
+         {
+            Send(self,@LoseChampionStatus);
+         }
 
          propagate;
       }
@@ -1065,6 +1121,40 @@ messages:
       }
 
       Send(poBrain,@NewOwner,#mob=self,#state=piState,#what=what);
+      
+      if NOT ((piBehavior & AI_NOFIGHT) OR (piBehavior & AI_NPC))
+         AND viCanSpawnAsChampion
+         AND IsClass(what,&Room)
+         AND Send(what,@GetCanSpawnChampions)
+         AND Send(SETTINGS_OBJECT,@GetChampionSpawnsEnabled)
+      {
+         iRand = Random(0,9999);
+         
+         if iRand > 450 AND iRand <= 650
+         {
+            Post(self,@GainChampionStatus,#iType=CHAMPION_TOUGH);
+         }
+         
+         if iRand > 250 AND iRand <= 450
+         {
+            Post(self,@GainChampionStatus,#iType=CHAMPION_SWIFT);
+         }
+         
+         if iRand > 50 AND iRand <= 250
+         {
+            Post(self,@GainChampionStatus,#iType=CHAMPION_DEADLY);
+         }
+         
+         if iRand > 0 AND iRand <= 50
+         {
+            Post(self,@GainChampionStatus,#iType=CHAMPION_INDOMITABLE);
+         }
+         
+         if iRand = 0
+         {
+            Post(self,@GainChampionStatus,#iType=CHAMPION_LEGENDARY);
+         }
+      }
 
       propagate;
    }
@@ -1835,7 +1925,7 @@ messages:
                Send(poOwner,@SomethingMoved,#what=self,
                      #new_row=iNew_row,#new_col=iNew_col,
                      #fine_row=iNew_finerow,#fine_col=iNew_finecol,
-                     #speed=(0x80|viSpeed),#non_monsters_only=TRUE);
+                     #speed=(0x80|piSpeed),#non_monsters_only=TRUE);
             }
          }
       }
@@ -2037,6 +2127,17 @@ messages:
       {
          iAttack = piOffense;
       }
+      
+      if piChampionStatus = CHAMPION_DEADLY
+         OR piChampionStatus = CHAMPION_INDOMITABLE
+      {
+         iAttack = (iAttack * 4) / 3;
+      }
+      
+      if piChampionStatus = CHAMPION_LEGENDARY
+      {
+         iAttack = (iAttack * 3) / 2;
+      }
 
       if piEnch_flags & ENCH_PALSY
       {
@@ -2059,6 +2160,17 @@ messages:
       else
       {
          iDefense = piDefense;
+      }
+      
+      if piChampionStatus = CHAMPION_TOUGH
+         OR piChampionStatus = CHAMPION_INDOMITABLE
+      {
+         iDefense = (iDefense * 4) / 3;
+      }
+      
+      if piChampionStatus = CHAMPION_LEGENDARY
+      {
+         iDefense = (iDefense * 3) / 2;
       }
 
       % Check for Shocked status effect, which lowers defense.
@@ -2090,7 +2202,9 @@ messages:
    % This returns the damage done to target "what"
    GetDamage(what = $, stroke_obj=$)
    {
-      local iDamage;
+      local iDamage, iMultiplier;
+
+      iMultiplier = 1;
 
       if piMinDamage = $ and piMaxDamage = $
       {
@@ -2114,7 +2228,18 @@ messages:
          iDamage = iDamage * 3 / 4 ;
       }
       
-      return Bound(iDamage,0,$);
+      if piChampionStatus = CHAMPION_DEADLY
+         OR piChampionStatus = CHAMPION_INDOMITABLE
+      {
+         iMultiplier = 2;
+      }
+      
+      if piChampionStatus = CHAMPION_LEGENDARY
+      {
+         iMultiplier = 3;
+      }
+      
+      return Bound(iDamage,0,$) * iMultiplier;
    }
 
    % This is the type of damage done.
@@ -2126,6 +2251,16 @@ messages:
    % This is the magical type of damage done.
    GetSpellType(what = $)
    {
+      local i;
+      
+      foreach i in plChampionAbilities
+      {
+         if First(i) = CHAMPION_ABIL_ELEMENTAL_DAMAGE_TYPE
+         {
+            return Nth(i,2);
+         }
+      }
+
       return viAttack_spell;
    }
 
@@ -2208,6 +2343,20 @@ messages:
       else
       {
          iDamage = damage;
+      }
+      
+      foreach i in plChampionAbilities
+      {
+         if First(i) = CHAMPION_ABIL_MAGIC_RESISTANCE
+            AND aspell <> 0
+         {
+            iDamage = (iDamage * (100-Nth(i,2)) / 100);
+         }
+         if First(i) = CHAMPION_ABIL_WEAPON_RESISTANCE
+            AND atype <> 0
+         {
+            iDamage = (iDamage * (100-Nth(i,2)) / 100);
+         }
       }
 
       % Set a predamage mark... we'll compare to it to see if threshold crossed.
@@ -2545,7 +2694,6 @@ messages:
    }
 
    %%% Movement messages
-
    MoveTowards(oTarget = $, face_target=FALSE, face_away=FALSE,
                to_master=FALSE)
    {
@@ -3589,6 +3737,38 @@ messages:
    HitSideEffect(what=$)
    "Called after every non-fatal monster hit"
    {
+      local i, oPurge, oDisarm;
+
+      foreach i in plChampionAbilities
+      {
+         if First(i) = CHAMPION_ABIL_PURGE
+         {
+            if Random(1,100) < Nth(i,2)
+            {
+               oPurge = Send(SYS,@FindSpellByNum,#num=SID_PURGE);
+               if oPurge <> $
+                  AND Send(what,@IsEnchanted)
+               {
+                  if IsClass(what,&Player)
+                  {
+                     Send(what,@MsgSendUser,#message_rsc=champion_purge_msg);
+                  }
+                  % Chances equal to a purge weapon
+                  Send(oPurge,@DoPurge,#who=what,#iChance=Random(25,75));
+               }
+            }
+         }
+         
+         if First(i) = CHAMPION_ABIL_DISARM
+         {
+            if Random(1,100) < Nth(i,2)
+            {
+               oDisarm = Send(SYS,@FindSkillByNum,#num=SKID_DISARM);
+               Send(oDisarm,@DoSkill,#who=self,#oTarget=what);
+            }
+         }
+      }
+      
       return;
    }
 
@@ -5069,6 +5249,66 @@ messages:
    {
       local iHit_Percent, rMonster_condition;
 
+      ClearTempString();
+      if piBehavior & AI_NPC
+      {
+         AppendTempString(monster_nothing);
+      }
+      else
+      {
+         AppendTempString("This ");
+         AppendTempString(Send(self,@GetName));
+         AppendTempString(" can be challenged for advancement until ");
+         AppendTempString(viLevel);
+         AppendTempString(" health points.");
+         
+         if piChampionStatus = CHAMPION_TOUGH
+         {
+            AppendTempString("\n\nThis ");
+            AppendTempString(Send(self,@GetName));
+            AppendTempString(" looks rather tough.");
+         }
+         
+         if piChampionStatus = CHAMPION_SWIFT
+         {
+            AppendTempString("\n\nThis ");
+            AppendTempString(Send(self,@GetName));
+            AppendTempString(" seems to move fairly swiftly.");
+         }
+         
+         if piChampionStatus = CHAMPION_DEADLY
+         {
+            AppendTempString("\n\nThis ");
+            AppendTempString(Send(self,@GetName));
+            AppendTempString(" appears exceptionally deadly.");
+         }
+         
+         if piChampionStatus = CHAMPION_INDOMITABLE
+         {
+            AppendTempString("\n\nThis ");
+            AppendTempString(Send(self,@GetName));
+            AppendTempString(" clearly possesses an indomitable strength.");
+         }
+         
+         if piChampionStatus = CHAMPION_LEGENDARY
+         {
+            if viHasLegendaryNames
+            {
+               AppendTempString("\n\nThis is the legendary ");
+               AppendTempString(Send(self,@GetName));
+               AppendTempString(", ");
+               AppendTempString(Send(self,@GetLegendaryName));
+               AppendTempString("!");
+            }
+            else
+            {
+               AppendTempString("\n\nThis is a legendary ");
+               AppendTempString(Send(self,@GetName));
+               AppendTempString(", a renowned terror upon the land!");
+            }
+         }
+      }
+
       if iHitPoint_Percent = $
       {
          iHit_Percent = piHit_points / piMax_hit_points;
@@ -5129,12 +5369,26 @@ messages:
    "construction, and to heal the monster, as well as for indicating "
    "its current damage."
    {
-      if viLevel < 40
+      local iMultiplier;
+
+      iMultiplier = 1;
+      if piChampionStatus = CHAMPION_TOUGH
+         OR piChampionStatus = CHAMPION_INDOMITABLE
       {
-         return viLevel;
+         iMultiplier = 3;
+      }
+      
+      if piChampionStatus = CHAMPION_LEGENDARY
+      {
+         iMultiplier = 10;
       }
 
-      return ((120 * viLevel) / 100);
+      if viLevel < 40
+      {
+         return viLevel * iMultiplier;
+      }
+
+      return ((120 * viLevel) / 100) * iMultiplier;
    }
    
    ReturnMaxHitPoints()
@@ -5384,16 +5638,16 @@ messages:
          iChilledTotal = iChilled * iChilledMultiple;
       }
 
-      return Send(self,@Fuzzy,#num=MOB_ATTACK_TIMER_WAIT)
-             + 3500-70*(3*viDifficulty+viSpeed) + iChilledTotal;
+      return Bound(Send(self,@Fuzzy,#num=MOB_ATTACK_TIMER_WAIT)
+             + 3500-70*(3*viDifficulty+piSpeed),250,$) + iChilledTotal;
    }
 
    GetMoveTime()
    {
       local iTime;
 
-      % Unit of viSpeed is: #gridsquares per 10 seconds (per 10000 ms)
-      % viSpeed is pre-defined by monster
+      % Unit of piSpeed is: #gridsquares per 10 seconds (per 10000 ms)
+      % piSpeed is pre-defined by monster
       % Move-increment is predefined/fixed at 16fine unit per step
       % --> The elapse-interval is fixed!
   
@@ -5404,12 +5658,12 @@ messages:
       % 4 * 1024 	= 4096 super-fine squares per 10000 ms
       % 4096 / 256  = 16 (Monster has to make 16 steps per 10000ms)
       % 10000 / 16  = 625 (steps must be made in 625ms intervals)
-      % T = 10000 / ((viSpeed * 1024) / 256)  
+      % T = 10000 / ((piSpeed * 1024) / 256)  
 
       % avoid division by zero, if objects teleport
-      % objects with viSpeed = 0 don't need seamless movements in the client
+      % objects with piSpeed = 0 don't need seamless movements in the client
       % so we just assume it is enough to teleport them once a second
-      if viSpeed > 0
+      if piSpeed > 0
       {
          % see formula above  
          iTime = 10000 / (viSpeed * 4);
@@ -6082,7 +6336,7 @@ messages:
       local i, j, oReagent, iNumberItems, oTreasure, oTreasure_type,
             lTreasureItems, iNumberOfItemsDropped, iNumberOfItemsLooted,
             iRandomCashAmount, oMoney, iGetResult, bCapacityFailure,
-            bRangeFailure, iSurvivalLoot;
+            bRangeFailure, iSurvivalLoot, tokengen, iSafetyCntr;
 
       % Apparitions, etc, provide no treasure
       if pbIllusion
@@ -6098,6 +6352,71 @@ messages:
                vrname,self);
 
          return;
+      }
+
+      if Send(self,@GetTreasureType) <> TID_NONE
+      {
+         if (viAttributes & MOB_ONE_TREASURE)
+         {
+            iNumberItems = 1;
+         }
+         else
+         {
+            % Random number of treasure items are dropped based on viLevel
+            %  and viDifficulty.  The higher these values are, the more items
+            %  that may be dropped.
+            iSurvivalLoot = piBoostedLevel
+              / Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalLoot);
+
+            iNumberItems = 1 + (viLevel/55) + Random(0,viDifficulty/3)
+                              + iSurvivalLoot;
+            iNumberItems = Bound(iNumberItems,$,6 + iSurvivalLoot);
+            iNumberItems = (Send(SETTINGS_OBJECT,@GetItemFactor)*iNumberItems)/100;
+            iNumberItems = Bound(iNumberItems,1,$);
+         }
+      
+         tokengen = TRUE;
+         i = 1;
+      
+         while i <= iNumberItems
+         {
+            oTreasure = Send(oTreasure_type,@GenerateTreasure,#level=viLevel,
+                             #who=who,#mob=self,#tokengen=tokengen,
+                             #corpse=corpse);
+
+            if oTreasure <> $
+            {
+               if IsClass(oTreasure,&NumberItem)
+               {
+                  Send(oTreasure,@AddNumber,
+                     #number=(Send(oTreasure,@GetNumber) *
+                        (Send(self,@GetChampionRewardMultiplier)-1)));
+               }
+
+               if IsClass(oTreasure,&SpellItem)
+               {
+                  iSafetyCntr = 0;
+
+                  while (NOT Send(oTreasure,@SpellItemIsAccessible))
+                        AND iSafetyCntr < 5
+                  {
+                     oTreasure = Send(oTreasure_type,@GenerateTreasure,
+                                      #level=viLevel,#who=who,#mob=self,
+                                      #tokengen=tokengen,#corpse=corpse);
+                     iSafetyCntr = iSafetyCntr + 1;
+                  }
+               }
+            
+               if IsClass(oTreasure,&Token) 
+               {
+                  tokengen = FALSE;
+               }
+
+               lTreasureItems = cons(oTreasure, lTreasureItems);
+            
+               i = i + 1;
+            }
+         }
       }
 
       % TreasureType now handles putting together the treasure list.
@@ -6131,8 +6450,9 @@ messages:
             corpse = $;
          }
 
-         oMoney = Create(&Money,#corpse=corpse,#number=iRandomCashAmount + (piBoostedLevel
-                     * Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalCash)));
+         oMoney = Create(&Money,#corpse=corpse,#number=(iRandomCashAmount + (piBoostedLevel
+                     * Send(Send(SYS,@GetSurvivalRoomMaintenance),@GetSurvivalCash)))
+                     * Send(self,@GetChampionRewardMultiplier));
 
          Send(Send(SYS,@GetStatistics),@MoneyCreated,#amount=Send(oMoney,@GetNumber));
          lTreasureItems = Cons(oMoney,lTreasureItems);
@@ -6355,6 +6675,7 @@ messages:
          OR (piBehavior & AI_NPC)
          OR poMaster <> $
          OR pbDontDispose
+         OR piChampionStatus <> 0
       {
          return;
       }
@@ -7183,6 +7504,295 @@ messages:
    LoseLight()
    {
       return 0;
+   }
+
+   GetChampString()
+   {
+      if piChampionStatus = CHAMPION_TOUGH
+      {
+         return champion_tough_prefix;
+      }
+      
+      if piChampionStatus = CHAMPION_SWIFT
+      {
+         return champion_speed_prefix;
+      }
+      
+      if piChampionStatus = CHAMPION_DEADLY
+      {
+         return champion_damage_prefix;
+      }
+      
+      if piChampionStatus = CHAMPION_INDOMITABLE
+      {
+         return champion_all_prefix;
+      }
+      
+      if piChampionStatus = CHAMPION_LEGENDARY
+      {
+         return champion_super_prefix;
+      }
+      
+      return champion_none;
+   }
+   
+   GetChampStatus()
+   {
+      return piChampionStatus;
+   }
+   
+   GainChampionStatus(iType=0)
+   {
+      local i, each_obj;
+
+      if poOwner = $
+      {
+         return;
+      }
+
+      piChampionStatus = iType;
+
+      piMax_Hit_points = Send(Self,@Fuzzy,#num=Send(self,@GetMaxHitPoints))
+                         + piBoostedLevel*viDifficulty;
+      piHit_points = piMax_hit_points*100;
+      
+      if iType = CHAMPION_SWIFT
+         OR iType = CHAMPION_INDOMITABLE
+      {
+         piSpeed = viSpeed * 2;
+      }
+      
+      if iType = CHAMPION_TOUGH
+         OR iType = CHAMPION_SWIFT
+         OR iType = CHAMPION_DEADLY
+      {
+         Send(self,@AddRandomChampionAbility);
+      }
+      
+      if iType = CHAMPION_INDOMITABLE
+      {
+         Send(self,@AddRandomChampionAbility);
+         Send(self,@AddRandomChampionAbility);
+
+         foreach i in Send(poOwner,@GetHolderActive)
+         {
+            each_obj = Send(poOwner,@HolderExtractObject,#data=i);
+            if IsClass(each_obj,&Player)
+            {
+               Send(each_obj,@MsgSendUser,#message_rsc=indomitable_arrived,
+                                          #parm1=Send(self,@GetName));
+            }
+         }
+      }
+      
+      if iType = CHAMPION_LEGENDARY
+      {
+         piSpeed = viSpeed * 3;
+         
+         Send(self,@AddRandomChampionAbility);
+         Send(self,@AddRandomChampionAbility);
+         Send(self,@AddRandomChampionAbility);
+
+         foreach i in Send(poOwner,@GetHolderActive)
+         {
+            each_obj = Send(poOwner,@HolderExtractObject,#data=i);
+            if IsClass(each_obj,&Player)
+            {
+               Send(each_obj,@MsgSendUser,#message_rsc=legendary_arrived,
+                                          #parm1=Send(self,@GetName));
+            }
+         }
+      }
+
+      Send(poOwner,@SomethingChanged,#what=self);
+
+      return;
+   }
+   
+   AddRandomChampionAbility()
+   {
+      local lAbilities, iRandomAbility, iValue, lElements, i;
+      
+      lAbilities = [CHAMPION_ABIL_MAGIC_RESISTANCE,
+                    CHAMPION_ABIL_WEAPON_RESISTANCE,
+                    CHAMPION_ABIL_EAGLE_EYES,
+                    CHAMPION_ABIL_FREE_ACTION,
+                    CHAMPION_ABIL_ELEMENTAL_DAMAGE_TYPE,
+                    CHAMPION_ABIL_PURGE,
+                    CHAMPION_ABIL_DISARM];
+                    
+      iRandomAbility = Nth(lAbilities,Random(1,Length(lAbilities)));
+      iValue = 0;
+      
+      if iRandomAbility = CHAMPION_ABIL_MAGIC_RESISTANCE
+         OR iRandomAbility = CHAMPION_ABIL_WEAPON_RESISTANCE
+         OR iRandomAbility = CHAMPION_ABIL_EAGLE_EYES
+         OR iRandomAbility = CHAMPION_ABIL_FREE_ACTION
+      {
+         iValue = Random(20,50);
+      }
+      
+      if iRandomAbility = CHAMPION_ABIL_ELEMENTAL_DAMAGE_TYPE
+      {
+         lElements = [ATCK_SPELL_FIRE,
+                      ATCK_SPELL_COLD,
+                      ATCK_SPELL_SHOCK,
+                      ATCK_SPELL_ACID,
+                      ATCK_SPELL_HOLY,
+                      ATCK_SPELL_UNHOLY];
+         iValue = Nth(lElements,Random(1,Length(lElements)));
+      }
+      
+      if iRandomAbility = CHAMPION_ABIL_PURGE
+      {
+         iValue = Random(5,15);
+      }
+      
+      if iRandomAbility = CHAMPION_ABIL_DISARM
+      {
+         iValue = Random(5,10);
+      }
+
+      foreach i in plChampionAbilities
+      {
+         if First(i) = iRandomAbility
+         {
+            SetNth(i,2,Nth(i,2) + iValue);
+            return;
+         }
+      }
+
+      plChampionAbilities = Cons([iRandomAbility,iValue],
+                                  plChampionAbilities);
+
+      return;
+   }
+   
+   LoseChampionStatus()
+   {
+      piChampionStatus = 0;
+      plChampionAbilities = $;
+
+      piMax_Hit_points = Send(Self,@Fuzzy,#num=Send(self,@GetMaxHitPoints))
+                         + piBoostedLevel*viDifficulty;
+      piHit_points = piMax_hit_points*100;
+      
+      piSpeed = viSpeed;
+      
+      if poOwner <> $
+      {
+         Send(poOwner,@SomethingChanged,#what=self);
+      }
+      
+      return;
+   }
+
+   SendLightingInformation()
+   {
+      if piChampionStatus = 1
+      {
+         AddPacket(2,(LIGHT_FLAG_ON | LIGHT_FLAG_DYNAMIC));
+         % 125 out of 255 intensity of light
+         AddPacket(1,125);
+         % Blue 'shield' glow.
+         AddPacket(2,LIGHT_BBLUE);
+         return;
+      }
+      if piChampionStatus = 2
+      {
+         AddPacket(2,(LIGHT_FLAG_ON | LIGHT_FLAG_DYNAMIC));
+         % 255 out of 255 intensity of light
+         AddPacket(1,255);
+         % Orange 'speedy' glow.
+         AddPacket(2,LIGHT_BORANGE);
+         return;
+      }
+      if piChampionStatus = 3
+      {
+         AddPacket(2,(LIGHT_FLAG_ON | LIGHT_FLAG_DYNAMIC));
+         % 255 out of 255 intensity of light
+         AddPacket(1,255);
+         % Red 'danger' glow.
+         AddPacket(2,LIGHT_BRED);
+         return;
+      }
+      if piChampionStatus = 4
+      {
+         AddPacket(2,(LIGHT_FLAG_ON | LIGHT_FLAG_DYNAMIC));
+         % 255 out of 255 intensity of light
+         AddPacket(1,255);
+         % Green 'everything' glow.
+         AddPacket(2,LIGHT_BGREEN);
+         return;
+      }
+      if piChampionStatus = 5
+      {
+         AddPacket(2,(LIGHT_FLAG_ON | LIGHT_FLAG_DYNAMIC));
+         % 255 out of 255 intensity of light
+         AddPacket(1,255);
+         % Gold 'we're all gonna die' glow.
+         AddPacket(2,LIGHT_BYELLOW);
+         return;
+      }
+
+      propagate;
+   }
+   
+   GetLegendaryName()
+   {
+      return legendary_name_none;
+   }
+   
+   GetBlindResistance()
+   {
+      local i;
+      
+      foreach i in plChampionAbilities
+      {
+         if First(i) = CHAMPION_ABIL_EAGLE_EYES
+         {
+            return Nth(i,2);
+         }
+      }
+      
+      return 0;
+   }
+   
+   GetHoldResistance()
+   {
+      local i;
+      
+      foreach i in plChampionAbilities
+      {
+         if First(i) = CHAMPION_ABIL_FREE_ACTION
+         {
+            return Nth(i,2);
+         }
+      }
+      
+      return 0;
+   }
+   
+   GetChampionRewardMultiplier()
+   {
+      if piChampionStatus = CHAMPION_TOUGH
+         OR piChampionStatus = CHAMPION_SWIFT
+         OR piChampionStatus = CHAMPION_DEADLY
+      {
+         return TIER_ONE_CHAMPION_REWARD_MULTIPLIER;
+      }
+
+      if piChampionStatus = CHAMPION_INDOMITABLE
+      {
+         return TIER_TWO_CHAMPION_REWARD_MULTIPLIER;
+      }
+
+      if piChampionStatus = CHAMPION_LEGENDARY
+      {
+         return TIER_THREE_CHAMPION_REWARD_MULTIPLIER;
+      }
+
+      propagate;
    }
 
 end

--- a/kod/object/active/holder/nomoveon/battler/monster/council.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/council.kod
@@ -54,6 +54,8 @@ classvars:
    viMyRow = 15
    viMyCol = 15
    viMyAngle = ANGLE_NORTH
+   
+   viCanSpawnAsChampion = FALSE
 
 properties:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/dethspid.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/dethspid.kod
@@ -152,7 +152,7 @@ messages:
          }
       }
 
-      return;
+      propagate;
    }
 
    IsAlly(target = $)

--- a/kod/object/active/holder/nomoveon/battler/monster/duskrat.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/duskrat.kod
@@ -181,7 +181,7 @@ messages:
          }
       }
 
-      return;
+      propagate;
    }
 
    IsAlly(target=$)

--- a/kod/object/active/holder/nomoveon/battler/monster/evfairy.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/evfairy.kod
@@ -186,6 +186,11 @@ messages:
 
    SendLightingInformation()
    {
+      if piChampionStatus <> 0
+      {
+         propagate;
+      }
+
       AddPacket(2,(LIGHT_FLAG_ON | LIGHT_FLAG_DYNAMIC));
       % Intensity (out of 255)
       AddPacket(1,30);

--- a/kod/object/active/holder/nomoveon/battler/monster/evilent.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/evilent.kod
@@ -230,7 +230,7 @@ messages:
          }
       }
 
-      return;
+      propagate;
    }
 
    CreateDeadBody(killer=$)

--- a/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/eviltwin.kod
@@ -69,6 +69,8 @@ classvars:
    viDefault_behavior = \
       AI_FIGHT_SINGLEMINDED | AI_FIGHT_MONSTERS \
       | AI_FIGHT_NEWBIESAFE | AI_FIGHT_AGGRESSIVE
+   
+   viCanSpawnAsChampion = FALSE
 
 properties:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/factions.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/factions.kod
@@ -31,6 +31,8 @@ classvars:
    viMyAngle = ANGLE_NORTH
    viMyFR = 32
    viMyFC = 32
+   
+   viCanSpawnAsChampion = FALSE
 
 messages:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/fairy.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/fairy.kod
@@ -184,6 +184,11 @@ messages:
 
    SendLightingInformation()
    {
+      if piChampionStatus <> 0
+      {
+         propagate;
+      }
+
       AddPacket(2,(LIGHT_FLAG_ON | LIGHT_FLAG_DYNAMIC));
       % Intensity (out of 255)
       AddPacket(1,30);

--- a/kod/object/active/holder/nomoveon/battler/monster/ghost.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/ghost.kod
@@ -201,6 +201,11 @@ messages:
 
    SendLightingInformation()
    {
+      if piChampionStatus <> 0
+      {
+         propagate;
+      }
+
       AddPacket(2,(LIGHT_FLAG_ON | LIGHT_FLAG_DYNAMIC));
       % 50 out of 255 intensity of light
       AddPacket(1,50);

--- a/kod/object/active/holder/nomoveon/battler/monster/nrthlwrm.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/nrthlwrm.kod
@@ -167,7 +167,7 @@ messages:
          Send(what,@AddExertion,#amount=(Random(EXERTION_DAMAGE_MIN,EXERTION_DAMAGE_MAX)*10000));
       }
 
-      return;
+      propagate;
    }
 
 end

--- a/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/reflectn.kod
@@ -71,6 +71,8 @@ classvars:
 
    viDefault_behavior = AI_FIGHT_MONSTERS | AI_FIGHT_NEWBIESAFE \
                         | AI_FIGHT_AGGRESSIVE
+   
+   viCanSpawnAsChampion = FALSE
 
 properties:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/scorpion.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/scorpion.kod
@@ -128,7 +128,7 @@ messages:
          }
       }
 
-      return;
+      propagate;
    }
 
 end

--- a/kod/object/active/holder/nomoveon/battler/monster/skel/daemskel.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/skel/daemskel.kod
@@ -105,7 +105,7 @@ messages:
          }
       }
 
-      return;
+      propagate;
    }
 
 end

--- a/kod/object/active/holder/nomoveon/battler/monster/spdrquen.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/spdrquen.kod
@@ -158,7 +158,7 @@ messages:
          }
       }
 
-      return;
+      propagate;
    }
 
    IsAlly(target = $)

--- a/kod/object/active/holder/nomoveon/battler/monster/specmum.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/specmum.kod
@@ -123,6 +123,11 @@ messages:
 
    SendLightingInformation()
    {
+      if piChampionStatus <> 0
+      {
+         propagate;
+      }
+
       AddPacket(2,(LIGHT_FLAG_ON | LIGHT_FLAG_DYNAMIC));
       % 5 out of 255 intensity of light
       AddPacket(1,5);

--- a/kod/object/active/holder/nomoveon/battler/monster/spider.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/spider.kod
@@ -146,7 +146,7 @@ messages:
          }
       }
 
-      return;
+      propagate;
    }
 
    IsAlly(target = $)

--- a/kod/object/active/holder/nomoveon/battler/monster/temples.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/temples.kod
@@ -34,6 +34,8 @@ classvars:
    viQuestID = 0
    viGender = GENDER_FEMALE
    vrTeach_quest_needed = priestess_teach_quest_needed
+   
+   viCanSpawnAsChampion = FALSE
 
 messages:
 

--- a/kod/object/active/holder/nomoveon/battler/monster/towns.kod
+++ b/kod/object/active/holder/nomoveon/battler/monster/towns.kod
@@ -28,6 +28,8 @@ classvars:
    viDefault_behavior = AI_NPC | AI_NOMOVE
 
    viSpeed = SPEED_AVERAGE
+   
+   viCanSpawnAsChampion = FALSE
 
 properties:
 

--- a/kod/object/active/holder/nomoveon/battler/player.kod
+++ b/kod/object/active/holder/nomoveon/battler/player.kod
@@ -9168,8 +9168,9 @@ messages:
             roll = FALSE;
          }
 
-         gainmult = Bound(Send(SETTINGS_OBJECT,
-                     @GetHPGainMultiplier),1,500);
+         gain = gain * Send(what,@GetChampionRewardMultiplier);
+
+         gainmult = Bound(Send(SETTINGS_OBJECT,@GetHPGainMultiplier),1,500);
          gain = gain * gainmult;
 
          if iExperienceSystem = EXPERIENCE_SYSTEM_CLASSIC
@@ -9196,17 +9197,20 @@ messages:
             {
                if monster_level <= 121
                {
-                  piTraining_points = piTraining_points + 1;
+                  piTraining_points = piTraining_points +
+                     (1*Send(what,@GetChampionRewardMultiplier));
                }
                else
                {
                   if monster_level <= 150
                   {
-                     piTraining_points = piTraining_points + 2;
+                     piTraining_points = piTraining_points +
+                        (2*Send(what,@GetChampionRewardMultiplier));
                   }
                   else
                   {
-                     piTraining_points = piTraining_points + 3;
+                     piTraining_points = piTraining_points +
+                        (3*Send(what,@GetChampionRewardMultiplier));
 
                   }
                }

--- a/kod/object/active/holder/room.kod
+++ b/kod/object/active/holder/room.kod
@@ -194,6 +194,8 @@ classvars:
 
    viFlag_row = $
    viFlag_col = $
+   
+   viCanSpawnChampions = TRUE
 
    viWeatherZone = WEATHER_ZONE_DEFAULT
    viWeatherMask = WEATHER_MASK_DEFAULT
@@ -5682,6 +5684,21 @@ messages:
       Send(self,@SetRoomFlagToDefault,#flag=ROOM_NO_PK);
 
       return;
+   }
+   
+   GetCanSpawnChampions()
+   {
+      return viCanSpawnChampions;
+   }
+   
+   LightingColorOverride()
+   {
+      return FALSE;
+   }
+   
+   GetLightingColorOverride(what=$)
+   {
+      return LIGHT_WHITE;
    }
 
 end

--- a/kod/object/passive/skill/disarm.kod
+++ b/kod/object/passive/skill/disarm.kod
@@ -109,28 +109,39 @@ messages:
 
       if oWeapon=$
       {
-         % Talented people can disarm even bare-handed.
-         iAbil = Send(who,@GetSkillAbility,#Skill_num=SKID_BRAWLING);
-         if iAbil < BRAWL_THRESHOLD
+         if IsClass(who,&Monster)
          {
-            return FALSE;
+            iModifier = Send(who,@GetLevel);
+         } 
+         else
+         {
+            % Talented people can disarm even bare-handed.
+            iAbil = Send(who,@GetSkillAbility,#Skill_num=SKID_BRAWLING);
+            if iAbil < BRAWL_THRESHOLD
+            {
+               return FALSE;
+            }
+         
+            iModifier = iAbil;
          }
-
-         iModifier = iAbil;
       }
       else
       {
          iModifier = Send(oWeapon,@GetDisarmBonus);
       }
 
-      if NOT (Send(self,@CanPayCosts,#who=who)
-         AND Send(self,@PayCosts,#who=who,#modifier=iModifier))
+      if IsClass(who,&Player)
+         AND NOT (Send(self,@CanPayCosts,#who=who)
+            AND Send(self,@PayCosts,#who=who,#modifier=iModifier))
       {
          return FALSE;
       }
 
-      % Get player's ability in this skill.
-      iAbil = Send(who,@GetSkillAbility,#Skill_num=viSkill_num);
+      if IsClass(who,&Player)
+      {
+         % Get player's ability in this skill.
+         iAbil = Send(who,@GetSkillAbility,#Skill_num=viSkill_num);
+      }
 
       if (IsClass(oTarget,&Player))
          AND (Send(SYS,@IsPKAllowed)
@@ -154,25 +165,37 @@ messages:
             {
                % Success!  They dropped it!
                Send(oTarget,@DropItem,#droppedItem=oOppWeapon);
-               Send(who,@MsgSendUser,#message_rsc=Disarm_dropped,
-                     #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
-               Send(oTarget,@MsgSendUser,#message_rsc=Disarm_opp_dropped,
-                     #parm1=Send(who,@GetDef),#parm2=Send(who,@GetName));
+               
+               if IsClass(who,&Player)
+               {
+                  send(who,@MsgSendUser,#message_rsc=Disarm_dropped,
+                       #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
+               }
+
+               send(oTarget,@MsgSendUser,#message_rsc=Disarm_opp_dropped,
+                    #parm1=Send(who,@GetCapDef),#parm2=Send(who,@GetName));
             }
             else
             {
-               Send(oTarget,@UnuseItem,#what=oOppWeapon);
-               Send(who,@MsgSendUser,#message_rsc=Disarm_unwield,
-                     #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
-               Send(oTarget,@MsgSendUser,#message_rsc=Disarm_opp_unwield,
-                     #parm1=Send(who,@GetDef),#parm2=Send(who,@GetName));
-            }
+               % Why would we send this a second time? TryUnuse already unuses...
+               %Send(oTarget,@UnuseItem,#what=oOppWeapon);
+               
+               if IsClass(who,&Player)
+               {
+                  send(who,@MsgSendUser,#message_rsc=Disarm_unwield,
+                       #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
+               }
 
-            % Disarming players takes a bit more vigor than usual,
-            % about 5x more. This adds the additional 4x extra in
-            % addition to the amount already taken. This is because
-            % it's much more harmful to players.
-            Send(who,@AddExertion,#amount=4 * (1000 * viSkillExertion));
+               send(oTarget,@MsgSendUser,#message_rsc=Disarm_opp_unwield,
+                    #parm1=Send(who,@GetCapDef),#parm2=Send(who,@GetName));
+            }
+            % Disarming players takes a bit more vigor than usual, about 5x more.
+            % This adds the additional 4x extra in addition to the amount already taken
+            % This is because it's much more harmful to players.
+            if IsClass(who,&Player)
+            {
+               send(who,@AddExertion,#amount=4 * (1000 * viSkillExertion));
+            }
          }
       }
       else
@@ -184,9 +207,12 @@ messages:
          {
             return FALSE;
          }
-         
-         Send(who,@MsgSendUser,#message_rsc=Disarm_unwield,
-               #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
+
+         if IsClass(who,&Player)
+         {
+            send(who,@MsgSendUser,#message_rsc=Disarm_unwield,
+              #parm1=Send(oTarget,@GetDef),#parm2=Send(oTarget,@GetName));
+         }
 
          % The better you are, the better your weapon, the longer your stun is.
          % The bigger the monster is, the shorter the stun is.
@@ -195,6 +221,11 @@ messages:
                         2000,6000);
          Send(oHoldSpell,@DoSpell,#what=who,#oTarget=oTarget,
                #iDuration=iAbil,#report=FALSE);
+      }
+      
+      if IsClass(who,&Monster)
+      {
+         return;
       }
 
       propagate;

--- a/kod/object/passive/spell/debuff/blind.kod
+++ b/kod/object/passive/spell/debuff/blind.kod
@@ -166,6 +166,12 @@ messages:
             return;
          }
       }
+      
+      if IsClass(oTarget,&Monster)
+         AND Send(oTarget,@GetBlindResistance) <> 0
+      {
+         iDuration = (iDuration * (100-Send(oTarget,@GetBlindResistance)))/100;
+      }
 
       % Re-check the bound on duration.
       iDuration = Bound(iDuration,piMinBlind,piMaxBlind);

--- a/kod/object/passive/spell/debuff/dazzle.kod
+++ b/kod/object/passive/spell/debuff/dazzle.kod
@@ -155,6 +155,12 @@ messages:
             return;
          }
       }
+      
+      if IsClass(oTarget,&Monster)
+         AND Send(oTarget,@GetBlindResistance) <> 0
+      {
+         iDuration = (iDuration * (100-Send(oTarget,@GetBlindResistance)))/100;
+      }
 
       % Re-check the bound on duration.
       iDuration = Bound(iDuration,piMinDazzle,piMaxDazzle);

--- a/kod/object/passive/spell/debuff/hold.kod
+++ b/kod/object/passive/spell/debuff/hold.kod
@@ -138,7 +138,7 @@ messages:
    DoSpell(what=$,oTarget=$,iDuration=$,report=TRUE,bAllowFreeAction=TRUE)
    "Holds target for duration seconds."
    {
-      local i, oSpell;
+      local i, oSpell, iTotalDuration;
 
       if oTarget = $
       {
@@ -169,6 +169,13 @@ messages:
             {
                % Resisted completely
                return FALSE;
+            }
+      
+            if IsClass(oTarget,&Monster)
+               AND Send(oTarget,@GetHoldResistance) <> 0
+            {
+               iTotalDuration = 
+                 (iTotalDuration * (100-Send(oTarget,@GetHoldResistance)))/100;
             }
 
             iDuration = Bound(iDuration,500,10000);

--- a/kod/util/settings.kod
+++ b/kod/util/settings.kod
@@ -264,6 +264,11 @@ properties:
 
    % Percent of mana required/used for broadcasting. Default 0 (no cost).
    piBroadcastManaPercent = 0
+   
+   % Expansion settings
+   %
+   % Champion Mob Spawns
+   pbChampionSpawnsEnabled = TRUE
 
    % Jasper vault access
    pbJasperVault = FALSE
@@ -721,6 +726,11 @@ messages:
    GetBroadcastManaCost()
    {
       return piBroadcastManaPercent;
+   }
+   
+   GetChampionSpawnsEnabled()
+   {
+      return pbChampionSpawnsEnabled;
    }
 
    GetExperienceSystem()


### PR DESCRIPTION
Almost any mob has a chance to spawn with special attributes and rewards. Rewards scale up with difficulty (the first three are all equal, indomitable is more, and legendary is way more).

1 in 50: Tough = blue aura, extra health, 33% more defense.
1 in 50: Swift = orange aura, much faster.
1 in 50: Deadly = red aura, more damage, 33% more offense.
1 in 200: Indomitable = green aura, extra health, much faster, more damage, +33% offense and defense.
1 in 10,000: Legendary  = gold aura, tremendous health, very fast, huge damage, +50% offense and defense. (probably not beatable alone, like... ever. Even a Legendary Giant Rat would be a tremendous threat.)

Mobs lose these attributes if they change owners, have no owner, or enter a room that disables these effects. In other words, no shenanigans.

Mobs can be identified in text (I.e. Your hammer crushes the tough tusked skeleton.) and/or by their glowing aura (hardware and ogre only).

Admins can give mobs these statuses by sending GainChampionStatus, iType = 1 through 5 (in the order listed above)

Champion status is separate and multiplicative with Survival level and natural mob level. For example, if you were to reach survival level 50 and a Legendary Shadowbeast were to spawn, you would be crushed into a fine pulp. However, it's possible to turn off champion statuses for places like survival arenas.

---

Champion Abilities

Champions also choose from a pool of special abilities.

Lowest tier champions get 1 ability. Indomitable gets 2. Legendary gets 3. The abilities, if chosen more than once, can stack.
- 20 - 50% Magic resistance
- 20 - 50% Weapon resistance
- 20 - 50% Blind & dazzle resistance
- 20 - 50% Hold resistance
- Elemental attack damage type
- Chance to proc purge (5-15%, comparable to weapon proc)
- Chance to disarm (5-10%)

---

Champion Rewards

Ah, the part you care about, right? Champions will tie into new loot systems.

Lowest tier champions will drop 1 special drop with a +1 power bonus.

Indomitable will drop 3 special drops with a +3 power bonus.

Legendary will drop 10 (**!**) for each player that deals enough damage to count as participating (**!!!!!**). Each of these drops will have a +10 power bonus. I can't stress enough how much of an 'event' you are going to have to make out of this if you run across one. This is a "guild come kill this thing" kind of mob. You're also not going to be able to abuse this by having mules or alts strike the mob - without safespots, any character you leave unattended is going to flat out die.

These drops all scale with monster level, so yeah, a legendary giant rat is not going to be the end of all life, but it won't drop godly loot, either. Low-level legendaries will be for noobs and builders to fight for fun and profit.

Stay tuned on what all that loot talk means :)

Champions will also drop increased normal loot, and give large XP and TP bonuses. The ratio will be x3 for lowest tier, x10 for indomitable, and x100 for legendary. No, I'm not kidding. Kill a legendary daemon skeleton = probably gain a HP, couple hundred training points, and hundreds of bds / dafs / shils. It's 1 in 10,000, and it's incredibly deadly. basically a mini event.

---

Misc:

Indomitable and Legendary champions send a text message through the screen when they arrive. Legendary's message is bold. If you're low and you see that message, just run. You'll thank me later.

All champion mobs ignore resets. You can't leave the screen and wish them away. This also means that you will, more than likely, run across Legendary mobs that other players spawned before being forced to abandon the area.

Planned:

Mobs on screen will gather near and treat indomitable & legendary as master.
